### PR TITLE
feat/ refactor : 펫 체중 기록 및 통계 기능 구현(#17) 및 도메인/API 리팩토링 

### DIFF
--- a/src/main/java/org/zerock/puppyrun/diary/controller/DiaryController.java
+++ b/src/main/java/org/zerock/puppyrun/diary/controller/DiaryController.java
@@ -1,6 +1,7 @@
 package org.zerock.puppyrun.diary.controller;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,7 +14,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.diary.controller.request.RegisterDiaryRequest;
 import org.zerock.puppyrun.diary.controller.response.DiaryResponse;
@@ -31,11 +34,12 @@ public class DiaryController {
     @PostMapping
     public ResponseEntity<DiaryResponse> registerDiary(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @RequestBody @Valid RegisterDiaryRequest request
+            @RequestPart("request") @Valid RegisterDiaryRequest request,
+            @RequestPart("images") List<MultipartFile> images
     ) {
         UUID memberId = userPrincipal.id(); // 인증된 사용자 ID 가져오기
 
-        DiaryResponse response = diaryService.registerDiary(memberId, request);
+        DiaryResponse response = diaryService.registerDiary(memberId, request, images);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/org/zerock/puppyrun/diary/controller/DiaryController.java
+++ b/src/main/java/org/zerock/puppyrun/diary/controller/DiaryController.java
@@ -4,7 +4,6 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.diary.controller.request.RegisterDiaryRequest;
+import org.zerock.puppyrun.diary.controller.request.UpdateDiaryRequest;
 import org.zerock.puppyrun.diary.controller.response.DiaryResponse;
 import org.zerock.puppyrun.diary.service.DiaryService;
 
@@ -51,7 +51,7 @@ public class DiaryController {
     public ResponseEntity<DiaryResponse> updateDiary(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable UUID diaryId,
-            @RequestBody @Valid RegisterDiaryRequest request
+            @RequestBody @Valid UpdateDiaryRequest request
     ) {
         UUID memberId = userPrincipal.id(); // 인증된 사용자 ID 가져오기
 

--- a/src/main/java/org/zerock/puppyrun/diary/controller/request/RegisterDiaryRequest.java
+++ b/src/main/java/org/zerock/puppyrun/diary/controller/request/RegisterDiaryRequest.java
@@ -26,10 +26,7 @@ public record RegisterDiaryRequest(
 
         @Valid
         @NotNull(message = "날씨 정보는 필수입니다.")
-        Weather weather,
-
-        // 이미지는 빈 리스트가 올 수 있으므로 별도의 @NotEmpty 검증을 하지 않음
-        List<String> images
+        Weather weather
 ) {
     public record Weather(
             @NotBlank(message = "기온 정보는 필수입니다.")

--- a/src/main/java/org/zerock/puppyrun/diary/controller/request/UpdateDiaryRequest.java
+++ b/src/main/java/org/zerock/puppyrun/diary/controller/request/UpdateDiaryRequest.java
@@ -9,9 +9,6 @@ import java.util.List;
 import java.util.UUID;
 
 public record UpdateDiaryRequest(
-        @NotNull(message = "일기 작성 시간대 정보는 필수입니다.")
-        LocalDateTime writingTime,
-
         @NotBlank(message = "일기 제목은 필수입니다.")
         @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.")
         String title,
@@ -21,10 +18,8 @@ public record UpdateDiaryRequest(
 
         @Valid
         @NotNull(message = "날씨 정보는 필수입니다.")
-        RegisterDiaryRequest.Weather weather,
+        RegisterDiaryRequest.Weather weather
 
-        // 이미지는 빈 리스트가 올 수 있으므로 별도의 @NotEmpty 검증을 하지 않음
-        List<String> images
 ) {
     public record Weather(
             @NotBlank(message = "기온 정보는 필수입니다.")

--- a/src/main/java/org/zerock/puppyrun/diary/service/DiaryService.java
+++ b/src/main/java/org/zerock/puppyrun/diary/service/DiaryService.java
@@ -1,10 +1,12 @@
 package org.zerock.puppyrun.diary.service;
 
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.exception.InvalidValueException;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.common.exception.UserForbiddenException;
@@ -30,7 +32,7 @@ public class DiaryService {
 
     // 일기 작성
     @Transactional
-    public DiaryResponse registerDiary(UUID memberId, RegisterDiaryRequest request) {
+    public DiaryResponse registerDiary(UUID memberId, RegisterDiaryRequest request, List<MultipartFile> images) {
 
         if (diaryRepository.existsByTrackingId(request.trackingId())) {
             throw new InvalidValueException("이미 해당 산책 기록에 대한 일기가 존재합니다.");
@@ -38,6 +40,8 @@ public class DiaryService {
 
         Tracking tracking = trackingRepository.findById(request.trackingId())
                 .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 산책 기록입니다"));
+
+        List<String> imagesUrl = List.of(); // Todo: s3 추가 예정
 
         SkyType skyType = SkyType.fromCode(request.weather().sky());  // 날씨 코드 변환
         PrecipitationType precipitationType = PrecipitationType.fromCode(request.weather().pty()); // 날씨 코드 변환
@@ -52,7 +56,7 @@ public class DiaryService {
                 .writingTime(request.writingTime())
                 .member(memberRepository.findByIdOrThrow(memberId))
                 .tracking(tracking)
-                .images(request.images())
+                .images(imagesUrl)
                 .build();
 
         Diary savedDiary = diaryRepository.save(diary);
@@ -69,10 +73,12 @@ public class DiaryService {
         PrecipitationType precipitationType = PrecipitationType.fromCode(request.weather().pty()); // 날씨 코드 변환
         String temp = request.weather().temp();
 
+        List<String> imagesUrl = List.of(); // Todo: s3 추가 예정
+
         UpdateDiaryDTO updateDiaryDTO = UpdateDiaryDTO.builder()
                 .title(request.title())
                 .content(request.content())
-                .images(request.images())
+                .images(imagesUrl)
                 .writingTime(request.writingTime())
                 .pty(precipitationType)
                 .sky(skyType)

--- a/src/main/java/org/zerock/puppyrun/diary/service/DiaryService.java
+++ b/src/main/java/org/zerock/puppyrun/diary/service/DiaryService.java
@@ -12,6 +12,7 @@ import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.common.exception.UserForbiddenException;
 import org.zerock.puppyrun.diary.DTO.UpdateDiaryDTO;
 import org.zerock.puppyrun.diary.controller.request.RegisterDiaryRequest;
+import org.zerock.puppyrun.diary.controller.request.UpdateDiaryRequest;
 import org.zerock.puppyrun.diary.controller.response.DiaryResponse;
 import org.zerock.puppyrun.diary.entity.Diary;
 import org.zerock.puppyrun.diary.repository.DiaryRepository;
@@ -66,20 +67,16 @@ public class DiaryService {
 
     // 일기 수정
     @Transactional
-    public DiaryResponse updateDiary(UUID memberId, UUID diaryId, RegisterDiaryRequest request) {
+    public DiaryResponse updateDiary(UUID memberId, UUID diaryId, UpdateDiaryRequest request) {
         Diary diary = findDiaryWithOwnershipCheck(diaryId, memberId);
 
         SkyType skyType = SkyType.fromCode(request.weather().sky());  // 날씨 코드 변환
         PrecipitationType precipitationType = PrecipitationType.fromCode(request.weather().pty()); // 날씨 코드 변환
         String temp = request.weather().temp();
 
-        List<String> imagesUrl = List.of(); // Todo: s3 추가 예정
-
         UpdateDiaryDTO updateDiaryDTO = UpdateDiaryDTO.builder()
                 .title(request.title())
                 .content(request.content())
-                .images(imagesUrl)
-                .writingTime(request.writingTime())
                 .pty(precipitationType)
                 .sky(skyType)
                 .temp(temp)

--- a/src/main/java/org/zerock/puppyrun/pet/DTO/UpdatePetDTO.java
+++ b/src/main/java/org/zerock/puppyrun/pet/DTO/UpdatePetDTO.java
@@ -7,6 +7,8 @@ import org.zerock.puppyrun.pet.entity.Breed;
 public record UpdatePetDTO(
         String name,
         String color,
-        Double weight
+        Double weight,
+        boolean isNeutered,
+        String gender
 ) {
 }

--- a/src/main/java/org/zerock/puppyrun/pet/DTO/UpdatePetDTO.java
+++ b/src/main/java/org/zerock/puppyrun/pet/DTO/UpdatePetDTO.java
@@ -1,13 +1,14 @@
 package org.zerock.puppyrun.pet.DTO;
 
+import java.time.LocalDate;
 import lombok.Builder;
-import org.zerock.puppyrun.pet.entity.Breed;
 
 @Builder
 public record UpdatePetDTO(
         String name,
         String color,
         Double weight,
+        LocalDate birthYear,
         boolean isNeutered,
         String gender
 ) {

--- a/src/main/java/org/zerock/puppyrun/pet/controller/PetController.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/PetController.java
@@ -13,7 +13,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.pet.controller.request.RegisterPetRequest;
 import org.zerock.puppyrun.pet.controller.request.UpdatePetRequest;
@@ -72,9 +74,10 @@ public class PetController {
     public ResponseEntity<PetUpdateResponse> updatePet(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable UUID petId,
-            @RequestBody @Valid UpdatePetRequest request
+            @RequestPart("request") @Valid UpdatePetRequest request,
+            @RequestPart("image") MultipartFile image
     ) {
-        PetUpdateResponse response = petService.updatePet(userPrincipal, petId, request);
+        PetUpdateResponse response = petService.updatePet(userPrincipal, petId, request, image);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/zerock/puppyrun/pet/controller/PetController.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/PetController.java
@@ -13,15 +13,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.pet.controller.request.RegisterPetRequest;
 import org.zerock.puppyrun.pet.controller.request.UpdatePetRequest;
 import org.zerock.puppyrun.pet.controller.response.PetDetailResponse;
 import org.zerock.puppyrun.pet.controller.response.PetListResponse;
 import org.zerock.puppyrun.pet.controller.response.PetUpdateResponse;
+import org.zerock.puppyrun.pet.controller.response.PetWeightLogResponse;
 import org.zerock.puppyrun.pet.service.PetService;
 
 @RestController
@@ -74,10 +73,9 @@ public class PetController {
     public ResponseEntity<PetUpdateResponse> updatePet(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable UUID petId,
-            @RequestPart("request") @Valid UpdatePetRequest request,
-            @RequestPart("image") MultipartFile image
+            @RequestBody @Valid UpdatePetRequest request
     ) {
-        PetUpdateResponse response = petService.updatePet(userPrincipal, petId, request, image);
+        PetUpdateResponse response = petService.updatePet(userPrincipal, petId, request);
         return ResponseEntity.ok(response);
     }
 
@@ -92,4 +90,17 @@ public class PetController {
         petService.deletePet(userPrincipal, petId);
         return ResponseEntity.ok().build();
     }
+
+    /**
+     * 펫 몸무게 기록 조회
+     */
+    @GetMapping("/{petId}/weight-logs")
+    public ResponseEntity<PetWeightLogResponse> getPetWeightLogs(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId
+    ) {
+        PetWeightLogResponse response = petService.getPetWeightLog(userPrincipal, petId);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/org/zerock/puppyrun/pet/controller/request/RegisterPetRequest.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/request/RegisterPetRequest.java
@@ -2,6 +2,7 @@ package org.zerock.puppyrun.pet.controller.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
@@ -15,6 +16,13 @@ public record RegisterPetRequest(
 
         @NotBlank(message = "견종 코드는 필수입니다.")
         String breedCode,
+
+        @NotNull(message = "중성화 여부는 필수입니다.")
+        Boolean isNeutered,
+
+        @NotBlank(message = "성별은 필수입니다.")
+        @Pattern(regexp = "^[MF]$", message = "성별은 'M' 또는 'F'만 입력 가능합니다.")
+        String gender,
 
         // null일 경우 Breed Enum의 기본값을 사용하도록 로직 처리됨
         String color,

--- a/src/main/java/org/zerock/puppyrun/pet/controller/request/RegisterPetRequest.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/request/RegisterPetRequest.java
@@ -1,10 +1,11 @@
 package org.zerock.puppyrun.pet.controller.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public record RegisterPetRequest(
         @NotBlank(message = "강아지 이름은 필수입니다.")
@@ -12,7 +13,7 @@ public record RegisterPetRequest(
         String name,
 
         @NotNull(message = "출생일은 필수입니다.")
-        LocalDateTime birthYear,
+        LocalDate birthYear,
 
         @NotBlank(message = "견종 코드는 필수입니다.")
         String breedCode,
@@ -26,6 +27,8 @@ public record RegisterPetRequest(
 
         // null일 경우 Breed Enum의 기본값을 사용하도록 로직 처리됨
         String color,
+
+        @Min(value = 1, message = "몸무게는 1kg 이상이어야 합니다.")
         Double weight
 ) {
 }

--- a/src/main/java/org/zerock/puppyrun/pet/controller/request/UpdatePetRequest.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/request/UpdatePetRequest.java
@@ -2,6 +2,7 @@ package org.zerock.puppyrun.pet.controller.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
@@ -16,10 +17,14 @@ public record UpdatePetRequest(
         @NotNull(message = "몸무게는 필수입니다.")
         Double weight,
 
-        @NotBlank(message = "색상 코드는 필수입니다.")
-        String color,
+        @NotNull(message = "중성화 여부는 필수입니다.")
+        Boolean isNeutered,
 
-        @NotBlank(message = "프로필 이미지 URL은 필수입니다.")
-        String profileImageUrl
+        @NotBlank(message = "성별은 필수입니다.")
+        @Pattern(regexp = "^[MF]$", message = "성별은 'M' 또는 'F'만 입력 가능합니다.")
+        String gender,
+
+        @NotBlank(message = "색상 코드는 필수입니다.")
+        String color
 ) {
 }

--- a/src/main/java/org/zerock/puppyrun/pet/controller/request/UpdatePetRequest.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/request/UpdatePetRequest.java
@@ -1,10 +1,11 @@
 package org.zerock.puppyrun.pet.controller.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public record UpdatePetRequest(
         @NotBlank(message = "강아지 이름은 필수입니다.")
@@ -12,9 +13,10 @@ public record UpdatePetRequest(
         String name,
 
         @NotNull(message = "출생일은 필수입니다.")
-        LocalDateTime birthYear,
+        LocalDate birthYear,
 
         @NotNull(message = "몸무게는 필수입니다.")
+        @Min(value = 1, message = "몸무게는 1kg 이상이어야 합니다.")
         Double weight,
 
         @NotNull(message = "중성화 여부는 필수입니다.")

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetDetailResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetDetailResponse.java
@@ -19,6 +19,8 @@ public record PetDetailResponse(
         String color,
         String breedCode,
         String profileImageUrl,
+        Boolean isNeutered,
+        String gender,
         BadgeInfo badgeInfo
 ) {
 
@@ -34,6 +36,8 @@ public record PetDetailResponse(
                 .color(pet.getColor())
                 .profileImageUrl(pet.getProfileImageUrl())
                 .breedCode(pet.getBreed().getCode())
+                .isNeutered(pet.getIsNeutered())
+                .gender(pet.getGender())
                 .badgeInfo(BadgeInfo.from(pet.getBadge(), walkedDistance))
                 .build();
     }

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetDetailResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetDetailResponse.java
@@ -1,9 +1,8 @@
 package org.zerock.puppyrun.pet.controller.response;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.Builder;
-import org.zerock.puppyrun.pet.entity.Breed;
 import org.zerock.puppyrun.pet.entity.Pet;
 import org.zerock.puppyrun.pet.entity.PetBadge;
 
@@ -14,7 +13,7 @@ import org.zerock.puppyrun.pet.entity.PetBadge;
 public record PetDetailResponse(
         UUID PetId,
         String name,
-        LocalDateTime birthYear,
+        LocalDate birthYear,
         Double weight,
         String color,
         String breedCode,

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetListResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetListResponse.java
@@ -1,11 +1,10 @@
 package org.zerock.puppyrun.pet.controller.response;
 
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
-import org.zerock.puppyrun.pet.entity.Breed;
 import org.zerock.puppyrun.pet.entity.Pet;
 
 public record PetListResponse(
@@ -26,7 +25,7 @@ public record PetListResponse(
     public record PetSummary(
             UUID PetId,
             String name,
-            LocalDateTime birthYear,
+            LocalDate birthYear,
             Double weight,
             String color,
             String profileImageUrl,

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetListResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetListResponse.java
@@ -30,7 +30,7 @@ public record PetListResponse(
             Double weight,
             String color,
             String profileImageUrl,
-            String breedInfo,
+            String breedCode,
             String badgeCode
     ) {
         public static PetSummary from(Pet pet) {
@@ -41,7 +41,7 @@ public record PetListResponse(
                     .weight(pet.getWeight())
                     .color(pet.getColor())
                     .profileImageUrl(pet.getProfileImageUrl())
-                    .breedInfo(pet.getBreed().getCode())
+                    .breedCode(pet.getBreed().getCode())
                     .badgeCode(pet.getBadge().getCode())
                     .build();
         }

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetUpdateResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetUpdateResponse.java
@@ -1,6 +1,6 @@
 package org.zerock.puppyrun.pet.controller.response;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.Builder;
 import org.zerock.puppyrun.pet.entity.Pet;
 
@@ -8,7 +8,7 @@ import org.zerock.puppyrun.pet.entity.Pet;
 public record PetUpdateResponse(
         String name,
 
-        LocalDateTime birthYear,
+        LocalDate birthYear,
 
         Double weight,
 

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetUpdateResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetUpdateResponse.java
@@ -14,6 +14,10 @@ public record PetUpdateResponse(
 
         String color,
 
+        Boolean isNeutered,
+
+        String gender,
+
         String profileImageUrl
 ) {
     public static PetUpdateResponse of(Pet pet) {
@@ -22,6 +26,8 @@ public record PetUpdateResponse(
                 .color(pet.getColor())
                 .name(pet.getName())
                 .weight(pet.getWeight())
+                .isNeutered(pet.getIsNeutered())
+                .gender(pet.getGender())
                 .profileImageUrl(pet.getProfileImageUrl())
                 .build();
     }

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetWeightLogResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetWeightLogResponse.java
@@ -1,0 +1,41 @@
+package org.zerock.puppyrun.pet.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.entity.PetWeightLog;
+
+@Builder
+public record PetWeightLogResponse(
+        UUID petId,
+        String color,
+        Double currentWeight,
+        List<WeightLog> weightLogList
+) {
+    public record WeightLog(
+            Double weight,
+            LocalDateTime recordedAt
+    ) {
+        public static WeightLog of(PetWeightLog petWeightLog) {
+            return new WeightLog(
+                    petWeightLog.getWeight(),
+                    petWeightLog.getCreatedAt()
+            );
+        }
+
+    }
+
+    public static PetWeightLogResponse of(Pet pet, List<PetWeightLog> weightLogList) {
+        List<WeightLog> weightLogs = weightLogList.stream()
+                .map(WeightLog::of)
+                .toList();
+        return PetWeightLogResponse.builder()
+                .petId(pet.getId())
+                .color(pet.getColor())
+                .currentWeight(pet.getWeight())
+                .weightLogList(weightLogs)
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
+++ b/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
@@ -1,7 +1,7 @@
 package org.zerock.puppyrun.pet.entity;
 
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,7 +29,7 @@ public class Pet extends BaseTimeEntity {
     private String name;
 
     @Column(name = "birth_year", nullable = false)
-    private LocalDateTime birthYear; // 출생년도
+    private LocalDate birthYear; // 출생년도
 
     @Enumerated(EnumType.STRING)
     @Column(name = "badge")
@@ -56,7 +56,7 @@ public class Pet extends BaseTimeEntity {
     private String gender;
 
     @Builder
-    public Pet(Member member, String name, LocalDateTime birthYear, Breed breed, String color, Double weight,
+    public Pet(Member member, String name, LocalDate birthYear, Breed breed, String color, Double weight,
                boolean isNeutered, String gender) {
         this.member = member;
         this.name = name;
@@ -78,6 +78,7 @@ public class Pet extends BaseTimeEntity {
         this.name = dto.name();
         this.color = dto.color();
         this.weight = dto.weight();
+        this.birthYear = dto.birthYear();
         this.isNeutered = dto.isNeutered();
         this.gender = dto.gender();
     }

--- a/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
+++ b/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
@@ -48,14 +48,24 @@ public class Pet extends BaseTimeEntity {
     @Column(name = "weight")
     private Double weight;
 
+    @Column(name = "is_neutered", nullable = false)
+    private Boolean isNeutered;
+
+    // length = 1로 설정하여 (M/F)만 들어가도록 제한
+    @Column(name = "gender", nullable = false, length = 1)
+    private String gender;
+
     @Builder
-    public Pet(Member member, String name, LocalDateTime birthYear, Breed breed, String color, Double weight) {
+    public Pet(Member member, String name, LocalDateTime birthYear, Breed breed, String color, Double weight,
+               boolean isNeutered, String gender) {
         this.member = member;
         this.name = name;
         this.breed = breed;
         this.birthYear = birthYear;
         this.color = (color == null || color.isBlank()) ? breed.getBasicColorHex() : color;
         this.weight = (weight == null || weight <= 0) ? breed.getAvgWeightMin() : weight;
+        this.isNeutered = isNeutered;
+        this.gender = gender;
         this.profileImageUrl = null;
         this.badge = PetBadge.BEGINNER;
     }
@@ -68,6 +78,8 @@ public class Pet extends BaseTimeEntity {
         this.name = dto.name();
         this.color = dto.color();
         this.weight = dto.weight();
+        this.isNeutered = dto.isNeutered();
+        this.gender = dto.gender();
     }
 
 

--- a/src/main/java/org/zerock/puppyrun/pet/entity/PetWeightLog.java
+++ b/src/main/java/org/zerock/puppyrun/pet/entity/PetWeightLog.java
@@ -1,0 +1,50 @@
+package org.zerock.puppyrun.pet.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.zerock.puppyrun.common.entity.BaseTimeEntity;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "pet_weight_log")
+public class PetWeightLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Pet pet;
+
+    @Column(nullable = false)
+    private Double weight;
+
+
+    @Builder
+    public PetWeightLog(Pet pet, Double weight) {
+        this.pet = pet;
+        this.weight = weight;
+    }
+
+    public void updateWeight(Double newWeight) {
+        this.weight = newWeight;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/pet/repository/PetWeightLogRepository.java
+++ b/src/main/java/org/zerock/puppyrun/pet/repository/PetWeightLogRepository.java
@@ -1,0 +1,19 @@
+package org.zerock.puppyrun.pet.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.pet.entity.PetWeightLog;
+
+@Repository
+public interface PetWeightLogRepository extends JpaRepository<PetWeightLog, UUID> {
+
+    // 전체 조회
+    List<PetWeightLog> findAllByPetIdOrderByCreatedAtDesc(UUID petId);
+
+    // 최신 데이터 1건만 조회
+    Optional<PetWeightLog> findFirstByPetIdOrderByCreatedAtDesc(UUID petId);
+
+}

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.common.exception.UserForbiddenException;
@@ -69,6 +70,8 @@ public class PetService {
                 .breed(breed)
                 .color(request.color())
                 .weight(request.weight())
+                .isNeutered(request.isNeutered())
+                .gender(request.gender())
                 .build();
         petRepository.save(newPet);
         return PetDetailResponse.of(newPet, 0);
@@ -83,12 +86,15 @@ public class PetService {
      * @return 수정된 펫의 정보 응답 DTO
      */
     @Transactional
-    public PetUpdateResponse updatePet(UserPrincipal userPrincipal, UUID petId, UpdatePetRequest request) {
+    public PetUpdateResponse updatePet(UserPrincipal userPrincipal, UUID petId, UpdatePetRequest request,
+                                       MultipartFile image) {
         Pet pet = findPetWithOwnershipCheck(userPrincipal.id(), petId);
         UpdatePetDTO dto = UpdatePetDTO.builder()
                 .color(request.color())
                 .name(request.name())
                 .weight(request.weight())
+                .isNeutered(request.isNeutered())
+                .gender(request.gender())
                 .build();
         pet.updatePet(dto);
         petRepository.save(pet);

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetService.java
@@ -21,6 +21,8 @@ import org.zerock.puppyrun.pet.controller.response.PetUpdateResponse;
 import org.zerock.puppyrun.pet.entity.Breed;
 import org.zerock.puppyrun.pet.entity.Pet;
 import org.zerock.puppyrun.pet.repository.PetRepository;
+import org.zerock.puppyrun.statistics.service.PetStatistics;
+import org.zerock.puppyrun.statistics.service.TrackingStatistics;
 
 @Service
 @Slf4j
@@ -29,7 +31,10 @@ import org.zerock.puppyrun.pet.repository.PetRepository;
 public class PetService {
     private final PetRepository petRepository;
     private final MemberRepository memberRepository;
+
     private final PetStatistics petStatistics;
+    private final TrackingStatistics TrackingStatistics;
+
 
     /**
      * 펫 ID로 펫을 조회하고, 요청한 사용자가 소유자인지 검증합니다.
@@ -126,7 +131,7 @@ public class PetService {
      */
     public PetDetailResponse getPet(UserPrincipal userPrincipal, UUID petId) {
         Pet pet = findPetWithOwnershipCheck(userPrincipal.id(), petId);
-        int walkedDistance = petStatistics.getTotalWalkedDistance(petId); // 누적 산책거리 조회
+        int walkedDistance = TrackingStatistics.getTotalWalkedDistance(petId); // 누적 산책거리 조회
         return PetDetailResponse.of(pet, walkedDistance);
     }
 

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetService.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.common.exception.UserForbiddenException;
@@ -18,8 +17,10 @@ import org.zerock.puppyrun.pet.controller.request.UpdatePetRequest;
 import org.zerock.puppyrun.pet.controller.response.PetDetailResponse;
 import org.zerock.puppyrun.pet.controller.response.PetListResponse;
 import org.zerock.puppyrun.pet.controller.response.PetUpdateResponse;
+import org.zerock.puppyrun.pet.controller.response.PetWeightLogResponse;
 import org.zerock.puppyrun.pet.entity.Breed;
 import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.entity.PetWeightLog;
 import org.zerock.puppyrun.pet.repository.PetRepository;
 import org.zerock.puppyrun.statistics.service.PetStatistics;
 import org.zerock.puppyrun.statistics.service.TrackingStatistics;
@@ -79,6 +80,8 @@ public class PetService {
                 .gender(request.gender())
                 .build();
         petRepository.save(newPet);
+        petStatistics.savePetWeightLog(newPet, request.weight());
+
         return PetDetailResponse.of(newPet, 0);
     }
 
@@ -91,9 +94,9 @@ public class PetService {
      * @return 수정된 펫의 정보 응답 DTO
      */
     @Transactional
-    public PetUpdateResponse updatePet(UserPrincipal userPrincipal, UUID petId, UpdatePetRequest request,
-                                       MultipartFile image) {
+    public PetUpdateResponse updatePet(UserPrincipal userPrincipal, UUID petId, UpdatePetRequest request) {
         Pet pet = findPetWithOwnershipCheck(userPrincipal.id(), petId);
+
         UpdatePetDTO dto = UpdatePetDTO.builder()
                 .color(request.color())
                 .name(request.name())
@@ -105,7 +108,8 @@ public class PetService {
         pet.updatePet(dto);
         petRepository.save(pet);
 
-        petStatistics.savePetWeightLog(petId, request.weight());
+        // 현재 몸무게와 비교 후 저장
+        petStatistics.savePetWeightLog(pet, request.weight());
 
         return PetUpdateResponse.of(pet);
     }
@@ -144,5 +148,14 @@ public class PetService {
     public PetListResponse getPetList(UserPrincipal userPrincipal) {
         List<Pet> petList = petRepository.findAllByMemberId(userPrincipal.id());
         return PetListResponse.of(petList);
+    }
+
+    /**
+     * 사용자가 소유한 펫의 몸무게 로그를 조회합니다.
+     */
+    public PetWeightLogResponse getPetWeightLog(UserPrincipal userPrincipal, UUID petId) {
+        Pet pet = findPetWithOwnershipCheck(userPrincipal.id(), petId);
+        List<PetWeightLog> petWeightLog = petStatistics.getPetWeightLog(pet.getId());
+        return PetWeightLogResponse.of(pet, petWeightLog);
     }
 }

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetService.java
@@ -94,6 +94,7 @@ public class PetService {
                 .name(request.name())
                 .weight(request.weight())
                 .isNeutered(request.isNeutered())
+                .birthYear(request.birthYear())
                 .gender(request.gender())
                 .build();
         pet.updatePet(dto);

--- a/src/main/java/org/zerock/puppyrun/statistics/service/PetStatistics.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/service/PetStatistics.java
@@ -1,0 +1,74 @@
+package org.zerock.puppyrun.statistics.service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.entity.PetWeightLog;
+import org.zerock.puppyrun.pet.repository.PetWeightLogRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class PetStatistics {
+    private final PetWeightLogRepository petWeightLogRepository;
+
+    /**
+     * 특정 펫의 몸무게를 저장 합니다
+     */
+    @Transactional
+    public void savePetWeightLog(Pet pet, double newWeight) {
+        // 최근 로그가 오늘 작성된 것이라면 새로 만들지 않고 값만 수정
+        Optional<PetWeightLog> latestLogOpt = petWeightLogRepository.findFirstByPetIdOrderByCreatedAtDesc(pet.getId());
+
+        if (latestLogOpt.isPresent()) {
+            PetWeightLog latestLog = latestLogOpt.get();
+            // 가장 최근 몸무게와 완벽히 동일하면 아무 작업도 하지 않음
+            if (latestLog.getWeight() == newWeight) {
+                log.info("이전 몸무게와 동일하여 로그 저장을 스킵합니다. PetID: {}", pet.getId());
+                return;
+            }
+
+            LocalDate latestLogDate = latestLog.getCreatedAt().toLocalDate();
+            if (latestLogDate.equals(LocalDate.now())) {
+                latestLog.updateWeight(newWeight);
+                log.info("오늘 기록된 로그가 있어 몸무게를 업데이트합니다. PetID: {}", pet.getId());
+                return;
+            }
+        }
+
+        // 위 조건에 해당하지 않으면 기존 몸무게로 새로운 로그 생성
+        createNewWeightLog(pet, newWeight);
+    }
+
+    /**
+     * 펫의 몸무게를 최신순으로 조회합니다.
+     *
+     * @param petId 조회할 펫의 ID
+     */
+    public List<PetWeightLog> getPetWeightLog(UUID petId) {
+        return petWeightLogRepository.findAllByPetIdOrderByCreatedAtDesc(petId);
+    }
+
+    /**
+     * 새로운 몸무게 로그를 생성하여 저장합니다.
+     *
+     * @param pet       로그를 남길 펫
+     * @param newWeight 새로운 몸무게
+     */
+    private void createNewWeightLog(Pet pet, double newWeight) {
+        PetWeightLog petWeightLog = PetWeightLog.builder()
+                .pet(pet)
+                .weight(newWeight)
+                .build();
+        petWeightLogRepository.save(petWeightLog);
+        log.info("새로운 몸무게 로그를 생성합니다. PetID: {}", pet.getId());
+    }
+
+}

--- a/src/main/java/org/zerock/puppyrun/statistics/service/TrackingStatistics.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/service/TrackingStatistics.java
@@ -1,4 +1,4 @@
-package org.zerock.puppyrun.pet.service;
+package org.zerock.puppyrun.statistics.service;
 
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -8,8 +8,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class PetStatistics {
-
+public class TrackingStatistics {
     /**
      * 특정 펫의 누적 산책 거리(미터)를 조회합니다.
      */
@@ -17,12 +16,4 @@ public class PetStatistics {
         // Todo: 추후 통계 개발 예정
         return 0;
     }
-
-    /**
-     * 특정 펫의 몸무게를 저장 합니다
-     */
-    public void savePetWeightLog(UUID petId, double weight) {
-        // Todo: 무게 조정 시 무게 log 등록 로직 추가
-    }
-
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/DTO/UpdateTrackingDTO.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/DTO/UpdateTrackingDTO.java
@@ -8,7 +8,6 @@ import org.zerock.puppyrun.tracking.entity.Visibility;
 public record UpdateTrackingDTO(
         LocalDateTime startedAt,
         LocalDateTime endedAt,
-        Integer distance,
         Visibility visibility
 ) {
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/TrackingController.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/TrackingController.java
@@ -1,6 +1,7 @@
 package org.zerock.puppyrun.tracking.controller;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.tracking.controller.request.RegisterTrackingRequest;
 import org.zerock.puppyrun.tracking.controller.response.MainTrackingResponse;
@@ -30,10 +33,12 @@ public class TrackingController {
 
     // 산책 저장
     @PostMapping("")
-    public ResponseEntity<String> saveTracking(@Valid @RequestBody RegisterTrackingRequest request,
-                                               @AuthenticationPrincipal UserPrincipal userPrincipal) {
+    public ResponseEntity<String> saveTracking(
+            @Valid @RequestPart("request") RegisterTrackingRequest request,
+            @RequestPart("images") List<MultipartFile> images,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
-        trackingService.saveTracking(userPrincipal.id(), request);
+        trackingService.saveTracking(userPrincipal.id(), request, images);
 
         return ResponseEntity.ok("산책 저장 완료");
     }

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/request/RegisterTrackingRequest.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/request/RegisterTrackingRequest.java
@@ -1,6 +1,7 @@
 package org.zerock.puppyrun.tracking.controller.request;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -23,7 +24,10 @@ public record RegisterTrackingRequest(
         Integer distance,        // 이동 거리
 
         @NotEmpty(message = "이동 경로가 비어있습니다.")
-        List<TrackingPoint> path // 이동 경로 리스트
+        List<TrackingPoint> path, // 이동 경로 리스트
+
+        @NotBlank(message = "평균 속도는 필수입니다.")
+        String averagePace         // 평균 속도
 ) {
     @Builder
     public record TrackingPoint(

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/request/UpdateTrackingRequest.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/request/UpdateTrackingRequest.java
@@ -6,7 +6,6 @@ import org.zerock.puppyrun.tracking.entity.Visibility;
 public record UpdateTrackingRequest(
         LocalDateTime startedAt,
         LocalDateTime endedAt,
-        Integer distance,
         Visibility visibility
 ) {
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/response/TrackingDetailResponse.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/response/TrackingDetailResponse.java
@@ -15,6 +15,8 @@ public record TrackingDetailResponse(
         Integer duration,            // 산책 진행 시간
         String visibility,           // 공개 여부
         Integer distance,            // 이동 거리
+        List<String> images,          // 이미지 리스트
+        String averagePace,              // 평균 속도
         List<TrackingPoint> path     // 이동 경로 리스트
 ) {
 

--- a/src/main/java/org/zerock/puppyrun/tracking/entity/Tracking.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/entity/Tracking.java
@@ -1,7 +1,9 @@
 package org.zerock.puppyrun.tracking.entity;
 
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -58,9 +60,18 @@ public class Tracking extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer distance;        // 산책 거리
 
+    @Column(nullable = false)
+    private String averagePace;      // 평균 속도
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Visibility visibility;
+
+    // 이미지 리스트 매핑
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "tracking_images", joinColumns = @JoinColumn(name = "tracking_id"))
+    @Column(name = "image_url")
+    private List<String> images;
 
     @Convert(converter = TrackingPathConverter.class)
     @Column(name = "path", columnDefinition = "LONGTEXT")
@@ -71,15 +82,18 @@ public class Tracking extends BaseTimeEntity {
 
     @Builder
     public Tracking(Member member, LocalDateTime startedAt, LocalDateTime endedAt, Integer distance,
-                    Double startedLat, Double startedLng, Visibility visibility, List<TrackingPath> path) {
+                    Double startedLat, Double startedLng, Visibility visibility, List<TrackingPath> path,
+                    String averagePace, List<String> images) {
         this.member = member;
         this.startedAt = startedAt;
         this.endedAt = endedAt;
         this.startedLat = startedLat;
         this.startedLng = startedLng;
+        this.averagePace = averagePace;
         this.duration = (int) Duration.between(startedAt, endedAt).getSeconds();
         this.distance = distance;
         this.visibility = visibility;
+        this.images = images != null ? images : List.of(); // TODO: 추후 S3 만들어지면 저장할 것
         this.path = path;
     }
 

--- a/src/main/java/org/zerock/puppyrun/tracking/entity/Tracking.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/entity/Tracking.java
@@ -100,7 +100,6 @@ public class Tracking extends BaseTimeEntity {
     public void update(UpdateTrackingDTO updateTrackingDTO) {
         this.startedAt = updateTrackingDTO.startedAt();
         this.endedAt = updateTrackingDTO.endedAt();
-        this.distance = updateTrackingDTO.distance();
         this.visibility = updateTrackingDTO.visibility();
 
         // 시간 변경에 따른 duration 재계산

--- a/src/main/java/org/zerock/puppyrun/tracking/service/TrackingService.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/service/TrackingService.java
@@ -84,7 +84,6 @@ public class TrackingService {
         Tracking tracking = findTrackingWithOwnershipCheck(memberId, trackingId);
 
         UpdateTrackingDTO updateTrackingDTO = UpdateTrackingDTO.builder()
-                .distance(request.distance())
                 .endedAt(request.endedAt())
                 .startedAt(request.startedAt())
                 .visibility(request.visibility())

--- a/src/main/java/org/zerock/puppyrun/tracking/service/TrackingService.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/service/TrackingService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.common.exception.UserForbiddenException;
 import org.zerock.puppyrun.diary.entity.Diary;
@@ -50,7 +51,7 @@ public class TrackingService {
      * 산책 저장
      */
     @Transactional
-    public void saveTracking(UUID memberId, RegisterTrackingRequest request) {
+    public void saveTracking(UUID memberId, RegisterTrackingRequest request, List<MultipartFile> images) {
         Member member = memberRepository.findByIdOrThrow(memberId);
 
         // 경로 데이터 변환
@@ -68,6 +69,7 @@ public class TrackingService {
                 .startedLng(startPoint.getLng())
                 .visibility(Visibility.from(request.visibility()))
                 .distance(request.distance())
+//                .images(images.stream().map(MultipartFile::getOriginalFilename).toList()) todo: s3 저장 후 url 생성
                 .path(path)
                 .build();
 


### PR DESCRIPTION
# 📌 Pull Request: 펫 체중 기록 및 통계 기능 구현(#17) 및 도메인/API 리팩토링 

# 📝 작업 요약 (Summary)

<!--
이 PR에서 수행한 작업의 핵심 내용을 간략히 요약해주세요.
무엇을, 왜 변경했는지 설명하면 좋습니다.
-->

- 펫 몸무게 변화 추이를 확인할 수 있는 기록(PetWeightLog) 조회 및 체중 통계 기능 구현 (#17)
- `PetStatistics`와 `TrackingStatistics`로 통계 책임을 분리하여 구조 개선
- 펫 및 산책 기록의 이미지 업로드 방식을 문자열(String) 기반에서 파일(MultipartFile) 기반으로 변경
- 데이터 무결성 보호를 위해 산책 거리(distance) 수정 기능 및 일기 사진 변경 로직 제거
- 펫 정보(Pet)에 성별, 중성화 여부 필드를 추가하고, 생년월일 타입을 `LocalDate`로 변경

# 🛠️ 변경 사항 (Changes)

<!--
주요 변경 사항을 카테고리별로 나누어 작성해주세요.
코드의 구조적 변경이나 로직의 핵심 변화를 적어주세요.
-->

## 1. 펫 체중 기록 및 통계 (Pet Weight & Statistics)

- **펫 몸무게 기록(PetWeightLog) 구현 및 연동**
    - `PetWeightLog` 엔티티 및 Repository를 구현하여 펫 정보와 시점별 체중 데이터 매핑
    - 당일 체중 다중 수정 시 새 로그를 생성하지 않고 최신 기록을 덮어쓰도록 중복 방지 로직 적용
    - 펫 등록 및 수정 시 통계 서비스(`PetStatistics`)와 연동하여 몸무게 로그 기록
    - 펫 체중 기록 조회 API(`GET /api/pets/{petId}/weight-logs`) 및 응답 DTO(`PetWeightLogResponse`) 추가
- **통계 역할 분리**
    - 기존 `PetStatistics`에 혼재되어 있던 산책 관련 로직(누적 산책 거리 조회 등)을 `TrackingStatistics`로 분리

## 2. API 스펙 및 업로드 방식 개선 (API & Upload Refactoring)

- **이미지 업로드 구조 변경**
    - 펫 및 산책 기록 이미지 업로드 시 기존 URL(String)을 받던 방식에서 파일 자체(MultipartFile)를 직접 받도록 개선
    - 컨트롤러에서 `@RequestPart`를 활용하여 JSON 데이터와 이미지 파일을 분리해서 받도록 요청 스펙 수정

## 3. 데이터 무결성 확보 및 엔티티 수정 (Data Integrity & Entity Refactoring)

- **수정 기능 제한을 통한 무결성 보호**
    - 산책 기록 수정 시 뱃지 획득 시스템의 잠재적 위험을 방지하기 위해 산책 거리(`distance`) 수정 기능 제거 (시간, 공개 여부만 수정 허용)
    - 일기 수정 API(`updateDiary`)에서 불필요한 사진 변경 로직 삭제
- **펫 엔티티(Pet) 필드 개선**
    - 생년월일(`birthYear`) 필드를 `LocalDateTime`에서 `LocalDate`로 변경하여 시간 정보 제거
    - 중성화 여부(`isNeutered`) 및 성별(`gender`) 필드 추가 (성별은 정규식 `@Pattern`을 통해 'M' 또는 'F'만 허용)

# 📸 테스트 시나리오 (Test Scenarios)

<!--
변경 사항을 검증하기 위해 수행한 테스트 시나리오를 작성해주세요.
Postman이나 Swagger 테스트 결과를 복사해 넣으면 리뷰에 도움이 됩니다.
-->

## 1. 펫 몸무게 로그 조회

- **Method**: `GET`
- **URL**: `/api/pets/{PetId}/weight-logs`
- **Content-Type**: `application/json`
- **Header**: `Authorization: Bearer {Access_Token}`

### ✅ 1-1 :  조회 성공

<!-- 정상적으로 통신이 완료 되었을 경우의 요청과 응답을 작성해주세요. -->

**Request Body**

```json
없음
```

**Response (200 OK)**

```json
{
    "pet_id": "30f5151a-eb6e-4f15-9ed1-30fd15ed8e09",
    "color": "#FFFFF0",
    "current_weight": 4.6,
    "weight_log_list": [
        {
            "weight": 4.6,
            "recorded_at": "2026-03-18T15:57:34.956035"
        },
        {
            "weight": 4.5,
            "recorded_at": "2026-03-17T15:56:19.535"
        }
    ]
}
```