### PR TITLE
feat: 일기(Diary) CRUD 구현 및 산책 기록 연동, JSON 파싱 예외 처리 강화 (#9 )

### DIFF
--- a/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -66,6 +67,33 @@ public class GlobalExceptionHandler {
                 .status(errorCode.getHttpStatus())
                 .body(errorResponse);
 
+    }
+
+
+    /**
+     * JSON 파싱 실패 Request Body의 JSON 형식이 잘못되었거나, 필드 타입이 맞지 않을 때(예: Integer 필드에 "abc" 입력) 발생합니다.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException e,
+            HttpServletRequest request) {
+
+        log.warn("JSON Parsing Error: {}", e.getMessage());
+
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+
+        String errorMessage = "요청 JSON 형식이 올바르지 않습니다. 오타나 데이터 타입을 확인해주세요.";
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                errorCode.getCode(),
+                errorCode.getDescription(),
+                errorMessage,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponse);
     }
 
 

--- a/src/main/java/org/zerock/puppyrun/diary/DTO/UpdateDiaryDTO.java
+++ b/src/main/java/org/zerock/puppyrun/diary/DTO/UpdateDiaryDTO.java
@@ -1,0 +1,19 @@
+package org.zerock.puppyrun.diary.DTO;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import org.zerock.puppyrun.weather.DTO.PrecipitationType;
+import org.zerock.puppyrun.weather.DTO.SkyType;
+
+@Builder
+public record UpdateDiaryDTO(
+        String title,
+        String content,
+        LocalDateTime writingTime,
+        String temp,
+        SkyType sky,
+        PrecipitationType pty,
+        List<String> images
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/diary/controller/DiaryController.java
+++ b/src/main/java/org/zerock/puppyrun/diary/controller/DiaryController.java
@@ -1,0 +1,89 @@
+package org.zerock.puppyrun.diary.controller;
+
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.diary.controller.request.RegisterDiaryRequest;
+import org.zerock.puppyrun.diary.controller.response.DiaryResponse;
+import org.zerock.puppyrun.diary.service.DiaryService;
+
+@RestController
+@RequestMapping("/api/diaries")
+@RequiredArgsConstructor
+public class DiaryController {
+    private final DiaryService diaryService;
+
+    /**
+     * 일기 작성
+     */
+    @PostMapping
+    public ResponseEntity<DiaryResponse> registerDiary(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestBody @Valid RegisterDiaryRequest request
+    ) {
+        UUID memberId = userPrincipal.id(); // 인증된 사용자 ID 가져오기
+
+        DiaryResponse response = diaryService.registerDiary(memberId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 일기 수정
+     */
+    @PutMapping("/{diaryId}")
+    public ResponseEntity<DiaryResponse> updateDiary(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID diaryId,
+            @RequestBody @Valid RegisterDiaryRequest request
+    ) {
+        UUID memberId = userPrincipal.id(); // 인증된 사용자 ID 가져오기
+
+        DiaryResponse response = diaryService.updateDiary(memberId, diaryId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 일기 삭제
+     */
+    @DeleteMapping("/{diaryId}")
+    public ResponseEntity<Void> deleteDiary(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID diaryId
+    ) {
+        UUID memberId = userPrincipal.id(); // 인증된 사용자 ID 가져오기
+
+        diaryService.deleteDiary(memberId, diaryId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 일기 상세 조회
+     */
+    @GetMapping("/{diaryId}")
+    public ResponseEntity<DiaryResponse> getDiary(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID diaryId
+    ) {
+        UUID memberId = userPrincipal.id(); // 인증된 사용자 ID 가져오기
+
+        DiaryResponse response = diaryService.getDiary(memberId, diaryId);
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/org/zerock/puppyrun/diary/controller/request/RegisterDiaryRequest.java
+++ b/src/main/java/org/zerock/puppyrun/diary/controller/request/RegisterDiaryRequest.java
@@ -1,0 +1,45 @@
+package org.zerock.puppyrun.diary.controller.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record RegisterDiaryRequest(
+
+        @NotNull(message = "산책 기록 ID는 필수입니다.")
+        UUID trackingId,
+
+        @NotNull(message = "일기 작성 시간대 정보는 필수입니다.")
+        LocalDateTime writingTime,
+
+        @NotBlank(message = "일기 제목은 필수입니다.")
+        @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.")
+        String title,
+
+        @NotBlank(message = "일기 내용은 필수입니다.")
+        String content,
+
+        @Valid
+        @NotNull(message = "날씨 정보는 필수입니다.")
+        Weather weather,
+
+        // 이미지는 빈 리스트가 올 수 있으므로 별도의 @NotEmpty 검증을 하지 않음
+        List<String> images
+) {
+    public record Weather(
+            @NotBlank(message = "기온 정보는 필수입니다.")
+            String temp,
+
+            @NotNull(message = "하늘 상태는 필수입니다.")
+            String sky,
+
+            @NotNull(message = "강수 형태는 필수입니다.")
+            String pty
+    ) {
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/diary/controller/request/UpdateDiaryRequest.java
+++ b/src/main/java/org/zerock/puppyrun/diary/controller/request/UpdateDiaryRequest.java
@@ -1,0 +1,40 @@
+package org.zerock.puppyrun.diary.controller.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record UpdateDiaryRequest(
+        @NotNull(message = "일기 작성 시간대 정보는 필수입니다.")
+        LocalDateTime writingTime,
+
+        @NotBlank(message = "일기 제목은 필수입니다.")
+        @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.")
+        String title,
+
+        @NotBlank(message = "일기 내용은 필수입니다.")
+        String content,
+
+        @Valid
+        @NotNull(message = "날씨 정보는 필수입니다.")
+        RegisterDiaryRequest.Weather weather,
+
+        // 이미지는 빈 리스트가 올 수 있으므로 별도의 @NotEmpty 검증을 하지 않음
+        List<String> images
+) {
+    public record Weather(
+            @NotBlank(message = "기온 정보는 필수입니다.")
+            String temp,
+
+            @NotNull(message = "하늘 상태는 필수입니다.")
+            String sky,
+
+            @NotNull(message = "강수 형태는 필수입니다.")
+            String pty
+    ) {
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/diary/controller/response/DiaryResponse.java
+++ b/src/main/java/org/zerock/puppyrun/diary/controller/response/DiaryResponse.java
@@ -1,0 +1,121 @@
+package org.zerock.puppyrun.diary.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.diary.entity.Diary;
+import org.zerock.puppyrun.tracking.entity.Tracking;
+import org.zerock.puppyrun.tracking.entity.TrackingPath;
+
+/**
+ * 다이어리 상세 조회 응답 DTO
+ */
+@Builder
+public record DiaryResponse(
+        UUID DiaryId,
+        UUID TrackingId,
+        LocalDateTime writingTime,
+        String title,
+        String content,
+        Weather weather,
+        TrackingDetail trackingDetail,
+        List<String> images
+) {
+
+    /**
+     * Diary 엔티티를 DiaryResponse로 변환하는 정적 팩토리 메서드
+     */
+    public static DiaryResponse of(Diary diary) {
+        Tracking tracking = diary.getTracking();
+        return DiaryResponse.builder()
+                .DiaryId(diary.getId())
+                .TrackingId(getTrackingId(tracking))
+                .writingTime(diary.getWritingTime())
+                .title(diary.getTitle())
+                .content(diary.getContent())
+                .weather(Weather.from(diary)) // 날씨 변환 위임
+                .trackingDetail(TrackingDetail.from(tracking)) // 산책 정보 변환 위임
+                .images(diary.getImages())
+                .build();
+    }
+
+    // Null Safe하게 Tracking ID 추출
+    private static UUID getTrackingId(Tracking tracking) {
+        return (tracking != null) ? tracking.getId() : null;
+    }
+
+    /**
+     * 날씨 상세 정보
+     */
+    @Builder
+    public record Weather(
+            String temp,
+            String sky,
+            String pty
+    ) {
+        public static Weather from(Diary diary) {
+            return Weather.builder()
+                    .temp(diary.getTemp())
+                    .sky(diary.getSky().getCode())
+                    .pty(diary.getPty().getCode())
+                    .build();
+        }
+    }
+
+    /**
+     * 산책 상세 정보
+     */
+    @Builder
+    public record TrackingDetail(
+            LocalDateTime startedAt,
+            LocalDateTime endedAt,
+            Integer duration,
+            String visibility,
+            Integer distance,
+            List<TrackingPoint> path
+    ) {
+        public static TrackingDetail from(Tracking tracking) {
+            if (tracking == null) {
+                return null;
+            }
+            return TrackingDetail.builder()
+                    .startedAt(tracking.getStartedAt())
+                    .endedAt(tracking.getEndedAt())
+                    .duration(tracking.getDuration())
+                    .visibility(tracking.getVisibility().name())
+                    .distance(tracking.getDistance())
+                    .path(TrackingPoint.listOf(tracking.getPath())) // 경로 변환 위임
+                    .build();
+        }
+    }
+
+    /**
+     * 산책 경로 포인트
+     */
+    @Builder
+    public record TrackingPoint(
+            Double lat,
+            Double lng,
+            Integer time
+    ) {
+        // 리스트 변환 헬퍼 메서드
+        public static List<TrackingPoint> listOf(List<TrackingPath> paths) {
+            return Optional.ofNullable(paths)
+                    .orElseGet(Collections::emptyList)
+                    .stream()
+                    .map(TrackingPoint::from)
+                    .toList();
+        }
+
+        private static TrackingPoint from(TrackingPath path) {
+            return TrackingPoint.builder()
+                    .lat(path.getLat())
+                    .lng(path.getLng())
+                    .time(path.getTime())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/diary/entity/Diary.java
+++ b/src/main/java/org/zerock/puppyrun/diary/entity/Diary.java
@@ -1,0 +1,134 @@
+package org.zerock.puppyrun.diary.entity;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.zerock.puppyrun.common.entity.BaseTimeEntity;
+import org.zerock.puppyrun.diary.DTO.UpdateDiaryDTO;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.tracking.entity.Tracking;
+import org.zerock.puppyrun.weather.DTO.PrecipitationType;
+import org.zerock.puppyrun.weather.DTO.SkyType;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "diary")
+public class Diary extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, length = 100)
+    private String title; // 일기 제목
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content; // 일기 내용
+
+    @ManyToOne(fetch = FetchType.LAZY) // 다대일 관계, 지연 로딩
+    @JoinColumn(name = "member_id", nullable = false) // 외래 키 컬럼명 지정
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member member;
+
+    // 날씨 정보
+    @Column(name = "writing_time", nullable = false, length = 20)
+    private LocalDateTime writingTime; // 일기 작성 시간대 정보
+
+    @Column(nullable = false, length = 20)
+    private String temp; // 기온
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SkyType sky; // 하늘
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PrecipitationType pty; // 강수
+
+
+    // 연관된 산책 기록 (Tracking 엔티티와 일대일 관계)
+    // 산책 기록이 삭제되어도 일기는 유지될 수 있도록 nullable입니다.
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tracking_id")
+    private Tracking tracking;
+
+    // 이미지 리스트 매핑
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "diary_images", joinColumns = @JoinColumn(name = "diary_id"))
+    @Column(name = "image_url")
+    private List<String> images;
+
+
+    @Builder
+    public Diary(String title, String content, Member member, String temp, SkyType sky, PrecipitationType pty,
+                 LocalDateTime writingTime, Tracking tracking, List<String> images) {
+        this.title = title;
+        this.content = content;
+        this.member = member;
+        this.writingTime = writingTime;
+        this.temp = temp;
+        this.sky = sky;
+        this.pty = pty;
+        this.tracking = tracking;
+        this.images = images != null ? images : List.of(); // TODO: 추후 S3 만들어지면 저장할 것
+    }
+
+    /**
+     * 일기 정보를 수정합니다.
+     * <p>이미지 리스트는 기존 리스트를 비우고 새로운 리스트로 교체됩니다.</p>
+     *
+     * @param updateDiaryDTO 수정할 정보가 담긴 DTO
+     */
+    public void update(UpdateDiaryDTO updateDiaryDTO) {
+        this.title = updateDiaryDTO.title();
+        this.content = updateDiaryDTO.content();
+        this.writingTime = updateDiaryDTO.writingTime();
+        this.temp = updateDiaryDTO.temp();
+        this.sky = updateDiaryDTO.sky();
+        this.pty = updateDiaryDTO.pty();
+
+        if (updateDiaryDTO.images() != null) {
+            this.images.clear();
+            this.images.addAll(updateDiaryDTO.images());
+        }
+    }
+
+    /**
+     * 산책 기록과의 연관관계를 해제합니다.
+     */
+    public void unsetTracking() {
+        this.tracking = null;
+    }
+
+    /**
+     * 요청한 사용자가 일기의 작성자가 아닌지 확인합니다.
+     *
+     * @param memberId 요청한 사용자의 UUID
+     * @return 작성자가 아니면 true, 작성자면 false
+     */
+    public boolean isNotOwner(UUID memberId) {
+        return !this.member.getId().equals(memberId);
+    }
+
+}

--- a/src/main/java/org/zerock/puppyrun/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/zerock/puppyrun/diary/repository/DiaryRepository.java
@@ -1,0 +1,21 @@
+package org.zerock.puppyrun.diary.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.diary.entity.Diary;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, UUID> {
+    // JPQL을 사용하여 Diary 엔티티의 id만 조회 (SELECT d.id ...)
+    @Query("SELECT d.id FROM Diary d WHERE d.tracking.id = :trackingId")
+    Optional<UUID> findIdByTrackingId(@Param("trackingId") UUID trackingId);
+
+
+    boolean existsByTrackingId(UUID trackingId);
+
+    Optional<Diary> findByTrackingId(UUID trackingId);
+}

--- a/src/main/java/org/zerock/puppyrun/diary/service/DiaryService.java
+++ b/src/main/java/org/zerock/puppyrun/diary/service/DiaryService.java
@@ -1,0 +1,113 @@
+package org.zerock.puppyrun.diary.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.common.exception.InvalidValueException;
+import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
+import org.zerock.puppyrun.common.exception.UserForbiddenException;
+import org.zerock.puppyrun.diary.DTO.UpdateDiaryDTO;
+import org.zerock.puppyrun.diary.controller.request.RegisterDiaryRequest;
+import org.zerock.puppyrun.diary.controller.response.DiaryResponse;
+import org.zerock.puppyrun.diary.entity.Diary;
+import org.zerock.puppyrun.diary.repository.DiaryRepository;
+import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.tracking.entity.Tracking;
+import org.zerock.puppyrun.tracking.repository.TrackingRepository;
+import org.zerock.puppyrun.weather.DTO.PrecipitationType;
+import org.zerock.puppyrun.weather.DTO.SkyType;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class DiaryService {
+    private final TrackingRepository trackingRepository;
+    private final DiaryRepository diaryRepository;
+    private final MemberRepository memberRepository;
+
+    // 일기 작성
+    @Transactional
+    public DiaryResponse registerDiary(UUID memberId, RegisterDiaryRequest request) {
+
+        if (diaryRepository.existsByTrackingId(request.trackingId())) {
+            throw new InvalidValueException("이미 해당 산책 기록에 대한 일기가 존재합니다.");
+        }
+
+        Tracking tracking = trackingRepository.findById(request.trackingId())
+                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 산책 기록입니다"));
+
+        SkyType skyType = SkyType.fromCode(request.weather().sky());  // 날씨 코드 변환
+        PrecipitationType precipitationType = PrecipitationType.fromCode(request.weather().pty()); // 날씨 코드 변환
+        String temp = request.weather().temp();
+
+        Diary diary = Diary.builder()
+                .sky(skyType)
+                .pty(precipitationType)
+                .temp(temp)
+                .title(request.title())
+                .content(request.content())
+                .writingTime(request.writingTime())
+                .member(memberRepository.findByIdOrThrow(memberId))
+                .tracking(tracking)
+                .images(request.images())
+                .build();
+
+        Diary savedDiary = diaryRepository.save(diary);
+
+        return DiaryResponse.of(savedDiary);
+    }
+
+    // 일기 수정
+    @Transactional
+    public DiaryResponse updateDiary(UUID memberId, UUID diaryId, RegisterDiaryRequest request) {
+        Diary diary = findDiaryWithOwnershipCheck(diaryId, memberId);
+
+        SkyType skyType = SkyType.fromCode(request.weather().sky());  // 날씨 코드 변환
+        PrecipitationType precipitationType = PrecipitationType.fromCode(request.weather().pty()); // 날씨 코드 변환
+        String temp = request.weather().temp();
+
+        UpdateDiaryDTO updateDiaryDTO = UpdateDiaryDTO.builder()
+                .title(request.title())
+                .content(request.content())
+                .images(request.images())
+                .writingTime(request.writingTime())
+                .pty(precipitationType)
+                .sky(skyType)
+                .temp(temp)
+                .build();
+
+        diary.update(updateDiaryDTO);
+        return DiaryResponse.of(diary);
+    }
+
+    // 일기 삭제
+    @Transactional
+    public void deleteDiary(UUID memberId, UUID diaryId) {
+        Diary diary = findDiaryWithOwnershipCheck(diaryId, memberId);
+        diaryRepository.delete(diary);
+    }
+
+    // 일기 조회
+    public DiaryResponse getDiary(UUID memberId, UUID diaryId) {
+        Diary diary = findDiaryWithOwnershipCheck(diaryId, memberId);
+        return DiaryResponse.of(diary);
+    }
+
+
+    /**
+     * 일기 조회 및 소유권 검증
+     */
+    private Diary findDiaryWithOwnershipCheck(UUID diaryId, UUID memberId) {
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 일기입니다."));
+
+        if (diary.isNotOwner(memberId)) {
+            throw new UserForbiddenException("해당 일기에 대한 권한이 없습니다.");
+        }
+        return diary;
+    }
+
+}

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/TrackingController.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/TrackingController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
-import org.zerock.puppyrun.tracking.controller.request.ResistedTrackingRequest;
+import org.zerock.puppyrun.tracking.controller.request.RegisterTrackingRequest;
 import org.zerock.puppyrun.tracking.controller.response.MainTrackingResponse;
 import org.zerock.puppyrun.tracking.controller.response.TrackingDetailResponse;
 import org.zerock.puppyrun.tracking.service.TrackingService;
@@ -25,7 +25,7 @@ public class TrackingController {
 
     // 산책 저장
     @PostMapping("")
-    public ResponseEntity<String> saveTracking(@Valid @RequestBody ResistedTrackingRequest request,
+    public ResponseEntity<String> saveTracking(@Valid @RequestBody RegisterTrackingRequest request,
                                                @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
         trackingService.saveTracking(userPrincipal.id(), request);

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/request/RegisterTrackingRequest.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/request/RegisterTrackingRequest.java
@@ -1,6 +1,5 @@
 package org.zerock.puppyrun.tracking.controller.request;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -9,7 +8,7 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record ResistedTrackingRequest(
+public record RegisterTrackingRequest(
         @NotNull(message = "산책 시작 시간은 필수입니다.")
         LocalDateTime startedAt, // 산책 시작 시간
 

--- a/src/main/java/org/zerock/puppyrun/tracking/service/TrackingService.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/service/TrackingService.java
@@ -10,7 +10,7 @@ import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.common.exception.UserForbiddenException;
 import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.member.repository.MemberRepository;
-import org.zerock.puppyrun.tracking.controller.request.ResistedTrackingRequest;
+import org.zerock.puppyrun.tracking.controller.request.RegisterTrackingRequest;
 import org.zerock.puppyrun.tracking.controller.response.MainTrackingResponse;
 import org.zerock.puppyrun.tracking.controller.response.TrackingDetailResponse;
 import org.zerock.puppyrun.tracking.entity.Tracking;
@@ -43,7 +43,7 @@ public class TrackingService {
      * 산책 저장
      */
     @Transactional
-    public void saveTracking(UUID memberId, ResistedTrackingRequest request) {
+    public void saveTracking(UUID memberId, RegisterTrackingRequest request) {
         Member member = memberRepository.findByIdOrThrow(memberId);
 
         List<TrackingPath> path = request.path().stream()


### PR DESCRIPTION
# 📌 Pull Request:  일기(Diary) CRUD 구현 및 산책 기록 연동, JSON 파싱 예외 처리 강화 (#9 )
# 📝 작업 요약 (Summary)

이번 PR에서는 사용자가 산책 후 기록을 남길 수 있는 **일기(Diary) 기능의 CRUD**를 구현하고, **산책 기록(Tracking)**과의 연동 로직을 완성했습니다.
또한, 클라이언트의 잘못된 요청(JSON 형식 오류, 유효성 검증 실패)에 대해 명확한 에러 메시지를 전달하기 위해 **Global Exception Handler**를 개선했습니다.

- 일기(Diary) 작성, 수정, 삭제, 상세 조회 API 구현
- API 예외 처리 핸들러 추가 (`HttpMessageNotReadableException` 등)

# 🛠️ 변경 사항 (Changes)

## 1. 일기 (Diary) 도메인 구현
- **Entity & Repository**
  - `Diary` 엔티티 정의: 제목, 내용, 날씨, 이미지, 산책 기록(Tracking)과의 1:1 관계 설정.
  - `DiaryRepository`: `existsByTrackingId`, `findIdByTrackingId` 등 조회 최적화 메서드 추가.
- **Service & Controller**
  - `DiaryService`:
    - `registerDiary`: 일기 작성 시 해당 산책 기록에 이미 일기가 존재하는지 중복 검사 로직 추가.
    - `findDiaryWithOwnershipCheck`: 조회 및 권한 검증 로직을 공통 메서드로 분리하여 중복 제거.
  - `DiaryController`: `@Valid`를 통한 요청 데이터 검증 및 `UserPrincipal`을 이용한 사용자 식별 처리.
- **DTO**
  - `DiaryResponse`: `of` 팩토리 메서드를 통해 `Weather`, `TrackingDetail` 등 내부 레코드로 변환 로직을 위임하여 가독성 향상.
  - `RegisterDiaryRequest` / `UpdateDiaryRequest`: 요청 목적에 따라 DTO를 분리하고 Validation 어노테이션 적용.


## 2. 예외 처리 (GlobalExceptionHandler)
- **JSON 파싱 에러 핸들링 추가**
  - `HttpMessageNotReadableException`: 요청 JSON 형식이 잘못되거나 데이터 타입이 불일치할 경우(예: Integer 필드에 String 입력) 400 Bad Request와 명확한 에러 메시지를 반환하도록 처리.
- **유효성 검증 에러 개선**
  - `MethodArgumentNotValidException`: `@Valid` 검증 실패 시 첫 번째 에러 메시지를 추출하여 클라이언트에게 전달하도록 수정.

# 📸 테스트 시나리오 (Test Scenarios)

## 1. 일기 작성 (Diary Registration)

* **Method**: POST
* **URL**: `/api/diaries`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {AccessToken}`

### ✅ 1-1 : 정상적으로 일기가 등록되는 경우

**Request Body**

``` json
{
    "tracking_id": "d0fb4fbd-b85d-4f87-a606-1cc605182577",
    "writing_time": "2024-05-27T18:00:00",
    "title": "저녁 가벼운 산책",
    "content": "비가 조금 와서 짧게 돌고 들어왔다.",
    "weather": {
        "temp": "18.0",
        "sky": "4",
        "pty": "1"
    },
    "images": []
}
```

**Response (200 OK)**

``` json
{
    "diary_id": "33718b93-7e1c-4e39-80f1-789446046ca9",
    "tracking_id": "d0fb4fbd-b85d-4f87-a606-1cc605182577",
    "writing_time": "2024-05-27T18:00:00",
    "title": "저녁 가벼운 산책",
    "content": "비가 조금 와서 짧게 돌고 들어왔다.",
    "weather": {
        "temp": "18.0",
        "sky": "4",
        "pty": "1"
    },
    "tracking_detail": {
        "started_at": "2026-03-01T18:00:00",
        "ended_at": "2026-03-01T19:15:00",
        "duration": 4500,
        "visibility": "PRIVATE",
        "distance": 8200,
        "path": [
            {
                "lat": 35.1587,
                "lng": 129.1604,
                "time": 0
            },
            {
                "lat": 35.159,
                "lng": 129.161,
                "time": 300
            },
            ...
        ]
    },
    "images": []
}

```

### ❌ 1-2 : 잘못된 날씨 코드

**Request Body**

``` json
{
    "tracking_id": "d0fb4fbd-b85d-4f87-a606-1cc605182577",
    "writing_time": "2024-05-27T18:00:00",
    "title": "저녁 가벼운 산책",
    "content": "비가 조금 와서 짧게 돌고 들어왔다.",
    "weather": {
        "temp": "18.0",
        "sky": "4",
        "pty": "-1" // 잘못된 데이터
    },
    "images": []
}
```

**Response (500 Internal Server Error)**

``` json
{
    "code": "WEATHER_001",
    "description": "잘못된 날씨입니다.",
    "message": "잘못된 강수형태 코드입니다: -1",
    "path": "/api/diaries",
    "timestamp": "2026-02-28T23:54:19.303454"
}
```

### ❌ 1-3 : 중복된 일기 등록 
이미 해당 산책 기록(Tracking ID)으로 등록된 일기가 존재하는 경우 

**Request Body**
``` json
{
    "tracking_id": "d0fb4fbd-b85d-4f87-a606-1cc605182577",   // 이미 해당 산책 ID 에 대한 일기가 존재
    "writing_time": "2024-05-27T18:00:00",
    "title": "저녁 가벼운 산책",
    "content": "비가 조금 와서 짧게 돌고 들어왔다.",
    "weather": {
        "temp": "18.0",
        "sky": "4",
        "pty": "1"
    },
    "images": []
}
```

**Response (400 Bad Request)**
``` json
{
    "code": "CLIENT_001",
    "description": "잘못된 요청입니다.",
    "message": "이미 해당 산책 기록에 대한 일기가 존재합니다.",
    "path": "/api/diaries",
    "timestamp": "2026-03-01T00:33:44.566101"
}
```


## 2. 일기 수정 (Update Diary)

* **Method**: PUT
* **URL**: `/api/diaries/{diaryId}`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {AccessToken}`

### ✅ 2-1 : 일기 수정 성공


**Request Body**
``` json
{
    "writing_time": "2024-05-27T16:00:00",
    "title": "수정된 제목", // 수정된
    "content": "강대훈이 산책을 많이 했다", // 수정됨
    "weather": {
        "temp": "18.0",
        "sky": "4",
        "pty": "1"
    },
    "images": []
}
```
**Response (200 OK)**
``` json
{
    "diary_id": "33718b93-7e1c-4e39-80f1-789446046ca9",
    "tracking_id": "d0fb4fbd-b85d-4f87-a606-1cc605182577",
    "writing_time": "2024-05-27T16:00:00",
    "title": "수정된 제목",
    "content": "강대훈이 산책을 많이 했다",
    "weather": {
        "temp": "18.0",
        "sky": "4",
        "pty": "1"
    },
    "tracking_detail": {
        "started_at": "2026-03-01T18:00:00",
        "ended_at": "2026-03-01T19:15:00",
        "duration": 4500,
        "visibility": "PRIVATE",
        "distance": 8200,
        "path": [
            {
                "lat": 35.1587,
                "lng": 129.1604,
                "time": 0
            },
            {
                "lat": 35.159,
                "lng": 129.161,
                "time": 300
            },
 ...
        ]
    },
    "images": []
}
```

### ❌ 2-2 : 잘못된 날씨 코드 

수정 시 정의되지 않은 날씨 코드를 전송했을 경우 

**Request Body**
``` json
{
    "tracking_id": "d0fb4fbd-b85d-4f87-a606-1cc605182577",
    "writing_time": "2024-05-27T16:00:00",
    "title": "수정된 제목", 
    "content": "강대훈이 산책을 많이 했다", 
    "weather": {
        "temp": "18.0",
        "sky": "4",
        "pty": "-1" // 잘못된 날씨 코드
    },
    "images": []
}
```
**Response (500 Internal Server Error)**
``` json
{
    "code": "WEATHER_001",
    "description": "잘못된 날씨입니다.",
    "message": "잘못된 강수형태 코드입니다: -1",
    "path": "/api/diaries/5b7672bd-4836-4a6e-b459-650a02189e35",
    "timestamp": "2026-03-01T00:48:54.556643"
}
```


## 3. 일기 삭제 (Delete Diary)

* **Method**: DELETE
* **URL**: `/api/diaries/{diaryId}`
* **Header**: `Authorization: Bearer {AccessToken}`

### ✅ 3-1 : 일기 삭제 성공 (200 OK)

<!-- 본인이 작성한 일기를 정상적으로 삭제하는 경우 -->

**Request Body**
``` json
없음
```

**Response (200 OK)**
``` json
없음
```

### ❌ 3-2 : 존재하지 않는 일기 

이미 삭제되었거나 존재하지 않는 Diary ID로 요청한 경우 

**Request Body**
``` json
없음
```

**Response (404 Not Found)**
``` json
{
    "code": "CLIENT_002",
    "description": "요청한 값을 찾을 수 없습니다.",
    "message": "존재하지 않는 일기입니다.",
    "path": "/api/diaries/d0fb4fbd-b85d-4f87-a606-1cc605182577",
    "timestamp": "2026-03-01T00:50:07.061017"
}
```

## 4. 일기 조회 (Get Diary)

* **Method**: GET
* **URL**: `/api/diaries/{diaryId}`
* **Header**: `Authorization: Bearer {AccessToken}`

### ✅ 4-1 : 일기 상세 조회 성공 (200 OK)

일기 상세 정보를 정상적으로 조회하는 경우 
등록된 일기가 없을 시 `diary_id = null` 로 반환

**Request Body**
``` json
없음
```
**Response (200 OK)**
``` json
{
    "diary_id": "33718b93-7e1c-4e39-80f1-789446046ca9",  // 등록된 일기가 없을 경우 null
    "tracking_id": "d0fb4fbd-b85d-4f87-a606-1cc605182577",
    "writing_time": "2024-05-27T18:00:00",
    "title": "저녁 가벼운 산책",
    "content": "비가 조금 와서 짧게 돌고 들어왔다.",
    "weather": {
        "temp": "18.0",
        "sky": "4",
        "pty": "1"
    },
    "tracking_detail": {
        "started_at": "2026-03-01T18:00:00",
        "ended_at": "2026-03-01T19:15:00",
        "duration": 4500,
        "visibility": "PRIVATE",
        "distance": 8200,
        "path": [
            {
                "lat": 35.1587,
                "lng": 129.1604,
                "time": 0
            },
            {
                "lat": 35.159,
                "lng": 129.161,
                "time": 300
            },
   ...
        ]
    },
    "images": []
}
```