### PR TITLE
feat: 공공데이터 기반 날씨 스케줄링 및 조회 기능 구현 (#10)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
     // Discord 로그 알림 의존성
     implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 
+    // 캐시 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     // 외부 api 호출  의존성
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // macOS Netty DNS Resolver
+    developmentOnly 'io.netty:netty-resolver-dns-native-macos::osx-aarch_64'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // 유효성 검사 라이브러리
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
 
+    // 외부 api 호출  의존성
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/zerock/puppyrun/common/config/CacheConfig.java
+++ b/src/main/java/org/zerock/puppyrun/common/config/CacheConfig.java
@@ -1,0 +1,37 @@
+package org.zerock.puppyrun.common.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+
+        // CacheType Enum에 정의된 설정들을 가져와서 CaffeineCache로 변환
+        List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+                .map(cache -> new CaffeineCache(
+                        cache.getCacheName(),
+                        Caffeine.newBuilder()
+                                .recordStats() // 통계 기록
+                                .expireAfterWrite(cache.getExpiredAfterWrite(), TimeUnit.SECONDS) // 만료 시간
+                                .maximumSize(cache.getMaximumSize()) // 최대 크기
+                                .build()
+                ))
+                .collect(Collectors.toList());
+
+        cacheManager.setCaches(caches);
+        return cacheManager;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/config/CacheType.java
+++ b/src/main/java/org/zerock/puppyrun/common/config/CacheType.java
@@ -1,0 +1,14 @@
+package org.zerock.puppyrun.common.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheType {
+    // 지역별 기후를 캐싱 (1시간마다 갱신, 최대 3개)
+    REGIONAL_WEATHER("RegionalWeather", 60 * 60, 30);
+    private final String cacheName;     // 캐시 이름
+    private final int expiredAfterWrite; // 만료 시간 (초 단위)
+    private final int maximumSize;      // 최대 저장 개수
+}

--- a/src/main/java/org/zerock/puppyrun/common/config/SchedulerConfig.java
+++ b/src/main/java/org/zerock/puppyrun/common/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package org.zerock.puppyrun.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/org/zerock/puppyrun/common/config/WebClientConfig.java
+++ b/src/main/java/org/zerock/puppyrun/common/config/WebClientConfig.java
@@ -1,0 +1,16 @@
+package org.zerock.puppyrun.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    //기본 WebClient 생성
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024)) // 2MB 제한
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/exception/CacheNotFoundException.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/CacheNotFoundException.java
@@ -1,0 +1,11 @@
+package org.zerock.puppyrun.common.exception;
+
+public class CacheNotFoundException extends BusinessException {
+    public CacheNotFoundException(String message) {
+        super(ErrorCode.CACHE_NOT_FOUND, message);
+    }
+
+    public CacheNotFoundException(String message, Throwable cause) {
+        super(ErrorCode.CACHE_NOT_FOUND, message, cause);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/exception/ErrorCode.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/ErrorCode.java
@@ -21,6 +21,14 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_005", "토큰이 만료되었습니다."),
     USER_FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_006", "접근 권한이 없습니다."),
 
+    // cache 에러
+    CACHE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "CACHE_001", "캐시를 찾을 수 없습니다."),
+
+    // 외부 API 에러
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "API_001", "외부 API 요청 중 오류가 발생했습니다."),
+
+    // 날씨 에러
+    INVALID_WEATHER(HttpStatus.INTERNAL_SERVER_ERROR, "WEATHER_001", "잘못된 날씨입니다."),
 
     // 유저 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "유저를 찾을 수 없습니다."),

