### PR TITLE
Infra: Java 21 기반 GitHub Actions CI 빌드 스크립트 추가

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,26 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "main", "dev" ]
+  pull_request:
+    branches: [ "main", "dev" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // 테스트할 때 쓸 가짜 DB
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,33 @@
+spring:
+  application:
+    name: PuppyRun
+
+  # [1] 테스트는 가벼운 H2 DB(메모리)를 사용하자 (MySQL X)
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    database-platform: org.hibernate.dialect.H2Dialect
+
+  # [2] 중요! CI에서는 도커 컴포즈를 끄고 H2만 쓰도록 강제 종료
+  docker:
+    compose:
+      enabled: false
+
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+
+# [3] 에러 나던 빈칸(변수)들에 가짜 값을 채워넣기
+jwt:
+  secret: this-is-a-very-long-dummy-secret-key-for-test-only-do-not-use-real-key
+  access-token-expiration: 900000
+  refresh-token-expiration: 1209600000
+
+discord:
+  webhooks:
+    url: https://discord.com/api/webhooks/dummy-url-for-test


### PR DESCRIPTION
# 📌 Pull Request: [Infra] GitHub Actions CI 환경 구축
## 📝 작업 요약 (Summary)
프로젝트의 안정적인 협업을 위해 GitHub Actions를 활용한 CI(지속적 통합) 환경을 구축했습니다. 이제 main 또는 dev 브랜치로 PR이 생성되거나 푸시될 때마다 자동으로 빌드와 테스트를 수행하여, 컴파일 에러나 테스트 실패가 있는 코드가 병합되는 것을 방지합니다.

GitHub Actions 워크플로우(gradle.yml) 작성

Java 21 + Gradle 기반의 자동 빌드/테스트 파이프라인 구성

Branch Protection Rule(브랜치 보호 규칙)과 연동될 수 있도록 설정

# 🛠️ 변경 사항 (Changes)
**1. 인프라 및 CI 설정 (Infrastructure)**
GitHub Actions 워크플로우 추가 (.github/workflows/gradle.yml)

Trigger 조건: main, dev 브랜치에 대한 push 및 pull_request 이벤트 발생 시 실행.

환경 설정: ubuntu-latest 환경에서 Java 21 (Temurin) JDK 설정.

권한 설정: gradlew 실행 권한 부여 (chmod +x).

빌드 실행: ./gradlew build 명령어를 통해 프로젝트 빌드 및 테스트 수행.

**2. 기타 (Chore)**
문서 동기화: pull_request_template.md 및 README.md 등 최신 상태의 문서 파일 포함.

# 📸 테스트 시나리오 (Test Scenarios)
⚠️ 참고: 이번 변경 사항은 API 기능 추가가 아닌 CI 인프라 설정이므로, Postman 테스트 대신 GitHub Actions 실행 결과로 검증을 대체합니다.

## 1. CI 파이프라인 동작 확인
Target: GitHub Repository Actions Tab

Trigger: PR 생성 및 커밋 푸시

✅ 1-1 : 정상 빌드 케이스 (Success)
PR을 생성한 후, GitHub 페이지 하단의 Checks 영역에서 아래와 같이 build 작업이 성공해야 합니다.

Expected Result

Actions 탭에서 해당 워크플로우가 Green (초록색 체크 ✅) 상태로 표시됨.

./gradlew build 명령어가 에러 없이 완료됨.

❌ 1-2 : 빌드 실패 케이스 (Failure)
컴파일 에러가 있는 코드를 푸시했을 경우, CI가 이를 감지하고 실패 처리해야 합니다.

Expected Result

Actions 탭에서 해당 워크플로우가 Red (빨간색 엑스 ❌) 상태로 표시됨.

PR 페이지에서 "Merge blocked" 상태가 되어야 함 (Branch Protection Rule 설정 시).