### PR TITLE
feat: 날씨 API 구조 개선 및 단기 예보 기능 구현 (#10)

### DIFF
--- a/src/main/java/org/zerock/puppyrun/common/scheduler/WeatherScheduler.java
+++ b/src/main/java/org/zerock/puppyrun/common/scheduler/WeatherScheduler.java
@@ -28,13 +28,16 @@ public class WeatherScheduler {
     private final WeatherMapper weatherMapper;
     private final CacheManager cacheManager;
 
+    int ONE_SECOND = 1000;
+    
     @Scheduled(cron = "0 0 * * * *")
     public void scheduledWeatherUpdate() {
+
         log.info("날씨 데이터 정기 업데이트 시작");
         DateTimeDTO dateTimeDTO = weatherApiClient.createCurrentDateTimeDto();
 
         Flux.fromArray(RegionType.values())
-                .delayElements(Duration.ofMillis(500)) // 요청 간 0.5초 딜레이
+                .delayElements(Duration.ofMillis(ONE_SECOND)) // 요청 간 0.5초 딜레이
                 .flatMap(region -> {
                     WeatherApiPara para = new WeatherApiPara(
                             dateTimeDTO.baseDate(),

--- a/src/main/java/org/zerock/puppyrun/weather/controller/WeatherController.java
+++ b/src/main/java/org/zerock/puppyrun/weather/controller/WeatherController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.zerock.puppyrun.weather.DTO.RegionType;
 import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+import org.zerock.puppyrun.weather.controller.response.WeatherForecastResponse;
 import org.zerock.puppyrun.weather.controller.response.WeatherResponse;
 import org.zerock.puppyrun.weather.service.WeatherService;
 
@@ -18,9 +19,13 @@ import org.zerock.puppyrun.weather.service.WeatherService;
 public class WeatherController {
     private final WeatherService weatherService;
 
-
-    @GetMapping("")
-    public ResponseEntity<?> getWeather(@RequestParam int lat, @RequestParam int lon) {
+    /**
+     * 현재 시간 기준 날씨 조회
+     */
+    @GetMapping("/current")
+    public ResponseEntity<WeatherResponse> getCurrentWeather(@RequestParam int lat,
+                                                             @RequestParam int lon
+    ) {
         RegionType regionType = RegionType.findNearest(lat, lon);
 
         List<WeatherDTO> weatherDTOList = weatherService.getRegionalWeather(regionType);
@@ -28,6 +33,20 @@ public class WeatherController {
         WeatherDTO weatherDTO = weatherService.getNearestTimeWeather(weatherDTOList);
 
         WeatherResponse response = WeatherResponse.of(weatherDTO, regionType);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    /**
+     * 날씨 예보 조회 (전체 리스트)
+     */
+    @GetMapping("/forecast")
+    public ResponseEntity<WeatherForecastResponse> getWeatherForecast(@RequestParam int lat, @RequestParam int lon) {
+        RegionType regionType = RegionType.findNearest(lat, lon);
+
+        List<WeatherDTO> weatherDTOList = weatherService.getRegionalWeather(regionType);
+
+        WeatherForecastResponse response = WeatherForecastResponse.of(weatherDTOList, regionType);
 
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/org/zerock/puppyrun/weather/controller/response/WeatherForecastResponse.java
+++ b/src/main/java/org/zerock/puppyrun/weather/controller/response/WeatherForecastResponse.java
@@ -1,0 +1,63 @@
+package org.zerock.puppyrun.weather.controller.response;
+
+import java.util.List;
+import lombok.Builder;
+import org.zerock.puppyrun.weather.DTO.RegionType;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+
+@Builder
+public record WeatherForecastResponse(
+        RegionType region,
+        List<WeatherTime> forecasts
+) {
+
+    /**
+     * WeatherDTO 리스트를 WeatherForecastResponse로 변환하는 정적 팩토리 메서드
+     */
+    public static WeatherForecastResponse of(List<WeatherDTO> dtoList, RegionType region) {
+        List<WeatherTime> forecastList = dtoList.stream()
+                .map(WeatherTime::from)
+                .toList();
+
+        return WeatherForecastResponse.builder()
+                .region(region)
+                .forecasts(forecastList)
+                .build();
+    }
+
+    @Builder
+    public record WeatherTime(
+            String date,
+            String time,
+            Detail detail
+    ) {
+        /**
+         * 단일 WeatherDTO를 WeatherTime으로 변환
+         */
+        public static WeatherTime from(WeatherDTO dto) {
+            return WeatherTime.builder()
+                    .date(dto.date())
+                    .time(dto.time())
+                    .detail(Detail.from(dto.detail()))
+                    .build();
+        }
+    }
+
+    @Builder
+    public record Detail(
+            String temp, // 온도
+            String sky,  // 하늘 (Code 값)
+            String pty   // 강수 (Code 값)
+    ) {
+        /**
+         * WeatherDTO.Detail을 응답용 Detail로 변환
+         */
+        public static Detail from(WeatherDTO.Detail dtoDetail) {
+            return Detail.builder()
+                    .temp(dtoDetail.temp())
+                    .sky(dtoDetail.sky().getCode()) // Enum -> Code String 변환
+                    .pty(dtoDetail.pty().getCode()) // Enum -> Code String 변환
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherApiClient.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherApiClient.java
@@ -28,11 +28,11 @@ public class WeatherApiClient {
     @Value("${data-kr.forecest-url}")
     private String FCST_URL;
 
-    private final String FCST_URI = "/getUltraSrtFcst";
-    private final int PAGE_NO = 1;
-    private final int NUM_OF_ROWS = 100;
-    private final String DATA_TYPE = "JSON";
-    private final String TIME_ZONE = "Asia/Seoul";
+    final String FCST_URI = "/getUltraSrtFcst";
+    final int PAGE_NO = 1;
+    final int NUM_OF_ROWS = 100;
+    final String DATA_TYPE = "JSON";
+    final String TIME_ZONE = "Asia/Seoul";
 
     /**
      * WebClient를 활용하여 리액티브 타입(Mono)으로 응답을 반환하도록 구현

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherMapper.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherMapper.java
@@ -15,9 +15,10 @@ import org.zerock.puppyrun.weather.DTO.WeatherDTO;
 @Slf4j
 public class WeatherMapper {
 
-    private final String TEMP = "T1H";
-    private final String SKY = "SKY";
-    private final String PTY = "PTY";
+    final String TEMP = "T1H";
+    final String SKY = "SKY";
+    final String PTY = "PTY";
+    final int FORECAST_LIMIT = 6; // 예보 데이터 제한 개수
 
     public List<WeatherDTO> toWeatherDTOList(WeatherApiResponse response) {
         // 응답 객체 자체의 Null 체크
@@ -38,7 +39,7 @@ public class WeatherMapper {
 
         return groupedByTime.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
-                .limit(2)
+                .limit(FORECAST_LIMIT)
                 .map(entry -> createWeatherDTO(entry.getValue()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherService.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherService.java
@@ -45,6 +45,7 @@ public class WeatherService {
 
         // 리스트에서 해당 시간대의 날씨 찾기
         return weatherDTOList.stream()
+                .limit(2)
                 .filter(dto -> dto.date().equals(targetDate) && dto.time().equals(targetTime))
                 .findFirst()
                 .orElseThrow(() -> {


### PR DESCRIPTION
# 📌 Pull Request: 날씨 API 구조 개선 및 단기 예보 기능 구현 (#10)

# 📝 작업 요약 (Summary)

이번 PR에서는 **날씨(Weather) API의 구조를  개선**했습니다.

1. **Weather (#10)**: 
- 날씨 조회 엔드포인트를 기능별로 분리하고, 응답 DTO 구조를 개선하였으며 데이터 매핑 로직을 최적화했습니다.

# 🛠️ 변경 사항 (Changes)

## 1. 날씨 (Weather) 도메인

- **WeatherController**
    - **단기 예보 추가** : 기존 최근 날씨 조회뿐만 아니라 최대 6시간 이후 예보를 받아올 수 있도록 기능 추가.
    - **엔드포인트 분리**: 기존 조회 방식에서 `/current` (현재 날씨)와 `/forecast` (단기 예보)로 분리.
    - **메서드명 변경**: `getNearestWeather` -> `getCurrentWeather`, `getAllWeather` -> `getWeatherForecast`.
- **WeatherService & Mapper**
    - **최적화**: 현재 날씨 조회 시 전체 리스트를 순회하지 않고 `limit(2)`를 사용하여 근접 시간대 탐색 성능 향상.
    - **매핑 범위 확대**: `FORECAST_LIMIT`을 6으로 설정하여 단기 예보 데이터를 6개 시간대까지 제공하도록 수정.
- **DTO**
    - `WeatherForecastResponse`: 예보 리스트를 담는 전용 응답 객체 구현.

## 2. 날씨 상태 코드 (Weather Conditions)

기상청 API에서 제공하는 코드를 내부 Enum으로 매핑하여 관리합니다.

### ☁️ 하늘 상태 (SkyType)

API의 `SKY` 값을 매핑합니다.

| 코드값 | Enum 상수 | 설명 |
| --- | --- | --- |
| `"1"` | `SUNNY` | 맑음 |
| `"3"` | `CLOUDY` | 구름많음 |
| `"4"` | `OVERCAST` | 흐림 |

### 🌧️ 강수 형태 (PrecipitationType)

API의 `PTY` 값을 매핑합니다.

| 코드값 | Enum 상수 | 설명 |
| --- | --- | --- |
| `"0"` | `NONE` | 없음 |
| `"1"` | `RAIN` | 비 |
| `"2"` | `RAIN_SNOW` | 비/눈 (진눈깨비) |
| `"3"` | `SNOW` | 눈 |
| `"5"` | `RAINDROP` | 빗방울 |
| `"6"` | `RAINDROP_SNOW_DRIFT` | 빗방울날림 |
| `"7"` | `SNOW_DRIFT` | 눈날림 |


## 3. 지역 코드 (Region)

사용자의 위경도 좌표를 기반으로 기상청 예보 구역(격자 좌표)을 매핑하는 `RegionType` Enum입니다.

- **주요 기능**: `findNearest(lat, lon)` 메서드를 통해 사용자 위치와 가장 가까운 행정구역을 자동으로 계산하여 반환합니다.
- **지원 지역**: 대한민국 주요 17개 행정구역

| Enum 상수 | 행정구역 명칭 | 격자 X (nx) | 격자 Y (ny) | 대표 위도 | 대표 경도 |
| --- | --- | --- | --- | --- | --- |
| `SEOUL` | 서울특별시 | 60 | 127 | 37.5636 | 126.9800 |
| `BUSAN` | 부산광역시 | 98 | 76 | 35.1770 | 129.0770 |
| `DAEGU` | 대구광역시 | 89 | 90 | 35.8685 | 128.6036 |
| `INCHEON` | 인천광역시 | 55 | 124 | 37.4532 | 126.7074 |
| `GWANGJU` | 광주광역시 | 58 | 74 | 35.1570 | 126.8534 |
| `DAEJEON` | 대전광역시 | 67 | 100 | 36.3471 | 127.3866 |
| `ULSAN` | 울산광역시 | 102 | 84 | 35.5354 | 129.3137 |
| `SEJONG` | 세종특별자치시 | 66 | 103 | 36.4800 | 127.2891 |
| `GYEONGGI` | 경기도 | 60 | 120 | 37.2718 | 127.0117 |
| `GANGWON` | 강원특별자치도 | 73 | 134 | 37.8827 | 127.7320 |
| `CHUNGBUK` | 충청북도 | 69 | 107 | 36.6325 | 127.4936 |
| `CHUNGNAM` | 충청남도 | 55 | 107 | 36.6588 | 126.6728 |
| `JEONBUK` | 전북특별자치도 | 63 | 89 | 35.8173 | 127.1111 |
| `JEONNAM` | 전라남도 | 51 | 67 | 34.8130 | 126.4650 |
| `GYEONGBUK` | 경상북도 | 87 | 106 | 36.5760 | 128.5058 |
| `GYEONGNAM` | 경상남도 | 91 | 77 | 35.2347 | 128.6942 |
| `JEJU` | 제주특별자치도 | 52 | 38 | 33.4857 | 126.5003 |

---
# 📸 테스트 시나리오 (Test Scenarios)

## 1. 현재 날씨 조회 (Current Weather)

- **Method**: `GET`
- **URL**: `/api/weather/current?lat={lat}&lon={lon}`
- **Header**:  `Authorization: Bearer {AccessToken}`
- **RequestParam:**
    - `lat {int}`: 위도
    - `lon {int}`: 경도

### ✅ 1-1 : 현재 위치 기반 날씨 조회 성공

**Response (200 OK)**

```json
{
    "region": "JEONBUK",
    "date": "20260218",
    "time": "1100",
    "detail": {
        "temp": "7",
        "sky": "1",
        "pty": "0"
    }
}
```

### ❌ 1-2 : api 호출중 서버 에러 발생

**Response (500 Internal Server Error)**

```json
{
    "code": "API_001",
    "description": "외부 API 요청 중 오류가 발생했습니다.",
    "message": "",
    "path": "/api/weather/current?lat=36&lon=127"
    "timestamp": "2026-01-23T20:29:50.636988"
}
```

## 2. 날씨 예보 조회 (Weather Forecast)

- **Method**: `GET`
- **URL**: `/api/weather/forecast?lat={lat}&lon={lon}`
- **Header**:  `Authorization: Bearer {AccessToken}`
- **RequestParam:**
    - `lat {int}`: 위도
    - `lon {int}`: 경도

### ✅ 2-1 : 단기 예보 리스트 조회 성공

**최대 6개의 예보 데이터가 리스트로 반환**

**Response (200 OK)**

```json
{
    "region": "JEONBUK",
    "forecasts": [
        {
            "date": "20260303",
            "time": "1400",
            "detail": {
                "temp": "14",
                "sky": "1",
                "pty": "0"
            }
        },
        {
            "date": "20260303",
            "time": "1500",
            "detail": {
                "temp": "14",
                "sky": "1",
                "pty": "0"
            }
        },
        {
            "date": "20260303",
            "time": "1600",
            "detail": {
                "temp": "14",
                "sky": "1",
                "pty": "0"
            }
        },
        {
            "date": "20260303",
            "time": "1700",
            "detail": {
                "temp": "13",
                "sky": "3",
                "pty": "0"
            }
        },
        {
            "date": "20260303",
            "time": "1800",
            "detail": {
                "temp": "11",
                "sky": "4",
                "pty": "0"
            }
        },
        {
            "date": "20260303",
            "time": "1900",
            "detail": {
                "temp": "9",
                "sky": "4",
                "pty": "0"
            }
        }
    ]
}
```

### ❌ 2-2 : api 호출중 서버 에러 발생

**Response (500 Internal Server Error)**

```json
{
    "code": "API_001",
    "description": "외부 API 요청 중 오류가 발생했습니다.",
    "message": "",
    "path": "/api/weather/forecast?lat=36&lon=127"
    "timestamp": "2026-01-23T20:29:50.636988"
}
```