--- a/src/main/java/org/zerock/puppyrun/common/exception/ExternalApiParsingException.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/ExternalApiParsingException.java
@@ -1,0 +1,14 @@
+package org.zerock.puppyrun.common.exception;
+
+/**
+ * 외부 API 요청이 올바르지 않을 때
+ */
+public class ExternalApiParsingException extends BusinessException {
+    public ExternalApiParsingException(String message) {
+        super(ErrorCode.EXTERNAL_API_ERROR, message);
+    }
+
+    public ExternalApiParsingException(String message, Throwable cause) {
+        super(ErrorCode.EXTERNAL_API_ERROR, message, cause);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/scheduler/WeatherScheduler.java
+++ b/src/main/java/org/zerock/puppyrun/common/scheduler/WeatherScheduler.java
@@ -1,6 +1,6 @@
 package org.zerock.puppyrun.common.scheduler;
 
-import java.util.Arrays;
+import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +16,8 @@ import org.zerock.puppyrun.weather.DTO.WeatherApiPara;
 import org.zerock.puppyrun.weather.DTO.WeatherDTO;
 import org.zerock.puppyrun.weather.service.WeatherApiClient;
 import org.zerock.puppyrun.weather.service.WeatherMapper;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @Component
 @RequiredArgsConstructor
@@ -31,23 +33,32 @@ public class WeatherScheduler {
         log.info("날씨 데이터 정기 업데이트 시작");
         DateTimeDTO dateTimeDTO = weatherApiClient.createCurrentDateTimeDto();
 
-        Arrays.stream(RegionType.values()).forEach(region -> {
-            WeatherApiPara para = new WeatherApiPara(dateTimeDTO.baseDate(), dateTimeDTO.baseTime(), region.getNx(),
-                    region.getNy());
+        Flux.fromArray(RegionType.values())
+                .delayElements(Duration.ofMillis(500)) // 요청 간 0.5초 딜레이
+                .flatMap(region -> {
+                    WeatherApiPara para = new WeatherApiPara(
+                            dateTimeDTO.baseDate(),
+                            dateTimeDTO.baseTime(),
+                            region.getNx(),
+                            region.getNy()
+                    );
 
-            weatherApiClient.fetchWeather(para)
-                    .subscribe(
-                            response -> {
+                    return weatherApiClient.fetchWeather(para)
+                            .doOnNext(response -> {
                                 try {
                                     List<WeatherDTO> dtoList = weatherMapper.toWeatherDTOList(response);
                                     putWeatherToCache(region.name(), dtoList);
                                 } catch (Exception e) {
-                                    log.error("스케줄러 갱신 중 오류 발생 (Region: {}): {}", region.name(), e.getMessage());
+                                    log.error("데이터 처리 중 오류 (Region: {}): {}", region.name(), e.getMessage());
                                 }
-                            },
-                            error -> log.error("API 호출 실패 (Region: {}): {}", region.name(), error.getMessage())
-                    );
-        });
+                            })
+                            // 에러 발생 시 로그만 찍고 진행
+                            .onErrorResume(e -> {
+                                log.error("API 호출 실패 (Region: {}): {}", region.name(), e.getMessage());
+                                return Mono.empty();
+                            });
+                })
+                .subscribe();
     }
 
     private void putWeatherToCache(String key, List<WeatherDTO> weatherDTOList) {

--- a/src/main/java/org/zerock/puppyrun/common/scheduler/WeatherScheduler.java
+++ b/src/main/java/org/zerock/puppyrun/common/scheduler/WeatherScheduler.java
@@ -1,0 +1,62 @@
+package org.zerock.puppyrun.common.scheduler;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.zerock.puppyrun.common.config.CacheType;
+import org.zerock.puppyrun.common.exception.CacheNotFoundException;
+import org.zerock.puppyrun.weather.DTO.DateTimeDTO;
+import org.zerock.puppyrun.weather.DTO.RegionType;
+import org.zerock.puppyrun.weather.DTO.WeatherApiPara;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+import org.zerock.puppyrun.weather.service.WeatherApiClient;
+import org.zerock.puppyrun.weather.service.WeatherMapper;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WeatherScheduler {
+
+    private final WeatherApiClient weatherApiClient;
+    private final WeatherMapper weatherMapper;
+    private final CacheManager cacheManager;
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void scheduledWeatherUpdate() {
+        log.info("날씨 데이터 정기 업데이트 시작");
+        DateTimeDTO dateTimeDTO = weatherApiClient.createCurrentDateTimeDto();
+
+        Arrays.stream(RegionType.values()).forEach(region -> {
+            WeatherApiPara para = new WeatherApiPara(dateTimeDTO.baseDate(), dateTimeDTO.baseTime(), region.getNx(),
+                    region.getNy());
+
+            weatherApiClient.fetchWeather(para)
+                    .subscribe(
+                            response -> {
+                                try {
+                                    List<WeatherDTO> dtoList = weatherMapper.toWeatherDTOList(response);
+                                    putWeatherToCache(region.name(), dtoList);
+                                } catch (Exception e) {
+                                    log.error("스케줄러 갱신 중 오류 발생 (Region: {}): {}", region.name(), e.getMessage());
+                                }
+                            },
+                            error -> log.error("API 호출 실패 (Region: {}): {}", region.name(), error.getMessage())
+                    );
+        });
+    }
+
+    private void putWeatherToCache(String key, List<WeatherDTO> weatherDTOList) {
+        Cache cache = cacheManager.getCache(CacheType.REGIONAL_WEATHER.getCacheName());
+        if (cache == null) {
+            log.error("캐시를 찾을 수 없습니다. : {} ", CacheType.REGIONAL_WEATHER.getCacheName());
+            throw new CacheNotFoundException("캐시를 찾을 수 없습니다.");
+        }
+        cache.put(key, weatherDTOList);
+        log.info("캐시 갱신 완료: Key={}", key);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/DateTimeDTO.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/DateTimeDTO.java
@@ -1,0 +1,7 @@
+package org.zerock.puppyrun.weather.DTO;
+
+public record DateTimeDTO(
+        String baseDate,
+        String baseTime
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/PrecipitationType.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/PrecipitationType.java
@@ -1,0 +1,37 @@
+package org.zerock.puppyrun.weather.DTO;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.zerock.puppyrun.common.exception.InvalidValueException;
+import org.zerock.puppyrun.weather.exception.WeatherNotFoundException;
+
+@Getter
+@RequiredArgsConstructor
+public enum PrecipitationType {
+
+    NONE("0", "없음"),
+    RAIN("1", "비"),
+    RAIN_SNOW("2", "비/눈"),
+    SNOW("3", "눈"),
+    RAINDROP("5", "빗방울"),
+    RAINDROP_SNOW_DRIFT("6", "빗방울날림"),
+    SNOW_DRIFT("7", "눈날림");
+
+    private final String code;
+    private final String description;
+
+    /**
+     * 정수형 코드값을 입력받아 해당하는 Enum 상수를 반환합니다.
+     *
+     * @param code 강수형태 코드 (0, 1, 2, 3, 5, 6, 7)
+     * @return PrecipitationType
+     * @throws InvalidValueException 정의되지 않은 코드일 경우 예외 발생
+     */
+    public static PrecipitationType fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(type -> type.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new WeatherNotFoundException("잘못된 강수형태 코드입니다: " + code));
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/RegionType.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/RegionType.java
@@ -1,0 +1,55 @@
+package org.zerock.puppyrun.weather.DTO;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RegionType {
+    SEOUL("서울특별시", 60, 127, 37.563569, 126.980008),
+    BUSAN("부산광역시", 98, 76, 35.177019, 129.076953),
+    DAEGU("대구광역시", 89, 90, 35.868542, 128.603553),
+    INCHEON("인천광역시", 55, 124, 37.453233, 126.707353),
+    GWANGJU("광주광역시", 58, 74, 35.156975, 126.853364),
+    DAEJEON("대전광역시", 67, 100, 36.347119, 127.386567),
+    ULSAN("울산광역시", 102, 84, 35.535408, 129.313689),
+    SEJONG("세종특별자치시", 66, 103, 36.480012, 127.289069),
+    GYEONGGI("경기도", 60, 120, 37.271844, 127.011689),
+    GANGWON("강원특별자치도", 73, 134, 37.882692, 127.731975),
+    CHUNGBUK("충청북도", 69, 107, 36.632500, 127.493586),
+    CHUNGNAM("충청남도", 55, 107, 36.658815, 126.672798),
+    JEONBUK("전북특별자치도", 63, 89, 35.817275, 127.111053),
+    JEONNAM("전라남도", 51, 67, 34.813044, 126.465000),
+    GYEONGBUK("경상북도", 87, 106, 36.575999, 128.505832),
+    GYEONGNAM("경상남도", 91, 77, 35.234736, 128.694167),
+    JEJU("제주특별자치도", 52, 38, 33.485694, 126.500333);
+
+    private final String name; // 행정구역 명칭
+    private final int nx;      // 기상청 격자 X
+    private final int ny;      // 기상청 격자 Y
+    private final double lat;  // 대표 위도
+    private final double lon;  // 대표 경도
+
+
+    /**
+     * 현재 위경도와 가장 가까운 지역을 찾아 반환합니다.
+     */
+    public static RegionType findNearest(double userLat, double userLon) {
+        return Arrays.stream(RegionType.values())
+                .min(Comparator.comparingDouble(region ->
+                        calculateDistanceSq(userLat, userLon, region.lat, region.lon)))
+                .orElse(SEOUL); // 기본값 서울
+    }
+
+    /**
+     * 두 지점 사이의 거리 제곱을 계산
+     */
+    private static double calculateDistanceSq(double lat1, double lon1, double lat2, double lon2) {
+        double dLat = lat1 - lat2;
+        double dLon = lon1 - lon2;
+        return (dLat * dLat) + (dLon * dLon);
+    }
+
+}

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/SkyType.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/SkyType.java
@@ -1,0 +1,33 @@
+package org.zerock.puppyrun.weather.DTO;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.zerock.puppyrun.common.exception.InvalidValueException;
+import org.zerock.puppyrun.weather.exception.WeatherNotFoundException;
+
+@Getter
+@RequiredArgsConstructor
+public enum SkyType {
+
+    SUNNY("1", "맑음"),
+    CLOUDY("3", "구름많음"),
+    OVERCAST("4", "흐림");
+
+    private final String code;
+    private final String description;
+
+    /**
+     * 정수형 코드값을 입력받아 해당하는 Enum 상수를 반환합니다.
+     *
+     * @param code 하늘상태 코드 (1, 3, 4)
+     * @return SkyType
+     * @throws InvalidValueException 정의되지 않은 코드일 경우 예외 발생
+     */
+    public static SkyType fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(type -> type.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new WeatherNotFoundException("잘못된 하늘상태 코드입니다: " + code));
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherApiPara.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherApiPara.java
@@ -1,0 +1,9 @@
+package org.zerock.puppyrun.weather.DTO;
+
+public record WeatherApiPara(
+        String baseDate,
+        String baseTime,
+        int nx,
+        int ny
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherApiResponse.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherApiResponse.java
@@ -1,0 +1,42 @@
+package org.zerock.puppyrun.weather.DTO;
+
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WeatherApiResponse(Response response) {
+
+    public record Response(
+            Header header,
+            Body body
+    ) {
+    }
+
+    public record Header(
+            String resultCode,
+            String resultMsg
+    ) {
+    }
+
+    public record Body(
+            Items items
+    ) {
+    }
+
+    public record Items(
+            List<Item> item
+    ) {
+    }
+
+    public record Item(
+            String baseDate,
+            String baseTime,
+            String category,
+            String fcstDate,
+            String fcstTime,
+            String fcstValue,
+            int nx,
+            int ny
+    ) {
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherDTO.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherDTO.java
@@ -1,0 +1,19 @@
+package org.zerock.puppyrun.weather.DTO;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record WeatherDTO(
+        String date,
+        String time,
+        Detail detail
+) {
+    @Builder
+    public record Detail(
+            String temp, // 온도
+            String sky,  // 하늘
+            String pty   // 강수
+    ) {
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherDTO.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherDTO.java
@@ -12,8 +12,8 @@ public record WeatherDTO(
     @Builder
     public record Detail(
             String temp, // 온도
-            String sky,  // 하늘
-            String pty   // 강수
+            SkyType sky,  // 하늘
+            PrecipitationType pty   // 강수
     ) {
     }
 }

--- a/src/main/java/org/zerock/puppyrun/weather/controller/WeatherController.java
+++ b/src/main/java/org/zerock/puppyrun/weather/controller/WeatherController.java
@@ -1,0 +1,34 @@
+package org.zerock.puppyrun.weather.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.zerock.puppyrun.weather.DTO.RegionType;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+import org.zerock.puppyrun.weather.controller.response.WeatherResponse;
+import org.zerock.puppyrun.weather.service.WeatherService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/weather")
+public class WeatherController {
+    private final WeatherService weatherService;
+
+
+    @GetMapping("")
+    public ResponseEntity<?> getWeather(@RequestParam int lat, @RequestParam int lon) {
+        RegionType regionType = RegionType.findNearest(lat, lon);
+
+        List<WeatherDTO> weatherDTOList = weatherService.getRegionalWeather(regionType);
+
+        WeatherDTO weatherDTO = weatherService.getNearestTimeWeather(weatherDTOList);
+
+        WeatherResponse response = WeatherResponse.of(weatherDTO, regionType);
+
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/controller/response/WeatherResponse.java
+++ b/src/main/java/org/zerock/puppyrun/weather/controller/response/WeatherResponse.java
@@ -23,8 +23,8 @@ public record WeatherResponse(
     public static WeatherResponse of(WeatherDTO dto, RegionType region) {
         Detail detail = Detail.builder()
                 .temp(dto.detail().temp())
-                .sky(dto.detail().sky())
-                .pty(dto.detail().pty())
+                .sky(dto.detail().sky().getCode())
+                .pty(dto.detail().pty().getCode())
                 .build();
         return WeatherResponse.builder()
                 .detail(detail)

--- a/src/main/java/org/zerock/puppyrun/weather/controller/response/WeatherResponse.java
+++ b/src/main/java/org/zerock/puppyrun/weather/controller/response/WeatherResponse.java
@@ -1,0 +1,36 @@
+package org.zerock.puppyrun.weather.controller.response;
+
+import lombok.Builder;
+import org.zerock.puppyrun.weather.DTO.RegionType;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO.Detail;
+
+@Builder
+public record WeatherResponse(
+        RegionType region,
+        String date,
+        String time,
+        Detail detail
+) {
+    @Builder
+    public record Detail(
+            String temp, // 온도
+            String sky,  // 하늘
+            String pty   // 강수
+    ) {
+    }
+
+    public static WeatherResponse of(WeatherDTO dto, RegionType region) {
+        Detail detail = Detail.builder()
+                .temp(dto.detail().temp())
+                .sky(dto.detail().sky())
+                .pty(dto.detail().pty())
+                .build();
+        return WeatherResponse.builder()
+                .detail(detail)
+                .region(region)
+                .date(dto.date())
+                .time(dto.time())
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/exception/WeatherNotFoundException.java
+++ b/src/main/java/org/zerock/puppyrun/weather/exception/WeatherNotFoundException.java
@@ -1,0 +1,14 @@
+package org.zerock.puppyrun.weather.exception;
+
+import org.zerock.puppyrun.common.exception.BusinessException;
+import org.zerock.puppyrun.common.exception.ErrorCode;
+
+public class WeatherNotFoundException extends BusinessException {
+    public WeatherNotFoundException(String message) {
+        super(ErrorCode.INVALID_WEATHER, message);
+    }
+
+    public WeatherNotFoundException(String message, Throwable cause) {
+        super(ErrorCode.INVALID_WEATHER, message, cause);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherApiClient.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherApiClient.java
@@ -1,0 +1,90 @@
+package org.zerock.puppyrun.weather.service;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.zerock.puppyrun.common.exception.ExternalApiParsingException;
+import org.zerock.puppyrun.weather.DTO.DateTimeDTO;
+import org.zerock.puppyrun.weather.DTO.WeatherApiPara;
+import org.zerock.puppyrun.weather.DTO.WeatherApiResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WeatherApiClient {
+
+    private final WebClient webClient;
+
+    @Value("${data-kr.api-key}")
+    private String API_KEY;
+    @Value("${data-kr.forecest-url}")
+    private String FCST_URL;
+
+    private final String FCST_URI = "/getUltraSrtFcst";
+    private final int PAGE_NO = 1;
+    private final int NUM_OF_ROWS = 100;
+    private final String DATA_TYPE = "JSON";
+    private final String TIME_ZONE = "Asia/Seoul";
+
+    /**
+     * WebClient를 활용하여 리액티브 타입(Mono)으로 응답을 반환하도록 구현
+     */
+    public Mono<WeatherApiResponse> fetchWeather(WeatherApiPara para) {
+        String uriString = String.format(
+                "%s%s?serviceKey=%s&pageNo=%d&numOfRows=%d&dataType=%s&base_date=%s&base_time=%s&nx=%d&ny=%d",
+                FCST_URL, FCST_URI, API_KEY, PAGE_NO, NUM_OF_ROWS, DATA_TYPE,
+                para.baseDate(), para.baseTime(), para.nx(), para.ny());
+
+        URI uri = URI.create(uriString);
+
+        log.info("Generated URI: {}", uri); // 생성된 URI 확인
+
+        return webClient.get()
+                .uri(uri)
+                .retrieve()
+                .bodyToMono(WeatherApiResponse.class)
+                .doOnNext(this::validateApiResponse);
+    }
+
+    public DateTimeDTO createCurrentDateTimeDto() {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of(TIME_ZONE));
+        LocalDateTime baseDateTime = now.minusHours(1);
+        String baseDate = baseDateTime.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String baseTime = baseDateTime.format(DateTimeFormatter.ofPattern("HH00"));
+        return new DateTimeDTO(baseDate, baseTime);
+    }
+
+    private void validateApiResponse(WeatherApiResponse response) {
+        if (response == null) {
+            throw new ExternalApiParsingException("날씨 API 응답이 비어있습니다.");
+        }
+
+        String resultCode = Optional.ofNullable(response.response())
+                .map(WeatherApiResponse.Response::header)
+                .map(WeatherApiResponse.Header::resultCode)
+                .orElse("UNKNOWN");
+
+        if (!"00".equals(resultCode)) {
+            String resultMsg = Optional.ofNullable(response.response())
+                    .map(WeatherApiResponse.Response::header)
+                    .map(WeatherApiResponse.Header::resultMsg)
+                    .orElse("메시지 없음");
+            log.error("날씨 API 호출 실패 - Code: {}, Msg: {}", resultCode, resultMsg);
+            throw new ExternalApiParsingException("날씨 API 호출 실패: %s".formatted(resultMsg));
+        }
+
+        Optional.of(response.response())
+                .map(WeatherApiResponse.Response::body)
+                .map(WeatherApiResponse.Body::items)
+                .map(WeatherApiResponse.Items::item)
+                .orElseThrow(() -> new ExternalApiParsingException("날씨 데이터(Body/Items)가 비어있습니다."));
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherMapper.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherMapper.java
@@ -1,0 +1,87 @@
+package org.zerock.puppyrun.weather.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.zerock.puppyrun.common.exception.ExternalApiParsingException;
+import org.zerock.puppyrun.weather.DTO.PrecipitationType;
+import org.zerock.puppyrun.weather.DTO.SkyType;
+import org.zerock.puppyrun.weather.DTO.WeatherApiResponse;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+
+@Component
+@Slf4j
+public class WeatherMapper {
+
+    private final String TEMP = "T1H";
+    private final String SKY = "SKY";
+    private final String PTY = "PTY";
+
+    public List<WeatherDTO> toWeatherDTOList(WeatherApiResponse response) {
+        // 응답 객체 자체의 Null 체크
+        if (response == null || response.response() == null ||
+                response.response().body() == null ||
+                response.response().body().items() == null) {
+            throw new ExternalApiParsingException("날씨 API 응답 구조가 올바르지 않습니다.");
+        }
+
+        List<WeatherApiResponse.Item> items = response.response().body().items().item();
+
+        if (items == null) {
+            throw new ExternalApiParsingException("날씨 데이터 아이템 목록이 비어있습니다.");
+        }
+
+        Map<String, List<WeatherApiResponse.Item>> groupedByTime = items.stream()
+                .collect(Collectors.groupingBy(item -> item.fcstDate() + item.fcstTime()));
+
+        return groupedByTime.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .limit(2)
+                .map(entry -> createWeatherDTO(entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private WeatherDTO createWeatherDTO(List<WeatherApiResponse.Item> groupItems) {
+        // 리스트 Null 및 Empty 체크
+        if (groupItems == null || groupItems.isEmpty()) {
+            throw new ExternalApiParsingException("날씨 데이터 그룹이 유효하지 않습니다.");
+        }
+
+        WeatherApiResponse.Item baseItem = groupItems.getFirst();
+
+        // 기준 아이템 Null 체크
+        if (baseItem == null) {
+            throw new ExternalApiParsingException("기준 날씨 아이템이 존재하지 않습니다.");
+        }
+
+        // 로그 출력
+        log.info("Weather Processing groupItems : {}", groupItems);
+
+        Map<String, String> valueMap = groupItems.stream()
+                .collect(Collectors.toMap(
+                        WeatherApiResponse.Item::category,
+                        WeatherApiResponse.Item::fcstValue,
+                        (existing, replacement) -> existing
+                ));
+
+        return WeatherDTO.builder()
+                .date(baseItem.fcstDate())
+                .time(baseItem.fcstTime())
+                .detail(buildWeatherDetail(valueMap))
+                .build();
+    }
+
+    private WeatherDTO.Detail buildWeatherDetail(Map<String, String> valueMap) {
+        SkyType skyType = SkyType.fromCode(valueMap.getOrDefault(SKY, "-1"));
+        PrecipitationType ptyType = PrecipitationType.fromCode(valueMap.getOrDefault(PTY, "-1"));
+        String temp = valueMap.getOrDefault(TEMP, "-1");
+
+        return WeatherDTO.Detail.builder()
+                .sky(skyType.getCode())
+                .pty(ptyType.getCode())
+                .temp(temp)
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherMapper.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherMapper.java
@@ -79,8 +79,8 @@ public class WeatherMapper {
         String temp = valueMap.getOrDefault(TEMP, "-1");
 
         return WeatherDTO.Detail.builder()
-                .sky(skyType.getCode())
-                .pty(ptyType.getCode())
+                .sky(skyType)
+                .pty(ptyType)
                 .temp(temp)
                 .build();
     }

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherService.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherService.java
@@ -24,10 +24,7 @@ public class WeatherService {
     private final WeatherApiClient weatherApiClient;
     private final WeatherMapper weatherMapper;
 
-    /**
-     * 조회된 예보 리스트 중 현재 시간(30분 단위 반올림)에 가장 적합한 데이터를 필터링
-     */
-    public WeatherDTO getNearestTimeWeather(List<WeatherDTO> weatherDTOList) {
+    public DateTimeDTO getTargetTime() {
         LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
         LocalDateTime nearestHour = now.plusMinutes(30).truncatedTo(ChronoUnit.HOURS);
 
@@ -35,12 +32,23 @@ public class WeatherService {
         String targetDate = nearestHour.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         String targetTime = nearestHour.format(DateTimeFormatter.ofPattern("HHmm"));
 
+        return new DateTimeDTO(targetDate, targetTime);
+    }
+
+    /**
+     * 조회된 예보 리스트 중 현재 시간(30분 단위 반올림)에 가장 적합한 데이터를 필터링
+     */
+    public WeatherDTO getNearestTimeWeather(List<WeatherDTO> weatherDTOList) {
+        DateTimeDTO target = getTargetTime();
+        String targetDate = target.baseDate();
+        String targetTime = target.baseTime();
+
         // 리스트에서 해당 시간대의 날씨 찾기
         return weatherDTOList.stream()
                 .filter(dto -> dto.date().equals(targetDate) && dto.time().equals(targetTime))
                 .findFirst()
                 .orElseThrow(() -> {
-                    log.error("시간 : {}, 날씨 정보를 찾을 수 없습니다.", targetTime);
+                    log.error("타겟 시간 : {}, 날씨 정보를 찾을 수 없습니다.", targetTime);
                     return new WeatherNotFoundException("해당 시간대의 날씨 정보를 찾을 수 없습니다.");
                 });
     }

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherService.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherService.java
@@ -1,0 +1,64 @@
+package org.zerock.puppyrun.weather.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.zerock.puppyrun.weather.DTO.DateTimeDTO;
+import org.zerock.puppyrun.weather.DTO.RegionType;
+import org.zerock.puppyrun.weather.DTO.WeatherApiPara;
+import org.zerock.puppyrun.weather.DTO.WeatherApiResponse;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+import org.zerock.puppyrun.weather.exception.WeatherNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WeatherService {
+
+    private final WeatherApiClient weatherApiClient;
+    private final WeatherMapper weatherMapper;
+
+    /**
+     * 조회된 예보 리스트 중 현재 시간(30분 단위 반올림)에 가장 적합한 데이터를 필터링
+     */
+    public WeatherDTO getNearestTimeWeather(List<WeatherDTO> weatherDTOList) {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalDateTime nearestHour = now.plusMinutes(30).truncatedTo(ChronoUnit.HOURS);
+
+        // 비교를 위해 문자열 포맷팅
+        String targetDate = nearestHour.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String targetTime = nearestHour.format(DateTimeFormatter.ofPattern("HHmm"));
+
+        // 리스트에서 해당 시간대의 날씨 찾기
+        return weatherDTOList.stream()
+                .filter(dto -> dto.date().equals(targetDate) && dto.time().equals(targetTime))
+                .findFirst()
+                .orElseThrow(() -> {
+                    log.error("시간 : {}, 날씨 정보를 찾을 수 없습니다.", targetTime);
+                    return new WeatherNotFoundException("해당 시간대의 날씨 정보를 찾을 수 없습니다.");
+                });
+    }
+
+    /**
+     * 지역별 날씨 조회 캐시가 없으면 API Client와 Mapper를 통해 데이터를 가져옵니다.
+     */
+    @Cacheable(value = "RegionalWeather", key = "#regionType.name()")
+    public List<WeatherDTO> getRegionalWeather(RegionType regionType) {
+        log.info("캐시 미스 API 직접 호출 진행: {}", regionType.name());
+
+        DateTimeDTO dateTimeDTO = weatherApiClient.createCurrentDateTimeDto();
+        WeatherApiPara para = new WeatherApiPara(dateTimeDTO.baseDate(), dateTimeDTO.baseTime(), regionType.getNx(),
+                regionType.getNy());
+
+        // 동기 처리 (block)
+        WeatherApiResponse response = weatherApiClient.fetchWeather(para).block();
+
+        return weatherMapper.toWeatherDTOList(response);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,7 @@ jwt:
 
 discord:
   webhooks-url: ${discord_webhooks_url}
+
+data-kr:
+  api-key: ${DATA_API_KEY}
+  forecest-url: ${DATA_FORECEST_URL}

--- a/src/test/java/org/zerock/puppyrun/weather/WeatherServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/weather/WeatherServiceTest.java
@@ -1,0 +1,168 @@
+package org.zerock.puppyrun.weather;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.zerock.puppyrun.common.scheduler.WeatherScheduler; // [추가] 스케줄러 import
+import org.zerock.puppyrun.weather.DTO.RegionType;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+import org.zerock.puppyrun.weather.service.WeatherService;
+
+@SpringBootTest
+class WeatherServiceTest {
+
+    @Autowired
+    private WeatherService weatherService;
+
+    @Autowired
+    private WeatherScheduler weatherScheduler;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void before() {
+
+    }
+
+    @Test
+    @DisplayName("1. 실제 외부 API 호출 테스트 - 서울 지역 날씨 조회")
+    void testRealApiCall() {
+        // given
+        RegionType region = RegionType.SEOUL;
+
+        // when
+        List<WeatherDTO> result = weatherService.getRegionalWeather(region);
+
+        // then
+        assertThat(result).isNotEmpty();
+
+        WeatherDTO firstItem = result.getFirst();
+        System.out.println("날짜: " + firstItem.date());
+        System.out.println("시간: " + firstItem.time());
+        System.out.println("온도: " + firstItem.detail().temp());
+        System.out.println("하늘: " + firstItem.detail().sky());
+        System.out.println("강수: " + firstItem.detail().pty());
+
+        assertThat(firstItem.date()).isNotNull();
+        assertThat(firstItem.time()).isNotNull();
+        assertThat(firstItem.detail().sky()).isNotNull();
+        assertThat(firstItem.detail().pty()).isNotNull();
+        assertThat(firstItem.detail().temp()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("2. 현재 시간(반올림) 기준 날씨 데이터 필터링 테스트")
+    void testGetNearestTimeWeather_RealData() {
+        // given
+        RegionType region = RegionType.SEOUL;
+        List<WeatherDTO> weatherList = weatherService.getRegionalWeather(region);
+
+        // when
+        WeatherDTO nearestWeather = weatherService.getNearestTimeWeather(weatherList);
+
+        // then
+        assertThat(nearestWeather).isNotNull();
+        System.out.println("기준 시간: " + nearestWeather.time());
+        System.out.println("온도: " + nearestWeather.detail().temp());
+    }
+
+    @Test
+    @DisplayName("3. 비동기 클라이언트(WebClient) 연동 확인")
+    void testAsyncClientIntegration() {
+        // given
+        RegionType region = RegionType.INCHEON;
+
+        // when
+        List<WeatherDTO> result = weatherService.getRegionalWeather(region);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("4. 캐싱 동작 확인 - 실제 API 호출 후 캐시 저장 및 조회")
+    void testCaching_RealApi() {
+        // given
+        RegionType region = RegionType.BUSAN;
+        String cacheKey = region.name();
+
+        if (cacheManager.getCache("RegionalWeather") != null) {
+            cacheManager.getCache("RegionalWeather").evict(cacheKey);
+        }
+
+        // when 1
+        long startTime1 = System.currentTimeMillis();
+        List<WeatherDTO> firstCall = weatherService.getRegionalWeather(region);
+        long duration1 = System.currentTimeMillis() - startTime1;
+
+        // then 1
+        assertThat(firstCall).isNotEmpty();
+        assertThat(cacheManager.getCache("RegionalWeather").get(cacheKey)).isNotNull();
+        System.out.println("첫 번째 호출 소요 시간: " + duration1 + "ms");
+
+        // when 2
+        long startTime2 = System.currentTimeMillis();
+        List<WeatherDTO> secondCall = weatherService.getRegionalWeather(region);
+        long duration2 = System.currentTimeMillis() - startTime2;
+
+        // then 2
+        assertThat(secondCall).isEqualTo(firstCall);
+        System.out.println("두 번째 호출 소요 시간: " + duration2 + "ms");
+        assertThat(duration2).isLessThan(duration1);
+    }
+
+    @Test
+    @DisplayName("5. 스케줄러 동작 확인 - 주기적 업데이트가 캐시에 반영되는지 테스트")
+    void testSchedulerExecution() throws InterruptedException {
+        // given
+        String cacheName = "RegionalWeather";
+        // 테스트할 지역 키 (예: SEOUL)
+        String key = RegionType.SEOUL.name();
+
+        // 캐시 초기화 (기존 데이터 제거하여 확실한 테스트 환경 조성)
+        if (cacheManager.getCache(cacheName) != null) {
+            cacheManager.getCache(cacheName).clear();
+        }
+
+        // 초기 상태: 캐시가 비어있어야 함
+        assertThat(cacheManager.getCache(cacheName).get(key)).isNull();
+
+        // when
+        // 스케줄러 메서드 강제 실행 (내부적으로 비동기 API 호출 수행)
+        System.out.println("스케줄러 수동 실행 시작...");
+        weatherScheduler.scheduledWeatherUpdate();
+
+        // then
+        // 비동기 작업(API 호출 -> 캐시 저장)이 완료될 때까지 잠시 대기 (최대 10초)
+        boolean isCached = false;
+        for (int i = 0; i < 10; i++) {
+            if (cacheManager.getCache(cacheName).get(key) != null) {
+                isCached = true;
+                break;
+            }
+            Thread.sleep(1000); // 1초 대기
+        }
+
+        // 캐시에 데이터가 들어왔는지 확인
+        assertThat(isCached).as("스케줄러 실행 후 캐시에 데이터가 저장되어야 합니다.").isTrue();
+
+        // 캐시된 데이터 내용 확인
+        @SuppressWarnings("unchecked")
+        List<WeatherDTO> cachedData = (List<WeatherDTO>) cacheManager.getCache(cacheName).get(key).get();
+
+        assertThat(cachedData).isNotNull();
+        assertThat(cachedData).isNotEmpty();
+
+        System.out.println("캐시된 지역: " + key);
+        System.out.println("데이터 개수: " + cachedData.size());
+        System.out.println("데이터: " + cachedData);
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/weather/WeatherServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/weather/WeatherServiceTest.java
@@ -1,18 +1,31 @@
 package org.zerock.puppyrun.weather;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.context.bean.override.mockito.MockitoBean; // 변경된 import
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.CacheManager;
-import org.zerock.puppyrun.common.scheduler.WeatherScheduler; // [추가] 스케줄러 import
+import org.zerock.puppyrun.common.scheduler.WeatherScheduler;
+import org.zerock.puppyrun.weather.DTO.DateTimeDTO;
+import org.zerock.puppyrun.weather.DTO.PrecipitationType;
 import org.zerock.puppyrun.weather.DTO.RegionType;
+import org.zerock.puppyrun.weather.DTO.SkyType;
+import org.zerock.puppyrun.weather.DTO.WeatherApiResponse;
 import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+import org.zerock.puppyrun.weather.service.WeatherApiClient;
+import org.zerock.puppyrun.weather.service.WeatherMapper;
 import org.zerock.puppyrun.weather.service.WeatherService;
+import reactor.core.publisher.Mono;
 
 @SpringBootTest
 class WeatherServiceTest {
@@ -26,14 +39,47 @@ class WeatherServiceTest {
     @Autowired
     private CacheManager cacheManager;
 
-    @BeforeEach
-    void before() {
+    // 외부 API 호출을 흉내 낼 Mock 객체
+    @MockitoBean
+    private WeatherApiClient weatherApiClient;
 
+    // 응답 변환을 흉내 낼 Mock 객체
+    @MockitoBean
+    private WeatherMapper weatherMapper;
+
+    private WeatherDTO mockWeatherDTO;
+
+    private String targetTime;
+    private String targetDate;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 시간 생성
+        DateTimeDTO target = weatherService.getTargetTime();
+        targetTime = target.baseTime();
+        targetDate = target.baseDate();
+
+        // 테스트용 가짜 데이터 생성
+        WeatherDTO.Detail detail = new WeatherDTO.Detail("25.0", SkyType.SUNNY, PrecipitationType.NONE);
+        mockWeatherDTO = new WeatherDTO(targetDate, targetTime, detail);
+
+        // DateTimeDTO 생성 요청 시 가짜 날짜 반환
+        given(weatherApiClient.createCurrentDateTimeDto())
+                .willReturn(new DateTimeDTO(targetDate, targetTime));
+
+        // API 호출 시 가짜 JSON(또는 객체) 반환 (Mono)
+        WeatherApiResponse mockResponse = Mockito.mock(WeatherApiResponse.class);
+
+        given(weatherApiClient.fetchWeather(any()))
+                .willReturn(Mono.just(mockResponse));
+
+        given(weatherMapper.toWeatherDTOList(any()))
+                .willReturn(List.of(mockWeatherDTO));
     }
 
     @Test
-    @DisplayName("1. 실제 외부 API 호출 테스트 - 서울 지역 날씨 조회")
-    void testRealApiCall() {
+    @DisplayName("1. 서비스 로직 테스트 - Mock 데이터를 통한 날씨 조회")
+    void testGetRegionalWeather() {
         // given
         RegionType region = RegionType.SEOUL;
 
@@ -42,24 +88,19 @@ class WeatherServiceTest {
 
         // then
         assertThat(result).isNotEmpty();
-
         WeatherDTO firstItem = result.getFirst();
-        System.out.println("날짜: " + firstItem.date());
-        System.out.println("시간: " + firstItem.time());
-        System.out.println("온도: " + firstItem.detail().temp());
-        System.out.println("하늘: " + firstItem.detail().sky());
-        System.out.println("강수: " + firstItem.detail().pty());
 
-        assertThat(firstItem.date()).isNotNull();
-        assertThat(firstItem.time()).isNotNull();
-        assertThat(firstItem.detail().sky()).isNotNull();
-        assertThat(firstItem.detail().pty()).isNotNull();
-        assertThat(firstItem.detail().temp()).isNotNull();
+        // Mock 데이터와 일치하는지 검증
+        assertThat(firstItem.date()).isEqualTo(targetDate);
+        assertThat(firstItem.detail().temp()).isEqualTo("25.0");
+        assertThat(firstItem.detail().sky()).isEqualTo(SkyType.SUNNY);
+
+        System.out.println("Mock 날씨 데이터 확인: " + firstItem);
     }
 
     @Test
-    @DisplayName("2. 현재 시간(반올림) 기준 날씨 데이터 필터링 테스트")
-    void testGetNearestTimeWeather_RealData() {
+    @DisplayName("2. 현재 시간 기준 날씨 데이터 필터링 테스트")
+    void testGetNearestTimeWeather() {
         // given
         RegionType region = RegionType.SEOUL;
         List<WeatherDTO> weatherList = weatherService.getRegionalWeather(region);
@@ -69,100 +110,83 @@ class WeatherServiceTest {
 
         // then
         assertThat(nearestWeather).isNotNull();
-        System.out.println("기준 시간: " + nearestWeather.time());
-        System.out.println("온도: " + nearestWeather.detail().temp());
+        assertThat(nearestWeather.time()).isEqualTo(targetTime);
     }
+//
+//    @Test
+//    @DisplayName("3. API 클라이언트 호출 여부 확인")
+//    void testApiClientCalled() {
+//        // given
+//        RegionType region = RegionType.INCHEON;
+//
+//        // when
+//        weatherService.getRegionalWeather(region);
+//
+//        // then
+//        // weatherService가 내부적으로 API Client를 호출했는지 검증
+//        // (캐시가 비어있을 경우 호출됨)
+//        // 주의: @Cacheable 때문에 이전 테스트의 캐시가 남아있을 수 있으므로 캐시 정리 필요할 수 있음
+//    }
 
     @Test
-    @DisplayName("3. 비동기 클라이언트(WebClient) 연동 확인")
-    void testAsyncClientIntegration() {
-        // given
-        RegionType region = RegionType.INCHEON;
-
-        // when
-        List<WeatherDTO> result = weatherService.getRegionalWeather(region);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.size()).isGreaterThan(0);
-    }
-
-    @Test
-    @DisplayName("4. 캐싱 동작 확인 - 실제 API 호출 후 캐시 저장 및 조회")
-    void testCaching_RealApi() {
+    @DisplayName("4. 캐싱 동작 확인 - API 호출 횟수 검증")
+    void testCaching() {
         // given
         RegionType region = RegionType.BUSAN;
         String cacheKey = region.name();
+        String cacheName = "RegionalWeather";
 
-        if (cacheManager.getCache("RegionalWeather") != null) {
-            cacheManager.getCache("RegionalWeather").evict(cacheKey);
+        // 캐시 초기화
+        if (cacheManager.getCache(cacheName) != null) {
+            cacheManager.getCache(cacheName).evict(cacheKey);
         }
 
-        // when 1
-        long startTime1 = System.currentTimeMillis();
-        List<WeatherDTO> firstCall = weatherService.getRegionalWeather(region);
-        long duration1 = System.currentTimeMillis() - startTime1;
+        // when 1: 첫 번째 호출 (API 호출 발생 O)
+        weatherService.getRegionalWeather(region);
 
         // then 1
-        assertThat(firstCall).isNotEmpty();
-        assertThat(cacheManager.getCache("RegionalWeather").get(cacheKey)).isNotNull();
-        System.out.println("첫 번째 호출 소요 시간: " + duration1 + "ms");
+        verify(weatherApiClient, times(1)).fetchWeather(any()); // 호출 1회 확인
 
-        // when 2
-        long startTime2 = System.currentTimeMillis();
-        List<WeatherDTO> secondCall = weatherService.getRegionalWeather(region);
-        long duration2 = System.currentTimeMillis() - startTime2;
+        // when 2: 두 번째 호출 (캐시 사용, API 호출 발생 X)
+        weatherService.getRegionalWeather(region);
 
         // then 2
-        assertThat(secondCall).isEqualTo(firstCall);
-        System.out.println("두 번째 호출 소요 시간: " + duration2 + "ms");
-        assertThat(duration2).isLessThan(duration1);
+        verify(weatherApiClient, times(1)).fetchWeather(any()); // 여전히 호출 횟수는 1회여야 함
+        assertThat(cacheManager.getCache(cacheName).get(cacheKey)).isNotNull(); // 캐시에 데이터 존재 확인
+
+        System.out.println("캐싱 동작 검증 완료: API 호출 1회 유지됨");
     }
 
     @Test
-    @DisplayName("5. 스케줄러 동작 확인 - 주기적 업데이트가 캐시에 반영되는지 테스트")
+    @DisplayName("5. 스케줄러 동작 확인 - Mock API를 통한 캐시 갱신")
     void testSchedulerExecution() throws InterruptedException {
         // given
         String cacheName = "RegionalWeather";
-        // 테스트할 지역 키 (예: SEOUL)
         String key = RegionType.SEOUL.name();
 
-        // 캐시 초기화 (기존 데이터 제거하여 확실한 테스트 환경 조성)
+        // 캐시 초기화
         if (cacheManager.getCache(cacheName) != null) {
             cacheManager.getCache(cacheName).clear();
         }
 
-        // 초기 상태: 캐시가 비어있어야 함
-        assertThat(cacheManager.getCache(cacheName).get(key)).isNull();
-
         // when
-        // 스케줄러 메서드 강제 실행 (내부적으로 비동기 API 호출 수행)
-        System.out.println("스케줄러 수동 실행 시작...");
+        System.out.println("스케줄러 수동 실행...");
         weatherScheduler.scheduledWeatherUpdate();
 
         // then
-        // 비동기 작업(API 호출 -> 캐시 저장)이 완료될 때까지 잠시 대기 (최대 10초)
+        // 비동기 실행 대기 (Mock이라 빠르지만, delayElements(500ms)가 있으므로 약간 대기)
         boolean isCached = false;
         for (int i = 0; i < 10; i++) {
             if (cacheManager.getCache(cacheName).get(key) != null) {
                 isCached = true;
                 break;
             }
-            Thread.sleep(1000); // 1초 대기
+            Thread.sleep(500);
         }
 
-        // 캐시에 데이터가 들어왔는지 확인
         assertThat(isCached).as("스케줄러 실행 후 캐시에 데이터가 저장되어야 합니다.").isTrue();
 
-        // 캐시된 데이터 내용 확인
-        @SuppressWarnings("unchecked")
-        List<WeatherDTO> cachedData = (List<WeatherDTO>) cacheManager.getCache(cacheName).get(key).get();
-
-        assertThat(cachedData).isNotNull();
-        assertThat(cachedData).isNotEmpty();
-
-        System.out.println("캐시된 지역: " + key);
-        System.out.println("데이터 개수: " + cachedData.size());
-        System.out.println("데이터: " + cachedData);
+        // API가 지역 개수만큼 호출되었는지 검증 (선택 사항)
+        // verify(weatherApiClient, atLeastOnce()).fetchWeather(any());
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,7 +2,6 @@ spring:
   application:
     name: PuppyRun
 
-  # [1] 테스트는 가벼운 H2 DB(메모리)를 사용하자 (MySQL X)
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL
     driver-class-name: org.h2.Driver
@@ -14,7 +13,7 @@ spring:
     show-sql: true
     database-platform: org.hibernate.dialect.H2Dialect
 
-  # [2] 중요! CI에서는 도커 컴포즈를 끄고 H2만 쓰도록 강제 종료
+  # 도커 컴포즈를 끄고 H2만 쓰도록 강제 종료
   docker:
     compose:
       enabled: false
@@ -22,7 +21,6 @@ spring:
   jackson:
     property-naming-strategy: SNAKE_CASE
 
-# [3] 에러 나던 빈칸(변수)들에 가짜 값을 채워넣기
 jwt:
   secret: this-is-a-very-long-dummy-secret-key-for-test-only-do-not-use-real-key
   access-token-expiration: 900000
@@ -30,3 +28,7 @@ jwt:
 
 discord:
   webhooks-url: https://discord.com/api/webhooks/dummy-url-for-test
+
+data-kr:
+  api-key: api-key
+  forecest-url: http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0


### PR DESCRIPTION
# 📌 Pull Request:  공공데이터 기반 날씨 스케줄링 및 조회 기능 구현 (#10)

# 📝 작업 요약 (Summary)

기상청 공공데이터 포털의 초단기예보 API를 연동하여 사용자 위치 기반의 실시간 날씨 정보를 제공하는 기능을 구현했습니다.
외부 API 호출 성능 최적화와 안정성을 위해 **Caffeine Cache**와 **WebFlux 기반의 스케줄러**를 도입했으며, API 호출 제한(Rate Limit) 문제를 해결하기 위한 지연 호출을 포함했습니다.


# 🛠️ 변경 사항 (Changes)

## 1. 날씨 도메인 및 API 연동 (Weather)
- **WeatherController**: 위경도(`lat`, `lon`)를 받아 가장 가까운 행정구역의 날씨를 반환하는 엔드포인트 구현.
- **WeatherService**: 
  - `getRegionalWeather`: 지역별 날씨 데이터를 조회하고 캐싱(`@Cacheable`) 처리.
  - `getNearestTimeWeather`: 현재 시간(30분 단위 반올림)에 가장 적합한 예보 데이터를 필터링.

## 2. 성능 최적화 및 스케줄러 (Scheduler & Cache)
- **WeatherScheduler**: 
  - 매시 정각마다 전 지역의 날씨 데이터를 미리 갱신
  - **Rate Limiting 해결**: `Flux.delayElements(500ms)`를 적용하여 API 요청 간 딜레이를 부여, `429 Too Many Requests` 에러 방지
  - **비동기 에러 처리**: `onErrorResume`을 사용하여 특정 지역 갱신 실패가 전체 스케줄러를 중단시키지 않도록 처리.
- **Caffeine Cache**: `RegionalWeather` 캐시를 설정하여 반복적인 외부 API 호출 최소화.

## 3. 인프라 및 설정 (Config)
- **WebFlux 도입**: 비동기 API 호출을 위한 `spring-boot-starter-webflux` 의존성 추가.
- **macOS DNS 이슈 해결**: Apple Silicon 환경에서 Netty DNS Resolver 경고 해결을 위한 `netty-resolver-dns-native-macos` 의존성 추가 (`developmentOnly`).
- **테스트 환경 개선**: 테스트 환경에 Mock 사용을 위한 `spring-boot-starter-test` 의존성 추가

## 4. 날씨 상태 코드 (Weather Conditions) 

기상청 API에서 제공하는 코드를 내부 Enum으로 매핑하여 관리합니다.

### 하늘 상태 (SkyType)
API의 `SKY` 값을 매핑합니다.

| 코드값 | Enum 상수 | 설명 |
| :---: | :--- | :--- |
| `"1"` | `SUNNY` | 맑음 |
| `"3"` | `CLOUDY` | 구름많음 |
| `"4"` | `OVERCAST` | 흐림 |

### 강수 형태 (PrecipitationType)
API의 `PTY` 값을 매핑합니다.

| 코드값 | Enum 상수 | 설명 |
| :---: | :--- | :--- |
| `"0"` | `NONE` | 없음 |
| `"1"` | `RAIN` | 비 |
| `"2"` | `RAIN_SNOW` | 비/눈 (진눈깨비) |
| `"3"` | `SNOW` | 눈 |
| `"5"` | `RAINDROP` | 빗방울 |
| `"6"` | `RAINDROP_SNOW_DRIFT` | 빗방울날림 |
| `"7"` | `SNOW_DRIFT` | 눈날림 |

---

## 5. 지역 코드 (Region)

사용자의 위경도 좌표를 기반으로 기상청 예보 구역(격자 좌표)을 매핑하는 `RegionType` Enum입니다.

*   **주요 기능**: `findNearest(lat, lon)` 메서드를 통해 사용자 위치와 가장 가까운 행정구역을 자동으로 계산하여 반환합니다.
*   **지원 지역**: 대한민국 주요 17개 행정구역

| Enum 상수 | 행정구역 명칭 | 격자 X (nx) | 격자 Y (ny) | 대표 위도 | 대표 경도 |
| :--- | :--- | :---: | :---: | :---: | :---: |
| `SEOUL` | 서울특별시 | 60 | 127 | 37.5636 | 126.9800 |
| `BUSAN` | 부산광역시 | 98 | 76 | 35.1770 | 129.0770 |
| `DAEGU` | 대구광역시 | 89 | 90 | 35.8685 | 128.6036 |
| `INCHEON` | 인천광역시 | 55 | 124 | 37.4532 | 126.7074 |
| `GWANGJU` | 광주광역시 | 58 | 74 | 35.1570 | 126.8534 |
| `DAEJEON` | 대전광역시 | 67 | 100 | 36.3471 | 127.3866 |
| `ULSAN` | 울산광역시 | 102 | 84 | 35.5354 | 129.3137 |
| `SEJONG` | 세종특별자치시 | 66 | 103 | 36.4800 | 127.2891 |
| `GYEONGGI` | 경기도 | 60 | 120 | 37.2718 | 127.0117 |
| `GANGWON` | 강원특별자치도 | 73 | 134 | 37.8827 | 127.7320 |
| `CHUNGBUK` | 충청북도 | 69 | 107 | 36.6325 | 127.4936 |
| `CHUNGNAM` | 충청남도 | 55 | 107 | 36.6588 | 126.6728 |
| `JEONBUK` | 전북특별자치도 | 63 | 89 | 35.8173 | 127.1111 |
| `JEONNAM` | 전라남도 | 51 | 67 | 34.8130 | 126.4650 |
| `GYEONGBUK` | 경상북도 | 87 | 106 | 36.5760 | 128.5058 |
| `GYEONGNAM` | 경상남도 | 91 | 77 | 35.2347 | 128.6942 |
| `JEJU` | 제주특별자치도 | 52 | 38 | 33.4857 | 126.5003 |

## 6. 예외처리 (Exception)

애플리케이션 전반에서 발생하는 예외를 일관성 있게 처리하기 위해 `ErrorCode` Enum과 커스텀 예외 클래스들을 정의하여 사용합니다.

### 6. ErrorCode 정의 (Weather & System)

HTTP 상태 코드와 비즈니스 로직에 맞는 커스텀 에러 코드, 메시지를 매핑하여 관리합니다.

*   **`WeatherNotFoundException`**
    *   **사용 시점**: 기상청 API에서 받은 날씨 코드(하늘 상태, 강수 형태 등)가 정의된 Enum(`SkyType`, `PrecipitationType`)에 없을 때 발생합니다.

*   **`ExternalApiParsingException`**
    *   **사용 시점**: 외부 API(기상청 등) 호출 후 응답 데이터를 파싱하거나 DTO로 변환하는 과정에서 오류가 발생했을 때 사용합니다.

*   **`CacheNotFoundException`**
    *   **사용 시점**: `CacheManager`를 통해 특정 이름의 캐시(예: `RegionalWeather`)를 조회했으나 존재하지 않을 때 발생합니다. 주로 스케줄러나 서비스 초기화 시점에 검증용으로 사용됩니다.

| 카테고리 | Code | HTTP Status | 설명 |
| :--- | :--- | :---: | :--- |
| **캐시** | `CACHE_001` | 500 | 캐시를 찾을 수 없습니다. |
| **외부 API** | `API_001` | 500 | 외부 API 요청 중 오류가 발생했습니다. |
| **날씨** | `WEATHER_001` | 500 | 잘못된 날씨입니다. |

# 📸 테스트 시나리오 (Test Scenarios)

## 1. <!-- [테스트할 API 이름 (예: 로그인)] --> 지역 날씨 조회

* **Method**: <!-- GET, POST, PUT, DELETE 중 선택 (예: POST) --> `GET`
* **URL**: <!-- 엔드포인트 경로 (예: /api/auth/sign-in) --> /api/weather
* **Request Parameter**: lat(위도), lon(경도)
* **Content-Type**: `application/json`
* **Header**: <!-- 필요한 헤더가 있다면 기재 (예: Authorization, Refresh-Token) --> Bearer {AccessToken}

### ✅ 1-1 : <!-- [성공 케이스 설명 (예: 정상 로그인)] --> 정상 조회


**Response (200 OK)**

```
{
    "region": "SEOUL",
    "date": "20260204",
    "time": "1400",
    "detail": {
        "temp": "8",
        "sky": "4",
        "pty": "0"
    }
}

```

### ❌ 1-2 : <!-- [실패 케이스 설명 (예: 잘못된 요청)] --> api 요청 중 오류


**Response (500 Server Error)**

```
{
    "code": "API_001",
    "description": "외부 API 요청 중 오류가 발생했습니다.",
    "message": "",
    "path": "/api/weather?lat=37.5665&lon=126.9780",
    "timestamp": "2026-01-23T20:29:50.636988"
}
```
### ❌ 1-3 : <!-- [실패 케이스 설명 (예: 잘못된 요청)] --> 요청된 날씨 코드가 없을 경우


**Response (500 Server Error)**

```
{
    "code": "WEATHER_001",
    "description": "잘못된 날씨입니다.",
    "message": "",
    "path": "/api/weather?lat=37.5665&lon=126.9780",
    "timestamp": "2026-01-23T20:29:50.636988"
}
