### PR TITLE
feat: 서버 에러 로그 디스코드 알림 연동 및 Logback 설정 (#4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 /.env
 
+/logs/

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,10 @@ configurations {
 }
 
 repositories {
-    mavenCentral()
+    repositories {
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
+    }
 }
 
 dependencies {
@@ -48,6 +51,10 @@ dependencies {
 
     // 테스트할 때 쓸 가짜 DB
     testImplementation 'com.h2database:h2'
+
+    // Discord 로그 알림 의존성
+    implementation 'com.github.napstr:logback-discord-appender:1.0.0'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,8 @@ configurations {
 }
 
 repositories {
-    repositories {
-        mavenCentral()
-        maven { url 'https://jitpack.io' }
-    }
+    mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name=PuppyRun
+    name: PuppyRun
 
   jpa:
     hibernate:
@@ -12,7 +12,7 @@ spring:
       lifecycle-management: start_and_stop
       skip:
         in-tests: false
-          
+
   jackson:
     property-naming-strategy: SNAKE_CASE
 
@@ -24,5 +24,4 @@ jwt:
 
 
 discord:
-  webhooks:
-    url: ${discord_webhooks_url}
+  webhooks-url: ${discord_webhooks_url}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_PATH" value="./logs"/>
+    <property name="LOG_FILE_NAME" value="application_log"/>
+
+    <!--콘솔 로그 설정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- 가독성을 위해 색상 패턴 적용 -->
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %magenta([%thread]) %cyan(%logger{36}) - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일 로그 설정 -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 디스코드 웹 후크 연결 -->
+    <springProperty name="DISCORD_URL" source="discord.webhooks-url"/>
+    <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+        <webhookUri>${DISCORD_URL}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>
+                🚨 **[Server Error Report]**
+                > **Time:** `%d{yyyy-MM-dd HH:mm:ss}`
+                > **Logger:** `%logger{36}`
+                > **Level:** `%-5level`
+
+                **📌 Error Message:**
+                ```text
+                %msg
+                ```
+
+                **🔍 Stack Trace:**
+                ```java
+                %ex{5}
+                ```
+                ---
+            </pattern>
+        </layout>
+        <color>#FF0000</color>
+    </appender>
+
+    <!-- 디스코드 비동기 처리 (ERROR 레벨만 전송) -->
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <!-- Root 로거 설정 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/> <!-- 위에서 정의한 CONSOLE 앱펜더 참조 -->
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="ASYNC_DISCORD"/>
+    </root>
+</configuration>

--- a/src/test/java/org/zerock/puppyrun/discordNotice/DiscordNotificationTest.java
+++ b/src/test/java/org/zerock/puppyrun/discordNotice/DiscordNotificationTest.java
@@ -1,0 +1,30 @@
+package org.zerock.puppyrun.discordNotice;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class DiscordNotificationTest {
+
+    // 로그백 로거 설정
+    private static final Logger log = LoggerFactory.getLogger(DiscordNotificationTest.class);
+
+    @Test
+    @DisplayName("디스코드 에러 알림 전송 테스트")
+    void discordAlarmTest() throws InterruptedException {
+        // ERROR 레벨 로그 기록
+        log.error("🚨 [Test] 디스코드 알림 테스트 메시지입니다.");
+        log.error("사유: 시스템 테스트 중 강제 에러 발생");
+
+        // 예외 객체를 포함한 로그 테스트 (스택 트레이스 확인)
+        RuntimeException dummyException = new RuntimeException("테스트용 예외 발생!");
+        log.error("🚨 [Test] 예외 포함 알림 테스트", dummyException);
+
+        // 전송되기 전에 테스트가 종료될 수 있으므로 잠시 대기
+        System.out.println("디스코드로 로그를 전송 중입니다... 채널을 확인하세요.");
+        Thread.sleep(5000);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -29,5 +29,4 @@ jwt:
   refresh-token-expiration: 1209600000
 
 discord:
-  webhooks:
-    url: https://discord.com/api/webhooks/dummy-url-for-test
+  webhooks-url: https://discord.com/api/webhooks/dummy-url-for-test


### PR DESCRIPTION
# 📌 Pull Request: 서버 에러 로그 디스코드 알림 연동 및 Logback 설정 (#4)

# 📝 작업 요약 (Summary)

<!-- 
이 PR에서 수행한 작업의 핵심 내용을 간략히 요약해주세요. 
무엇을, 왜 변경했는지 설명하면 좋습니다.
예: 
- JWT 기반 인증 시스템 구축 (로그인, 회원가입)
- Refresh Token Rotation (RTR) 전략 적용하여 보안 강화
- AuthController 및 AuthService 리팩토링
-->

서버 내부에서 발생하는 ERROR 레벨의 로그를 디스코드 웹훅을 통해 실시간 알림으로 받을 수 있도록 환경을 구축했습니다. 서버 성능 저하를 방지하기 위해 알림 발송은 **비동기(Async)** 로 처리하였으며, 로그 파일 저장 정책과 콘솔 가독성 개선 작업도 함께 진행했습니다.

# 🛠️ 변경 사항 (Changes)

<!-- 
주요 변경 사항을 카테고리별로 나누어 작성해주세요. 
코드의 구조적 변경이나 로직의 핵심 변화를 적어주세요.

예: 
## 1. 보안 및 인증 (Security & JWT)
- **JwtTokenProvider 리팩토링**
  - 토큰 타입 구분: TokenType Enum(ACCESS, REFRESH)을 도입하여 토큰 생성 시 type claim을 포함하도록 수정.
  - 검증 로직 강화: `getUserIdFromRefreshToken` 메서드를 추가하여, 재발급 요청 시 토큰 타입이 반드시 REFRESH인지 확인하도록 제한.
## 2. 비즈니스 로직 (AuthService)•
- **서비스 통합**: 기존 `SignUpService`, `SignInService`를 `AuthService`로 통합하여 응집도 향상.
- **트랜잭션 전략 최적화**: 클래스 레벨에 @Transactional(readOnly = true)를 적용하고, 쓰기 작업(registerMember 등)에만 별도 트랜잭션 적용.
-->

## 1. 로깅 환경 설정 
- logback-spring.xml 설정
  - DiscordAppender: 에러 로그 발생 시 디스코드 웹훅으로 전송 (Markdown 템플릿 적용).
  - AsyncAppender: 디스코드 API 호출로 인한 메인 스레드 지연을 막기 위해 비동기 래핑 처리.
  - RollingFileAppender: 로그 파일 저장 정책 적용 (파일당 Max 100MB, 최대 30일 보관).
  - ConsoleAppender: 개발 편의성을 위해 로그 레벨별 색상 패턴 적용.
- 기타 설정
  - application.yml: 디스코드 웹훅 URL 설정 추가.
  - .gitignore: 생성되는 로그 파일 폴더(/logs/)가 커밋되지 않도록 제외.

## 2. 테스트 코드 작성
- ERROR 레벨 로그 발생 시 디스코드 알림 전송 로직이 정상 동작하는지 확인하는 테스트 코드 작성.

# 📸 테스트 시나리오 (Test Scenarios)

<!-- 
변경 사항을 검증하기 위해 수행한 테스트 시나리오를 작성해주세요. 
Postman이나 Swagger 테스트 결과를 복사해 넣으면 리뷰에 도움이 됩니다.
-->

## 1. 디스코드 에러 알림<!-- [테스트할 API 이름 (예: 로그인)] -->

### ✅ 1-1 : 런타임 예외 발생 시 알림 도착 확인 <!-- [성공 케이스 설명 (예: 정상 로그인)] -->

<!-- 정상적으로 통신이 완료 되었을 경우의 요청과 응답을 작성해주세요. -->

🚨 **[Server Error Report]**
> **Time:** `2026-01-09 18:40:46`
> **Logger:** `o.z.p.d.DiscordNotificationTest`
> **Level:** `ERROR`

**📌 Error Message:**
```text
[Test] 예외 포함 알림 테스트
```

**🔍 Stack Trace:**
```java
java.lang.RuntimeException: 테스트용 예외 발생!
    at org.zerock.puppyrun.discordNotice.DiscordNotificationTest.discordAlarmTest(DiscordNotificationTest.java:23)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:701)
    at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:502)
```
---
