### PR TITLE
feat: 산책(Tracking) 수정·삭제 API 구현 및 일기 연동 처리 (#9)

### DIFF
--- a/src/main/java/org/zerock/puppyrun/tracking/DTO/UpdateTrackingDTO.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/DTO/UpdateTrackingDTO.java
@@ -1,0 +1,14 @@
+package org.zerock.puppyrun.tracking.DTO;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import org.zerock.puppyrun.tracking.entity.Visibility;
+
+@Builder
+public record UpdateTrackingDTO(
+        LocalDateTime startedAt,
+        LocalDateTime endedAt,
+        Integer distance,
+        Visibility visibility
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/TrackingController.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/TrackingController.java
@@ -5,9 +5,12 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,6 +18,8 @@ import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.tracking.controller.request.RegisterTrackingRequest;
 import org.zerock.puppyrun.tracking.controller.response.MainTrackingResponse;
 import org.zerock.puppyrun.tracking.controller.response.TrackingDetailResponse;
+import org.zerock.puppyrun.tracking.controller.request.ChangeVisibilityRequest;
+import org.zerock.puppyrun.tracking.controller.request.UpdateTrackingRequest;
 import org.zerock.puppyrun.tracking.service.TrackingService;
 
 @RestController
@@ -41,6 +46,7 @@ public class TrackingController {
         return ResponseEntity.ok(response);
     }
 
+    // 산책 기록 상세 조회
     @GetMapping("/{trackingId}")
     public ResponseEntity<TrackingDetailResponse> getTracking(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -51,4 +57,38 @@ public class TrackingController {
         return ResponseEntity.ok(response);
     }
 
+    // 산책 정보 수정 (전체 수정)
+    @PutMapping("/{trackingId}")
+    public ResponseEntity<TrackingDetailResponse> updateTracking(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID trackingId,
+            @RequestBody UpdateTrackingRequest request) {
+
+        TrackingDetailResponse response = trackingService.updateTracking(userPrincipal.id(), trackingId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 산책 공개 여부 변경 (부분 수정)
+    @PatchMapping("/{trackingId}/visibility")
+    public ResponseEntity<Void> changeVisibility(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID trackingId,
+            @RequestBody ChangeVisibilityRequest request) { // {"visibility": "PUBLIC"} 형태의 JSON 요청 처리
+
+        trackingService.changeTrackingVisibility(userPrincipal.id(), trackingId, request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    // 산책 정보 삭제
+    @DeleteMapping("/{trackingId}")
+    public ResponseEntity<Void> deleteTracking(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID trackingId) {
+
+        trackingService.deleteTracking(userPrincipal.id(), trackingId);
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/request/ChangeVisibilityRequest.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/request/ChangeVisibilityRequest.java
@@ -1,0 +1,6 @@
+package org.zerock.puppyrun.tracking.controller.request;
+
+public record ChangeVisibilityRequest(
+        String visibility // "PUBLIC" 또는 "PRIVATE"
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/request/UpdateTrackingRequest.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/request/UpdateTrackingRequest.java
@@ -1,0 +1,12 @@
+package org.zerock.puppyrun.tracking.controller.request;
+
+import java.time.LocalDateTime;
+import org.zerock.puppyrun.tracking.entity.Visibility;
+
+public record UpdateTrackingRequest(
+        LocalDateTime startedAt,
+        LocalDateTime endedAt,
+        Integer distance,
+        Visibility visibility
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/response/MainTrackingResponse.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/response/MainTrackingResponse.java
@@ -1,20 +1,82 @@
 package org.zerock.puppyrun.tracking.controller.response;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.Builder;
 import org.zerock.puppyrun.tracking.entity.Tracking;
+import org.zerock.puppyrun.tracking.entity.TrackingPath;
 
 @Builder
 public record MainTrackingResponse(
-        List<TrackingDetailResponse> trackingList
+        List<TrackingDetail> trackingList
 ) {
+
+    /**
+     * Tracking 리스트를 MainTrackingResponse로 변환
+     */
     public static MainTrackingResponse from(List<Tracking> trackingList) {
-        List<TrackingDetailResponse> responses = trackingList.stream()
-                .map(TrackingDetailResponse::from)
+        List<TrackingDetail> details = trackingList.stream()
+                .map(TrackingDetail::from)
                 .toList();
 
-        return MainTrackingResponse.builder()
-                .trackingList(responses)
-                .build();
+        return new MainTrackingResponse(details);
+    }
+
+    @Builder
+    public record TrackingDetail(
+            UUID id,                     // 산책 고유 아이디
+            LocalDateTime startedAt,     // 산책 시작 시간
+            LocalDateTime endedAt,       // 산책 종료 시간
+            Integer duration,            // 산책 진행 시간
+            String visibility,           // 공개 여부
+            Integer distance,            // 이동 거리
+            List<TrackingPoint> path     // 이동 경로 리스트
+    ) {
+        /**
+         * Tracking 엔티티를 TrackingDetail DTO로 변환
+         */
+        public static TrackingDetail from(Tracking tracking) {
+            return TrackingDetail.builder()
+                    .id(tracking.getId())
+                    .startedAt(tracking.getStartedAt())
+                    .endedAt(tracking.getEndedAt())
+                    .duration(tracking.getDuration())
+                    .visibility(tracking.getVisibility().name())
+                    .distance(tracking.getDistance())
+                    .path(TrackingPoint.listOf(tracking.getPath()))
+                    .build();
+        }
+    }
+
+    @Builder
+    public record TrackingPoint(
+            Double lat,   // 위도
+            Double lng,   // 경도
+            Integer time  // 경과 시간
+    ) {
+        /**
+         * TrackingPath 엔티티 리스트를 TrackingPoint DTO 리스트로 변환
+         */
+        public static List<TrackingPoint> listOf(List<TrackingPath> paths) {
+            return Optional.ofNullable(paths)
+                    .orElseGet(Collections::emptyList)
+                    .stream()
+                    .map(TrackingPoint::from)
+                    .toList();
+        }
+
+        /**
+         * 단일 TrackingPath 변환
+         */
+        private static TrackingPoint from(TrackingPath path) {
+            return TrackingPoint.builder()
+                    .lat(path.getLat())
+                    .lng(path.getLng())
+                    .time(path.getTime())
+                    .build();
+        }
     }
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/response/TrackingDetailResponse.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/response/TrackingDetailResponse.java
@@ -8,13 +8,14 @@ import org.zerock.puppyrun.tracking.entity.Tracking;
 
 @Builder
 public record TrackingDetailResponse(
-        UUID id,                 // 산책 고유 아이디
-        LocalDateTime startedAt, // 산책 시작 시간
-        LocalDateTime endedAt,   // 산책 종료 시간
-        Integer duration,        // 산책 진행 시간
-        String visibility,       // 공개 여부
-        Integer distance,        // 이동 거리
-        List<TrackingPoint> path // 이동 경로 리스트
+        UUID id,                     // 산책 고유 아이디
+        UUID diaryId,                // 일기 고유 아이디
+        LocalDateTime startedAt,     // 산책 시작 시간
+        LocalDateTime endedAt,       // 산책 종료 시간
+        Integer duration,            // 산책 진행 시간
+        String visibility,           // 공개 여부
+        Integer distance,            // 이동 거리
+        List<TrackingPoint> path     // 이동 경로 리스트
 ) {
 
     @Builder
@@ -25,13 +26,14 @@ public record TrackingDetailResponse(
     ) {
     }
 
-    public static TrackingDetailResponse from(Tracking tracking) {
+    public static TrackingDetailResponse of(Tracking tracking, UUID diaryId) {
         List<TrackingPoint> pathPoints = tracking.getPath().stream()
                 .map(p -> new TrackingPoint(p.getLat(), p.getLng(), p.getTime()))
                 .toList();
 
         return TrackingDetailResponse.builder()
                 .id(tracking.getId())
+                .diaryId(diaryId)
                 .startedAt(tracking.getStartedAt())
                 .endedAt(tracking.getEndedAt())
                 .duration(tracking.getDuration())

--- a/src/main/java/org/zerock/puppyrun/tracking/entity/Tracking.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/entity/Tracking.java
@@ -94,6 +94,11 @@ public class Tracking extends BaseTimeEntity {
 
     }
 
+    public void changeVisibility(Visibility visibility) {
+        this.visibility = visibility;
+    }
+
+
     public boolean isNotOwner(UUID memberId) {
         return !this.member.getId().equals(memberId);
     }

--- a/src/main/java/org/zerock/puppyrun/tracking/entity/Tracking.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/entity/Tracking.java
@@ -23,8 +23,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.zerock.puppyrun.common.entity.BaseTimeEntity;
-
 import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.tracking.DTO.UpdateTrackingDTO;
 
 @Entity
 @Getter
@@ -58,7 +58,6 @@ public class Tracking extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer distance;        // 산책 거리
 
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Visibility visibility;
@@ -84,9 +83,18 @@ public class Tracking extends BaseTimeEntity {
         this.path = path;
     }
 
+    public void update(UpdateTrackingDTO updateTrackingDTO) {
+        this.startedAt = updateTrackingDTO.startedAt();
+        this.endedAt = updateTrackingDTO.endedAt();
+        this.distance = updateTrackingDTO.distance();
+        this.visibility = updateTrackingDTO.visibility();
 
-    public boolean isOwner(UUID memberId) {
-        return this.member.getId().equals(memberId);
+        // 시간 변경에 따른 duration 재계산
+        this.duration = (int) Duration.between(startedAt, endedAt).getSeconds();
+
     }
 
+    public boolean isNotOwner(UUID memberId) {
+        return !this.member.getId().equals(memberId);
+    }
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/service/TrackingService.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/service/TrackingService.java
@@ -8,10 +8,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.common.exception.UserForbiddenException;
+import org.zerock.puppyrun.diary.entity.Diary;
+import org.zerock.puppyrun.diary.repository.DiaryRepository;
 import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.tracking.controller.request.ChangeVisibilityRequest;
 import org.zerock.puppyrun.tracking.controller.request.RegisterTrackingRequest;
 import org.zerock.puppyrun.tracking.controller.response.MainTrackingResponse;
+import org.zerock.puppyrun.tracking.controller.request.UpdateTrackingRequest;
+import org.zerock.puppyrun.tracking.DTO.UpdateTrackingDTO;
 import org.zerock.puppyrun.tracking.controller.response.TrackingDetailResponse;
 import org.zerock.puppyrun.tracking.entity.Tracking;
 import org.zerock.puppyrun.tracking.entity.TrackingPath;
@@ -23,19 +28,21 @@ import org.zerock.puppyrun.tracking.repository.TrackingRepository;
 @Slf4j
 @Transactional(readOnly = true)
 public class TrackingService {
+    private final DiaryRepository diaryRepository;
     private final TrackingRepository trackingRepository;
     private final MemberRepository memberRepository;
 
     /**
      * 산책 상세 조회
      */
-    public Tracking getTracking(UUID memberId, UUID trackingId) {
+    public Tracking findTrackingWithOwnershipCheck(UUID memberId, UUID trackingId) {
         Tracking tracking = trackingRepository.findById(trackingId)
                 .orElseThrow(() -> new ResourceNotFoundException("해당 산책 기록을 찾을 수 없습니다."));
 
-        if (!tracking.isOwner(memberId)) {
+        if (tracking.isNotOwner(memberId)) {
             throw new UserForbiddenException("해당 산책 기록에 대한 권한이 없습니다.");
         }
+
         return tracking;
     }
 
@@ -46,6 +53,7 @@ public class TrackingService {
     public void saveTracking(UUID memberId, RegisterTrackingRequest request) {
         Member member = memberRepository.findByIdOrThrow(memberId);
 
+        // 경로 데이터 변환
         List<TrackingPath> path = request.path().stream()
                 .map(point -> new TrackingPath(point.lat(), point.lng(), point.time()))
                 .toList();
@@ -62,6 +70,55 @@ public class TrackingService {
                 .distance(request.distance())
                 .path(path)
                 .build();
+
+        trackingRepository.save(tracking);
+    }
+
+    /**
+     * 산책 정보 수정
+     */
+    @Transactional
+    public TrackingDetailResponse updateTracking(UUID memberId, UUID trackingId, UpdateTrackingRequest request) {
+        Tracking tracking = findTrackingWithOwnershipCheck(memberId, trackingId);
+
+        UpdateTrackingDTO updateTrackingDTO = UpdateTrackingDTO.builder()
+                .distance(request.distance())
+                .endedAt(request.endedAt())
+                .startedAt(request.startedAt())
+                .visibility(request.visibility())
+                .build();
+
+        tracking.update(updateTrackingDTO);
+
+        // 일기 ID 조회 (없으면 null)
+        UUID diaryId = diaryRepository.findIdByTrackingId(trackingId)
+                .orElse(null);
+
+        return TrackingDetailResponse.of(tracking, diaryId);
+    }
+
+    /**
+     * 산책 공개 여부 변경 (Lightweight Update)
+     */
+    @Transactional
+    public void changeTrackingVisibility(UUID memberId, UUID trackingId, ChangeVisibilityRequest request) {
+        Tracking tracking = findTrackingWithOwnershipCheck(memberId, trackingId);
+        Visibility visibility = Visibility.from(request.visibility());
+        // 공개 여부 변경
+        tracking.changeVisibility(visibility);
+    }
+
+    /**
+     * 산책 기록 삭제
+     */
+    @Transactional
+    public void deleteTracking(UUID memberId, UUID trackingId) {
+        Tracking tracking = findTrackingWithOwnershipCheck(memberId, trackingId);
+
+        // 연관된 일기가 있다면 tracking_id를 null로 변경
+        diaryRepository.findByTrackingId(trackingId)
+                .ifPresent(Diary::unsetTracking);
+        trackingRepository.delete(tracking);
     }
 
     /**
@@ -76,9 +133,11 @@ public class TrackingService {
      * 산책 상세 조회
      */
     public TrackingDetailResponse getTrackingResponse(UUID memberId, UUID trackingId) {
-        Tracking tracking = getTracking(memberId, trackingId);
-        return TrackingDetailResponse.from(tracking);
+        Tracking tracking = findTrackingWithOwnershipCheck(memberId, trackingId);
+
+        UUID diaryId = diaryRepository.findIdByTrackingId(trackingId)
+                .orElse(null);
+
+        return TrackingDetailResponse.of(tracking, diaryId);
     }
-
-
 }


### PR DESCRIPTION
# 📌 Pull Request: 산책(Tracking) 수정·삭제 API 구현 및 일기 연동 처리 (#9)

# 📝 작업 요약 (Summary)

이번 PR에서는 **산책 기록(Tracking)의 수정, 삭제, 상세 조회** 기능을 구현했습니다.
특히 산책 기록 수정 시 **소요 시간(Duration) 재계산 로직**을 적용하고, 공개 여부(Visibility)만 빠르게 변경할 수 있는 **PATCH 엔드포인트**를 분리했습니다.
또한, 산책 기록 삭제 시 연관된 일기(Diary) 데이터가 사라지지 않도록 **연관관계 해제 로직**을 추가했습니다.

- 산책 기록 전체 수정(PUT) 및 공개 여부 개별 수정(PATCH) 구현
- 산책 기록 삭제(DELETE) 시 일기와의 연관관계 안전하게 해제
- 응답 DTO 구조 개선 및 일기 ID(diaryId) 연동

# 🛠️ 변경 사항 (Changes)

## 1. 산책 (Tracking) 도메인

- **Entity (`Tracking`)**
    - `update()`: 시작/종료 시간 변경 시 `duration`을 자동으로 재계산하는 로직 포함.
    - `changeVisibility()`: 공개 여부 상태 변경을 위한 도메인 메서드 추가.
    - `isNotOwner()`: 소유권 검증 로직 수정.
- **DTO**
    - `UpdateTrackingRequest`: 산책 정보 전체 수정을 위한 DTO.
    - `ChangeVisibilityRequest`: 공개 여부 단일 수정을 위한 DTO.
    - `TrackingDetailResponse`: `diaryId` 필드 추가 및 `from` -> `of` 팩토리 메서드 네이밍 변경.

## 2. 비즈니스 로직 (TrackingService)

- **수정 로직 분리**
    - `updateTracking`: 거리, 시간 등 전체 정보 업데이트.
    - `changeTrackingVisibility`: 공개 여부만 변경하는 경량화 로직.
- **삭제 로직 개선 (`deleteTracking`)**
    - 산책 기록 삭제 전, `diaryRepository.findByTrackingId`를 조회하여 연관된 일기가 있다면 `unsetTracking()`을 호출해 FK를 `null`로 변경 (데이터 보존).
- **상세 조회 (`getTrackingResponse`)**
    - 산책 기록 조회 시 연관된 일기가 있다면 `diaryId`를 반환, 없으면 `null` 반환.

## 3. 컨트롤러 (TrackingController)

- `PUT /api/tracking/{trackingId}`: 산책 정보 수정 엔드포인트.
- `PATCH /api/tracking/{trackingId}/visibility`: 공개 여부 변경 엔드포인트.
- `DELETE /api/tracking/{trackingId}`: 산책 기록 삭제 엔드포인트.

# 📸 테스트 시나리오 (Test Scenarios)

## 1. 산책 정보 수정 (Update Tracking)

- **Method**: PUT
- **URL**: `/api/tracking/{trackingId}`
- **Content-Type**: `application/json`
- **Header**: `Authorization: Bearer {AccessToken}`

### ✅ 1-1 : 산책 정보 수정 성공

시작/종료 시간, 거리, 공개 여부 등을 수정하고 Duration이 재계산되는지 확인

**Request Body**

```json
{
    "started_at": "2024-05-28T10:00:00",
    "ended_at": "2024-05-28T11:30:00",
    "distance": 2100,
    "visibility": "PRIVATE"
}
```

**Response (200 OK)**

```json
{
    "id": "d0fb4fbd-b85d-4f87-a606-1cc605182577",
    "diary_id": null,
    "started_at": "2024-05-28T10:00:00",
    "ended_at": "2024-05-28T11:30:00",
    "duration": 5400,
    "visibility": "PRIVATE",
    "distance": 2100,
    "path": [
        {
            "lat": 35.1587,
            "lng": 129.1604,
            "time": 0
        },
        {
            "lat": 35.159,
            "lng": 129.161,
            "time": 300
        },
...
    ]
}
```

## 2. 산책 공개 여부 변경 (Change Visibility)

- **Method**: PATCH
- **URL**: `/api/tracking/{trackingId}/visibility`
- **Content-Type**: `application/json`
- **Header**: `Authorization: Bearer {AccessToken}`

### ✅ 2-1 : 공개 여부 변경 성공

PUBLIC <-> PRIVATE  변경

**Request Body**

```json
{
    "visibility": "PUBLIC"
}
```

**Response (200 OK)**

```json
없음
```

### ❌ 2-2 : 잘못된 공개 코드

"PUBLIC", "PRIVATE" 외의 잘못된 문자열 전송 시

**Request Body**

```json
{
    "visibility": "Incorrect code"
}
```

**Response (400 Bad Request)**

```json
{
    "code": "CLIENT_001",
    "description": "잘못된 요청입니다.",
    "message": "공개 여부 값이 올바르지 않습니다. | Incorrect code",
    "path": "/api/tracking/d0fb4fbd-b85d-4f87-a606-1cc605182577/visibility",
    "timestamp": "2026-03-01T01:46:56.081129"
}
```

## 3. 산책 기록 삭제 (Delete Tracking)

- **Method**: DELETE
- **URL**: `/api/tracking/{trackingId}`
- **Header**: `Authorization: Bearer {AccessToken}`

### ✅ 3-1 : 산책 기록 삭제 성공

삭제 요청이 성공하고, 연관된 일기(Diary)의 tracking_id가 NULL로 변경되었는지 확인

**Request Body**

```json
없음
```

**Response (200 OK)**

```json
없음
```

### ❌ 3-2 : 존재하지 않는 기록

<!-- 삭제하려는 trackingId가 DB에 존재하지 않는 경우 -->

**Request Body**

```json
없음
```

**Response (404 Not Found)**

```json
{
    "code": "CLIENT_002",
    "description": "요청한 값을 찾을 수 없습니다.",
    "message": "해당 산책 기록을 찾을 수 없습니다.",
    "path": "/api/tracking/d0fb4fbd-b85d-4f87-a606-1cc605182577",
    "timestamp": "2026-03-02T17:46:49.635047"
}
```