### PR TITLE
feat: FCM 푸시 알림 인프라 및 데일리 산책 리마인더 스케줄러 구현 (#26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 /.env
 
 /logs/
+/src/main/resources/firebase-service-account.json

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Firebase 알림 의존성
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/zerock/puppyrun/common/config/AsyncConfig.java
+++ b/src/main/java/org/zerock/puppyrun/common/config/AsyncConfig.java
@@ -1,0 +1,38 @@
+package org.zerock.puppyrun.common.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+    /**
+     * 알림 설정을 위한 스레드 풀 생성
+     */
+    @Bean(name = "notificationTaskExecutor")
+    public Executor notificationTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        // 기본 스레드 수: 코어 수와 동일하게 설정
+        executor.setCorePoolSize(Runtime.getRuntime().availableProcessors());
+
+        // 최대 스레드 수: CorePool이 꽉 차고 Queue도 꽉 찼을 때, 임시로 스레드를 더 생성
+        executor.setMaxPoolSize(Runtime.getRuntime().availableProcessors() * 2);
+
+        // 대기열(Queue) 크기: CorePool의 스레드가 모두 바쁠 때, 요청을 이만큼 쌓아둘 수 있음
+        executor.setQueueCapacity(50);
+
+        // 스레드가 다 찰 경우 메인 스레드에서 직접 처리
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+        // 로그에 스레드 이름이 찍혀 디버깅에 용이
+        executor.setThreadNamePrefix("FCM-Noti-");
+
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/config/FirebaseConfig.java
+++ b/src/main/java/org/zerock/puppyrun/common/config/FirebaseConfig.java
@@ -1,0 +1,40 @@
+package org.zerock.puppyrun.common.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.zerock.puppyrun.common.exception.BusinessException;
+import org.zerock.puppyrun.common.exception.ErrorCode;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.account-path}")
+    private String FIREBASE_ACCOUNT_PATH;
+
+    @PostConstruct
+    public void init() {
+        try {
+            log.info("Firebase 초기화 시작");
+            InputStream serviceAccount = new ClassPathResource(FIREBASE_ACCOUNT_PATH).getInputStream();
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+            }
+            log.info("Firebase 초기화 완료");
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "Firebase 초기화 실패", e);
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/config/FirebaseConfig.java
+++ b/src/main/java/org/zerock/puppyrun/common/config/FirebaseConfig.java
@@ -8,12 +8,14 @@ import java.io.InputStream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 import org.zerock.puppyrun.common.exception.BusinessException;
 import org.zerock.puppyrun.common.exception.ErrorCode;
 
 @Slf4j
 @Configuration
+@Profile("!test")
 public class FirebaseConfig {
 
     @Value("${firebase.account-path}")

--- a/src/main/java/org/zerock/puppyrun/common/init/DataInitializer.java
+++ b/src/main/java/org/zerock/puppyrun/common/init/DataInitializer.java
@@ -10,6 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.zerock.puppyrun.common.auth.jwt.JwtTokenProvider;
 import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.notification.entity.NotificationSettings;
+import org.zerock.puppyrun.notification.repository.NotificationRepository;
 
 @Component
 @RequiredArgsConstructor
@@ -20,6 +22,7 @@ public class DataInitializer implements CommandLineRunner {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final NotificationRepository notificationRepository;
 
     private static final String ADMIN_EMAIL = "admin@puppyrun.com";
     private static final String ADMIN_PASSWORD = "admin1234";
@@ -36,6 +39,10 @@ public class DataInitializer implements CommandLineRunner {
 
         // 확보된 관리자 계정으로 토큰을 발급하고 로그를 출력합니다.
         String accessToken = jwtTokenProvider.generateAccessToken(admin.toDto());
+
+        // 관리자 계정 알림 설정
+        createNotificationSettings(admin);
+
         log.info("관리자 계정({})으로 토큰을 발급했습니다.", admin.getEmail());
         log.info("Admin Access Token: {}", accessToken);
 
@@ -51,5 +58,20 @@ public class DataInitializer implements CommandLineRunner {
                 .build();
         admin.setAdmin();
         return memberRepository.save(admin);
+    }
+
+    private void createNotificationSettings(Member member) {
+        log.info("관리자 계정의 알림 설정을 생성합니다.");
+        if (notificationRepository.findByMemberId(member.getId()).isPresent()) {
+            log.info("이미 알림 설정이 존재합니다. 생성을 건너뜁니다.");
+            return;
+        }
+
+        NotificationSettings settings = NotificationSettings.builder()
+                .member(member)
+                .isPushAgreed(true)
+                .fcmToken("")
+                .build();
+        notificationRepository.save(settings);
     }
 }

--- a/src/main/java/org/zerock/puppyrun/common/scheduler/WalkingRemindScheduler.java
+++ b/src/main/java/org/zerock/puppyrun/common/scheduler/WalkingRemindScheduler.java
@@ -1,0 +1,24 @@
+package org.zerock.puppyrun.common.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.service.NotificationProcessor;
+import org.zerock.puppyrun.notification.service.ReminderSender;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class WalkingRemindScheduler {
+    private final NotificationProcessor processor;
+    private final ReminderSender sender;
+
+    // 매일 밤 20:00에 실행
+    @Scheduled(cron = "0 0 20 * * *")
+    public void sendDailyWalkingReminder() {
+        log.info("데일리 산책 리마인드 발송 시작");
+        processor.broadcast(NotificationType.DAILY_WALKING_REMINDER, sender);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/entity/NotificationSettings.java
+++ b/src/main/java/org/zerock/puppyrun/notification/entity/NotificationSettings.java
@@ -1,0 +1,81 @@
+package org.zerock.puppyrun.notification.entity;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.zerock.puppyrun.common.entity.BaseTimeEntity;
+import org.zerock.puppyrun.member.entity.Member;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationSettings extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 푸시 알림을 보낼 기기의 고유 주소
+    @Column(name = "fcm_token")
+    private String fcmToken;
+
+    // 알림 수신 동의 여부 (푸시 알림은 법적으로 동의가 필수)
+    @Column(name = "is_push_agreed")
+    private boolean isPushAgreed;
+
+
+    // 유저가 수신 거부(OFF)한 알림 타입만 모아두는 리스트
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "notification_opt_outs",
+            joinColumns = @JoinColumn(name = "settings_id")
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_type")
+    private Set<NotificationType> optOutTypes = new HashSet<>();
+
+
+    @Builder
+    public NotificationSettings(Member member, String fcmToken, boolean isPushAgreed) {
+        this.member = member;
+        this.fcmToken = fcmToken;
+        this.isPushAgreed = isPushAgreed; // 할당
+    }
+
+
+    public void Update(String fcmToken, boolean isPushAgreed) {
+        this.fcmToken = fcmToken;
+        this.isPushAgreed = isPushAgreed; // 할당
+    }
+
+    // 알림 차단(OFF)
+    public void disableType(NotificationType type) {
+        this.optOutTypes.add(type);
+    }
+
+    // 알림 다시 켜기(ON - 차단 목록에서 제거)
+    public void enableType(NotificationType type) {
+        this.optOutTypes.remove(type);
+    }
+
+}

--- a/src/main/java/org/zerock/puppyrun/notification/entity/NotificationType.java
+++ b/src/main/java/org/zerock/puppyrun/notification/entity/NotificationType.java
@@ -1,0 +1,44 @@
+package org.zerock.puppyrun.notification.entity;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.zerock.puppyrun.common.exception.DataIntegrityException;
+import org.zerock.puppyrun.pet.entity.PetBadge;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    // 시스템/공지 (SYS)
+    NOTICE("SYS_001", Priority.HIGH, "전체 공지사항"),
+
+    // 활동/산책 (ACT)
+    DAILY_WALKING_REMINDER("ACT_001", Priority.HIGH, "일일 산책 리마인더"),
+    WALK_GOAL_ACHIEVED("ACT_002", Priority.NORMAL, "주간 산책 목표 달성"),
+
+    //  마케팅/이벤트 (MKT)
+    EVENT_PROMO("MKT_001", Priority.NORMAL, "이벤트 및 프로모션 안내");
+
+
+    private final String code;          // 알림 코드
+    private final Priority priority;      // 알림 중요도
+    private final String description;     // 설명
+
+    public enum Priority {
+        HIGH, NORMAL
+    }
+
+    /**
+     * 문자열 코드값을 입력받아 해당하는 NotificationType Enum 상수를 반환합니다.
+     *
+     * @param code 뱃지 코드 (e.g., "SYS_001", "ACT_001")
+     * @return 코드에 해당하는 NotificationType 상수
+     * @throws DataIntegrityException 정의되지 않은 코드일 경우 예외 발생
+     */
+    public static NotificationType fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(notificationType -> notificationType.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new DataIntegrityException("잘못된 알림 코드입니다: " + code));
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/event/NotificationEventListener.java
+++ b/src/main/java/org/zerock/puppyrun/notification/event/NotificationEventListener.java
@@ -1,0 +1,131 @@
+package org.zerock.puppyrun.notification.event;
+
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.SendResponse;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.zerock.puppyrun.notification.service.DTO.PushTask;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationEventListener {
+    // 구글이 허용하는 한 번의 최대 전송량
+    private static final int MAX_FCM_BATCH_SIZE = 500;
+
+    /**
+     * FCM 메시지를 비동기적으로 일괄 발송합니다. 이 메서드는 호출 즉시 반환되며, 실제 전송은 백그라운드 스레드에서 처리됩니다.
+     *
+     * @param pushTasks 내용과 토큰이 각각 세팅된 Message 리스트
+     */
+    @Async("notificationTaskExecutor") // 이 메서드 자체를 별도의 스레드에서 실행하도록 지정
+    public void sendMessagesInBulk(List<PushTask> pushTasks) {
+        if (pushTasks == null || pushTasks.isEmpty()) {
+            log.info("푸시 알림이 비어있습니다.");
+            return;
+        }
+
+        int totalSize = pushTasks.size();
+        log.info("총 {}건의 푸시 알림 비동기 발송을 시작합니다.", totalSize);
+
+        // 500개씩 묶어서(Chunk) 구글 서버에 전송
+        for (int i = 0; i < totalSize; i += MAX_FCM_BATCH_SIZE) {
+
+            int endIndex = Math.min(i + MAX_FCM_BATCH_SIZE, totalSize);
+            List<PushTask> chunkedTask = pushTasks.subList(i, endIndex);
+            List<Message> messages = chunkedTask.stream().map(PushTask::message).toList();
+
+            // 비동기 sendEachAsync 호출로 ApiFuture를 받음
+            ApiFuture<BatchResponse> future = FirebaseMessaging.getInstance().sendEachAsync(messages);
+
+            // ApiFuture에 콜백을 등록하여 비동기 결과 처리
+            ApiFutures.addCallback(future, new ApiFutureCallback<BatchResponse>() {
+                // 전송 성공 시 (개별 메시지 실패 포함)
+                @Override
+                public void onSuccess(BatchResponse response) {
+                    log.info("알림 묶음 전송 성공 (성공: {}, 실패: {})",
+                            response.getSuccessCount(), response.getFailureCount());
+
+                    // 실패한 토큰이 있다면 후처리 로직 호출
+                    if (response.getFailureCount() > 0) {
+                        handleFailedTokens(chunkedTask, response);
+                    }
+                }
+
+                //  전송 실패시
+                @Override
+                public void onFailure(Throwable t) {
+                    log.error("알림 묶음 전송 중 오류 발생", t);
+                }
+            });
+
+
+        }
+    }
+
+    /**
+     * FCM 토픽 방식을 사용하여 메시지를 비동기적으로 일괄 발송
+     *
+     * @param pushTask 발송할 메시지
+     */
+    @Async("notificationTaskExecutor")
+    public void sendTopicMessage(PushTask pushTask) {
+        log.info("토픽 [{}] 대상 푸시 알림 비동기 발송을 시작합니다.", pushTask.topic());
+
+        // 여러 개의 토큰 리스트 대신, 단 한 번의 호출로 구글 서버에 토픽 발송을 위임
+        ApiFuture<String> future = FirebaseMessaging.getInstance().sendAsync(pushTask.message());
+
+        // ApiFuture에 콜백을 등록하여 비동기 결과 처리
+        ApiFutures.addCallback(future, new ApiFutureCallback<String>() {
+
+            // 토픽 발송 요청 성공 시 (개별 유저 수신 여부와는 무관함)
+            @Override
+            public void onSuccess(String messageId) {
+                log.info("토픽 [{}] 알림 전송 요청 성공! (MessageID: {})", pushTask.topic(), messageId);
+            }
+
+            // 토픽 발송 요청 자체가 실패했을 때 (네트워크 오류, 인증 오류 등)
+            @Override
+            public void onFailure(Throwable t) {
+                log.error("토픽 [{}] 알림 전송 중 오류 발생", pushTask.topic(), t);
+            }
+        });
+    }
+
+
+    /**
+     * 실패한 토큰들을 걸러내고 DB에서 비활성화 처리하는 후처리 메서드
+     */
+    private void handleFailedTokens(List<PushTask> sentPushTasks, BatchResponse batchResponse) {
+        List<SendResponse> responses = batchResponse.getResponses();
+        List<String> deadTokens = new ArrayList<>();
+
+        for (int i = 0; i < responses.size(); i++) {
+            if (!responses.get(i).isSuccessful()) {
+                // 어떤 토큰이 실패했는지 찾아냄 (보낸 리스트와 응답 리스트의 순서가 일치)
+                String failedToken = sentPushTasks.get(i).fcmToken();
+                log.warn("발송 실패한 토큰 발견. 삭제 대상: {}, 원인: {}", failedToken,
+                        responses.get(i).getException().getMessage());
+                deadTokens.add(failedToken);
+
+            }
+        }
+
+        if (!deadTokens.isEmpty()) {
+            log.info("{}개의 만료된 토큰을 데이터베이스에서 비활성화 처리해야 합니다.", deadTokens.size());
+            // TODO: deadTokens 리스트를 MemberRepository로 넘겨서 DB의 fcm_token을 NULL로 업데이트하는 로직을 구현 예정
+        }
+    }
+
+
+}

--- a/src/main/java/org/zerock/puppyrun/notification/event/NotificationEventListener.java
+++ b/src/main/java/org/zerock/puppyrun/notification/event/NotificationEventListener.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.zerock.puppyrun.common.exception.BusinessException;
+import org.zerock.puppyrun.common.exception.ErrorCode;
 import org.zerock.puppyrun.notification.service.DTO.PushTask;
 
 @Slf4j
@@ -80,6 +82,15 @@ public class NotificationEventListener {
      */
     @Async("notificationTaskExecutor")
     public void sendTopicMessage(PushTask pushTask) {
+        if (pushTask == null) {
+            log.info("푸시 알림이 비어있습니다.");
+            return;
+        }
+
+        if (pushTask.topic() == null) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "토픽 정보가 비어있습니다.");
+        }
+
         log.info("토픽 [{}] 대상 푸시 알림 비동기 발송을 시작합니다.", pushTask.topic());
 
         // 여러 개의 토큰 리스트 대신, 단 한 번의 호출로 구글 서버에 토픽 발송을 위임

--- a/src/main/java/org/zerock/puppyrun/notification/repository/DTO/EnabledNotifications.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/DTO/EnabledNotifications.java
@@ -1,0 +1,11 @@
+package org.zerock.puppyrun.notification.repository.DTO;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record EnabledNotifications(
+        UUID memberId,
+        String fcmToken,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/notification/repository/NotificationRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/NotificationRepoCustom.java
@@ -1,0 +1,12 @@
+package org.zerock.puppyrun.notification.repository;
+
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+
+public interface NotificationRepoCustom {
+    List<EnabledNotifications> findNextMembers(LocalDateTime lastCreatedAt, Pageable pageable, NotificationType type);
+}

--- a/src/main/java/org/zerock/puppyrun/notification/repository/NotificationRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/NotificationRepoCustomImpl.java
@@ -1,0 +1,46 @@
+package org.zerock.puppyrun.notification.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.member.entity.Status;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+
+import static org.zerock.puppyrun.notification.entity.QNotificationSettings.notificationSettings;
+import static org.zerock.puppyrun.member.entity.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepoCustomImpl implements NotificationRepoCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<EnabledNotifications> findNextMembers(LocalDateTime lastCreatedAt, Pageable pageable,
+                                                      NotificationType type) {
+        return queryFactory
+                .select(Projections.constructor(EnabledNotifications.class, // 추후 설정이 늘어날 수 있어 DTO로 받음
+                        notificationSettings.member.id,
+                        notificationSettings.fcmToken,
+                        member.createdAt
+                ))
+                .from(notificationSettings)
+                .join(notificationSettings.member, member) // JOIN
+                .where(
+                        member.status.eq(Status.ACTIVE),
+                        notificationSettings.isPushAgreed.eq(true),
+
+                        notificationSettings.optOutTypes.contains(type).not(),
+
+                        // 처음 조회할 때는 lastCreatedAt이 null일 수 있으므로 동적 쿼리 처리
+                        lastCreatedAt != null ? member.createdAt.gt(lastCreatedAt) : null
+                )
+                .orderBy(member.createdAt.asc())
+                .limit(pageable.getPageSize()) // Pageable에서 지정한 크기 만큼만 조회
+                .fetch();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package org.zerock.puppyrun.notification.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zerock.puppyrun.notification.entity.NotificationSettings;
+
+public interface NotificationRepository extends JpaRepository<NotificationSettings, UUID>, NotificationRepoCustom {
+
+    Optional<NotificationSettings> findByMemberId(UUID memberId);
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/DTO/PushTask.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/DTO/PushTask.java
@@ -1,0 +1,82 @@
+package org.zerock.puppyrun.notification.service.DTO;
+
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.Builder;
+import org.springframework.util.Assert;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+
+public record PushTask(
+        String fcmToken, // 토픽 발송일 경우 null
+        String topic,    // 토큰 발송일 경우 null
+        Message message
+) {
+
+    @Builder
+    public PushTask(NotificationType type, String fcmToken, String topic, String title, String body) {
+        // 표준 생성자로 위임
+        this(fcmToken, topic, createMessage(type, fcmToken, topic, title, body));
+    }
+
+    /**
+     * 알림 중요도에 따라 Message(Config 포함)를 동적으로 생성하는 헬퍼 메서드
+     */
+    private static Message createMessage(NotificationType type, String fcmToken, String topic, String title,
+                                         String body) {
+
+        // 공통 필수 값 검증
+        Assert.notNull(type, "알림 타입은 필수 입니다.");
+        Assert.hasText(title, "알림 제목은 필수 입니다.");
+        Assert.hasText(body, "알림 본문은 필수 입니다.");
+
+        // 토큰과 토픽 중 정확히 하나만 존재해야 함
+        boolean hasToken = fcmToken != null && !fcmToken.isBlank();
+        boolean hasTopic = topic != null && !topic.isBlank();
+        Assert.isTrue(hasToken ^ hasTopic, "발송 대상(FCM 토큰 또는 토픽) 중 정확히 하나만 지정해야 합니다.");
+
+        // 중요도에 따른 설정값 초기화
+        AndroidConfig.Priority androidPriority;
+        String apnsPriority;
+
+        if (type.getPriority() == NotificationType.Priority.HIGH) {
+            androidPriority = AndroidConfig.Priority.HIGH;
+            apnsPriority = "10"; // iOS 수신 즉시 표시 (High)
+        } else {
+            androidPriority = AndroidConfig.Priority.NORMAL;
+            apnsPriority = "5";  // iOS 배터리 고려하여 백그라운드에서 수신 (Normal)
+        }
+
+        // Message 빌더 공통 설정 조립
+        Message.Builder messageBuilder = Message.builder()
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .putData("type", type.name())
+
+                // (Android) 설정
+                .setAndroidConfig(AndroidConfig.builder()
+                        .setPriority(androidPriority)
+                        .build())
+
+                // (iOS - APNs) 설정
+                .setApnsConfig(ApnsConfig.builder()
+                        .putHeader("apns-priority", apnsPriority)
+                        .setAps(Aps.builder()
+                                .setSound("default")
+                                .build())
+                        .build());
+
+        // 발송 타겟 지정 (Token vs Topic)
+        if (hasToken) {
+            messageBuilder.setToken(fcmToken);
+        } else {
+            messageBuilder.setTopic(topic);
+        }
+
+        return messageBuilder.build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/NotificationProcessor.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/NotificationProcessor.java
@@ -1,0 +1,72 @@
+package org.zerock.puppyrun.notification.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.service.DTO.PushTask;
+import org.zerock.puppyrun.notification.event.NotificationEventListener;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+import org.zerock.puppyrun.notification.repository.NotificationRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationProcessor {
+    // 의존성 주입
+    private final NotificationRepository notificationRepository;
+    private final NotificationEventListener notificationEventListener;
+
+    private static final int CHUNK_SIZE = 1000;
+
+    @Async("notificationTaskExecutor")
+    public void broadcast(NotificationType type, Sender sender) {
+        // Limit만 1000으로 걸어주는 용도의 Pageable
+        Pageable limitOnly = PageRequest.of(0, CHUNK_SIZE);
+
+        //옛날 날짜를 기준점
+        LocalDateTime lastCreatedAt = null;
+        // 알림 발송 로직이 시작되는 정확한 시간을 기록
+        List<EnabledNotifications> memberSettings;
+
+        do {
+            // 마지막으로 본 시간 이후의 1000명을 조회
+            memberSettings = notificationRepository.findNextMembers(lastCreatedAt, limitOnly, type);
+            if (memberSettings.isEmpty()) {
+                log.info("알림 가능한 멤버가 없습니다.");
+                break; // 더 이상 데이터가 없으면 탈출
+            }
+
+            // 메세지를 다르게 만드는 분기
+            List<PushTask> pushTasks = sender.setPushTasks(type, memberSettings);
+
+            // 검색된 멤버 알림 처리
+            notificationEventListener.sendMessagesInBulk(pushTasks);
+
+            // 맨 마지막 사람의 가입일자를 다음 기준점(Cursor)으로 업데이트
+            lastCreatedAt = memberSettings.getLast().createdAt();
+
+        } while (memberSettings.size() == CHUNK_SIZE); // 딱 1000개를 꽉 채워서 가져왔다면 다음 데이터가 더 있을 확률이 높으므로 계속 반복
+    }
+
+    // 다수 토픽 알림
+    @Async("notificationTaskExecutor")
+    public void broadcast(NotificationType type, String title, String body) {
+
+        // 공통 메세지 생성
+        PushTask pushTask = PushTask.builder()
+                .body(body)
+                .title(title)
+                .type(type)
+                .topic(type.getCode())
+                .build();
+
+        notificationEventListener.sendTopicMessage(pushTask);
+
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/ReminderSender.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/ReminderSender.java
@@ -1,0 +1,63 @@
+package org.zerock.puppyrun.notification.service;
+
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.service.DTO.PushTask;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+import org.zerock.puppyrun.tracking.DTO.DailyMemberStat;
+import org.zerock.puppyrun.tracking.repository.TrackingRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReminderSender implements Sender {
+    private final TrackingRepository trackingRepository;
+
+    @Override
+    public List<PushTask> setPushTasks(NotificationType type, List<EnabledNotifications> memberSettings) {
+        // 오늘 날짜
+        LocalDate today = LocalDate.now();
+
+        List<UUID> memberIds = memberSettings.stream().map(EnabledNotifications::memberId).toList();
+        List<DailyMemberStat> statList = trackingRepository.findMemberIdsByDate(memberIds, today, today);
+
+        // 검색 속도를 위해 List를 Map 형태로 변환
+        Map<UUID, DailyMemberStat> statMap = statList.stream()
+                .collect(Collectors.toMap(DailyMemberStat::memberId, stat -> stat));
+
+        return memberSettings.stream()
+                .map(member -> {
+                    DailyMemberStat stat = statMap.get(member.memberId());
+                    return setTask(type, member.fcmToken(), stat);
+                })
+                .toList();
+    }
+
+    private PushTask setTask(NotificationType type, String fcmToken, DailyMemberStat stat) {
+        String message;
+        if (stat == null) {
+            // Map에 없으면 산책을 아예 안 한 사람
+            message = "아직 산책 전이신가요? 강아지가 문 앞을 서성이고 있어요! 🦮";
+        } else if (stat.totalDistance() >= 3000) { // 3km 이상
+            message = "와우! 무려 " + (stat.totalDistance() / 1000.0) + "km나 걸으셨네요! 오늘 꿀잠 예약입니다! 🔥";
+        } else { // 3km 미만
+            message = "오늘도 잊지 않고 산책 완료! 훌륭한 보호자이십니다 🐾";
+        }
+
+        return PushTask.builder()
+                .fcmToken(fcmToken)
+                .type(type)
+                .title("오늘도 산책할 시간이에요!")
+                .body(message)
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/Sender.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/Sender.java
@@ -1,0 +1,12 @@
+package org.zerock.puppyrun.notification.service;
+
+import java.util.List;
+
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.service.DTO.PushTask;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+
+public interface Sender {
+    public List<PushTask> setPushTasks(NotificationType type, List<EnabledNotifications> memberSettings);
+
+}

--- a/src/main/java/org/zerock/puppyrun/tracking/DTO/DailyMemberStat.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/DTO/DailyMemberStat.java
@@ -1,0 +1,11 @@
+package org.zerock.puppyrun.tracking.DTO;
+
+import java.util.UUID;
+
+public record DailyMemberStat(
+        UUID memberId,
+        Integer trackingCount, // 오늘 산책 횟수
+        Integer totalDistance, // 오늘 총 걸은 거리
+        Integer totalDuration  // 오늘 총 걸은 시간
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
@@ -3,6 +3,7 @@ package org.zerock.puppyrun.tracking.repository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
+import org.zerock.puppyrun.tracking.DTO.DailyMemberStat;
 import org.zerock.puppyrun.tracking.DTO.DailyTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
 
@@ -15,4 +16,6 @@ public interface TrackingRepoCustom {
 
 
     List<DailyTracking> getDailyActivities(UUID memberId, LocalDate targetDate);
+
+    List<DailyMemberStat> findMemberIdsByDate(List<UUID> memberIds, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
@@ -1,6 +1,7 @@
 package org.zerock.puppyrun.tracking.repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.DateTemplate;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -11,6 +12,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.tracking.DTO.DailyMemberStat;
 import org.zerock.puppyrun.tracking.DTO.DailyTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
 import org.zerock.puppyrun.tracking.entity.Tracking;
@@ -117,4 +119,24 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
         }).toList();
 
     }
+
+    @Override
+    public List<DailyMemberStat> findMemberIdsByDate(List<UUID> memberIds, LocalDate startDate, LocalDate endDate) {
+        return queryFactory
+                .select(Projections.constructor(DailyMemberStat.class,
+                        tracking.member.id,
+                        tracking.id.count().intValue(),
+                        tracking.distance.sum().coalesce(0),
+                        tracking.duration.sum().coalesce(0)
+                ))
+                .from(tracking)
+                .where(
+                        tracking.startedAt.goe(startDate.atStartOfDay()),
+                        tracking.startedAt.lt(endDate.plusDays(1).atStartOfDay()),
+                        tracking.member.id.in(memberIds)
+                )
+                .groupBy(tracking.member.id)
+                .fetch();
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,6 @@ discord:
 data-kr:
   api-key: ${DATA_API_KEY}
   forecest-url: ${DATA_FORECEST_URL}
+
+firebase:
+  account-path: ${FCM_ACCOUNT_PATH}

--- a/src/test/java/org/zerock/puppyrun/discordNotice/DiscordNotificationTest.java
+++ b/src/test/java/org/zerock/puppyrun/discordNotice/DiscordNotificationTest.java
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 public class DiscordNotificationTest {
 
     // 로그백 로거 설정

--- a/src/test/java/org/zerock/puppyrun/weather/WeatherServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/weather/WeatherServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean; // 변경된 import
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +29,7 @@ import org.zerock.puppyrun.weather.service.WeatherService;
 import reactor.core.publisher.Mono;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class WeatherServiceTest {
 
     @Autowired


### PR DESCRIPTION
# 📌 Pull Request: FCM 푸시 알림 인프라 및 데일리 산책 리마인더 스케줄러 구현 (#26)

# 📝 작업 요약 (Summary)

- Firebase Admin SDK를 도입하여 FCM 기반의 푸시 알림 발송 인프라 및 비동기 처리 환경 구축
- 사용자가 알림 수신 여부(Opt-out)를 제어할 수 있는 알림 설정(`NotificationSettings`) 도메인 추가
- 알림 발송의 확장을 고려하여 전략 패턴(`Sender` 인터페이스) 및 Spring Event 기반의 비동기 알림 아키텍처 설계
- 매일 20시, 사용자의 당일 산책 기록 통계를 바탕으로 맞춤형 메시지를 전송하는 데일리 산책 독려 스케줄러 구현
- **[성능 및 안정성 최적화]** 대용량 유저 대상 푸시 발송 시 발생할 수 있는 OOM(Out of Memory) 방지 및 N+1 문제를 해결하기 위해 커서(Cursor) 기반 페이징, Chunk 단위 전송, 메모리 조인(Map) 적용

# 🛠️ 변경 사항 (Changes)

## 1. FCM 푸시 알림 환경 및 인프라 구축 (Infrastructure)
- **Firebase 의존성 및 환경 설정**: `build.gradle`에 Firebase Admin SDK 추가 및 `FirebaseConfig` 초기화 설정 연동
- **전용 비동기 스레드 풀 적용**: 메인 스레드 블로킹 방지를 위해 `@EnableAsync` 적용 및 `AsyncConfig`에 푸시 발송 전용 스레드 풀(`notificationTaskExecutor`) 세팅
- **테스트 환경 편의성 개선**: 로컬 테스트 시 NPE 방지 및 즉각적인 테스트를 위해 `DataInitializer`에 관리자 계정 기본 알림 설정 자동 생성 로직 추가

## 2. 알림 도메인 및 메시지 캡슐화 (Notification Domain & DTO)
- **알림 설정(Opt-out) 및 타입 정의**: 수신 동의 여부 제어를 위한 `NotificationSettings` 엔티티 및 알림 중요도(Priority)를 포함한 `NotificationType` Enum 추가
- **OS별 수신 최적화**: `PushTask` 객체 생성 시 알림 중요도에 따라 iOS(APNs) 백그라운드 배터리 최적화(apns-priority 10/5) 및 Android 우선순위를 동적 할당
- **안전한 타겟팅 검증 (Fail-Fast)**: 단일 기기(Token)와 그룹(Topic) 발송을 모두 지원하되, 객체 생성 시점에 둘 중 하나만 입력되도록 XOR 연산(`^`) 기반의 검증 로직 적용

## 3. 대규모 확장을 고려한 알림 발송 아키텍처 (Notification Architecture)
- **전략 패턴(Strategy Pattern) 도입**: 알림 종류(리마인더, 마케팅, 공지 등)에 따라 메시지 생성 책임을 분리하는 `Sender` 인터페이스 설계 (OCP 준수)
- **대량 발송 최적화 (OOM 방지)**: `NotificationProcessor`에서 커서 기반(lastCreatedAt) No-offset 페이징을 적용해 전체 유저를 1000명 단위(Chunk)로 끊어서 안전하게 메모리에 로드
- **FCM API 전송량 Limit 대응**: 구글 서버의 1회 전송 제한을 준수하기 위해 `NotificationEventListener`에서 `MAX_FCM_BATCH_SIZE` 단위로 리스트를 분할(subList)하여 비동기 벌크 전송
- **Dead Token 후처리 파이프라인**: 비동기 콜백(`ApiFutureCallback`)을 통해 FCM 서버의 응답을 분석하고, 만료되거나 유효하지 않은 토큰을 식별하는 `handleFailedTokens` 방어 로직 구축

## 4. 맞춤형 데일리 산책 리마인더 (Scheduler & Business Logic)
- **야간 리마인더 스케줄러 등록**: `@Scheduled`를 활용하여 매일 밤 8시(20:00)에 반려견 산책을 독려하는 `WalkingRemindScheduler` 자동화 구축
- **대량 통계 조회 및 O(1) 매칭 최적화 (`ReminderSender`)**: 
  - N+1 문제 방지를 위해 1000명(Chunk)의 당일 산책 통계를 단일 `IN` 쿼리로 일괄 조회
  - 조회된 List를 `Map<UUID, DailyMemberStat>`으로 변환하여 애플리케이션 메모리 단에서 O(1) 시간 복잡도로 빠르게 유저별 맞춤 메시지(3km 달성/미달성/미산책) 조립