### PR TITLE
feat: 사용자 알림 제어 및 FCM 토픽 관리 시스템 구축 (#26)

### DIFF
--- a/src/main/java/org/zerock/puppyrun/common/exception/ErrorCode.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     // 클라이언트 에러
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "CLIENT_001", "잘못된 요청입니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "CLIENT_002", "요청한 값을 찾을 수 없습니다."),
-
+    EXISTS_RESOURCE(HttpStatus.CONFLICT, "CLIENT_003", "이미 존재하는 값입니다."),
 
     // 인증/인가 관련 에러
     USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "로그인 정보가 유효하지 않습니다."),

--- a/src/main/java/org/zerock/puppyrun/common/exception/ErrorCode.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/ErrorCode.java
@@ -34,6 +34,9 @@ public enum ErrorCode {
     // 날씨 에러
     INVALID_WEATHER(HttpStatus.INTERNAL_SERVER_ERROR, "WEATHER_001", "잘못된 날씨입니다."),
 
+    // 알림 설정 에러
+    NOT_EXISTS_FCM_TOKEN(HttpStatus.NOT_FOUND, "NOTI_001", "FCM 토큰이 존재하지 않습니다."),
+
     // 유저 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "유저를 찾을 수 없습니다."),
     EXISTS_USER(HttpStatus.CONFLICT, "USER_002", "이미 존재하는 유저입니다.");

--- a/src/main/java/org/zerock/puppyrun/common/exception/ExistsResourceException.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/ExistsResourceException.java
@@ -1,0 +1,11 @@
+package org.zerock.puppyrun.common.exception;
+
+public class ExistsResourceException extends BusinessException {
+    public ExistsResourceException(String message) {
+        super(ErrorCode.EXISTS_RESOURCE, message);
+    }
+
+    public ExistsResourceException(String message, Throwable cause) {
+        super(ErrorCode.EXISTS_RESOURCE, message, cause);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/controller/AdminNoticeController.java
+++ b/src/main/java/org/zerock/puppyrun/notification/controller/AdminNoticeController.java
@@ -1,0 +1,33 @@
+package org.zerock.puppyrun.notification.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.service.NotificationProcessor;
+
+@RestController
+@RequestMapping("/api/admin/notice")
+@Slf4j
+@RequiredArgsConstructor
+public class AdminNoticeController {
+    private final NotificationProcessor processor;
+
+    @PostMapping("/send-push")
+    public ResponseEntity<Void> sendNoticePush(
+            @RequestParam String title,
+            @RequestParam String body
+    ) {
+
+        // 전체 알림 발송
+        processor.broadcast(NotificationType.NOTICE, title, body);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/controller/NotificationController.java
+++ b/src/main/java/org/zerock/puppyrun/notification/controller/NotificationController.java
@@ -1,0 +1,71 @@
+package org.zerock.puppyrun.notification.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.notification.controller.request.FcmTokenUpdateRequest;
+import org.zerock.puppyrun.notification.controller.request.NotificationAgreeRequest;
+import org.zerock.puppyrun.notification.controller.request.NotificationToggleRequest;
+import org.zerock.puppyrun.notification.controller.response.NotificationOptionsResponse;
+import org.zerock.puppyrun.notification.service.NotificationCommandService;
+import org.zerock.puppyrun.notification.service.NotificationQueryService;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationCommandService notificationCommandService;
+    private final NotificationQueryService notificationQueryService;
+
+    // 알림 설정 조회
+    @GetMapping
+    public ResponseEntity<NotificationOptionsResponse> getOptions(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        NotificationOptionsResponse response = notificationQueryService.getOptions(userPrincipal);
+        return ResponseEntity.ok(response);
+    }
+
+    // 전체 알림 설정 변경 (명시적 상태 전달)
+    @PatchMapping("/options/global")
+    public ResponseEntity<Void> toggleGlobal(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody NotificationAgreeRequest request
+    ) {
+        notificationCommandService.toggleGlobal(userPrincipal, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 개별 알림 설정 변경
+    @PatchMapping("/options")
+    public ResponseEntity<Void> toggleIndividual(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody NotificationToggleRequest request
+    ) {
+        notificationCommandService.toggle(userPrincipal, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 알림 동의 설정
+    @PostMapping("/agree")
+    public ResponseEntity<Void> agreeNotification(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody NotificationAgreeRequest request
+    ) {
+        notificationCommandService.saveNotification(userPrincipal, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // fcm token 등록
+    @PostMapping("/fcm-token")
+    public ResponseEntity<Void> updateFcmToken(
+            @AuthenticationPrincipal UserPrincipal user,
+            @Valid @RequestBody FcmTokenUpdateRequest request) {
+        notificationCommandService.updateToken(user, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/controller/request/FcmTokenUpdateRequest.java
+++ b/src/main/java/org/zerock/puppyrun/notification/controller/request/FcmTokenUpdateRequest.java
@@ -1,0 +1,10 @@
+package org.zerock.puppyrun.notification.controller.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FcmTokenUpdateRequest(
+        @NotBlank(message = "FCM 토큰은 필수입니다.")
+        String fcmToken
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/notification/controller/request/NotificationAgreeRequest.java
+++ b/src/main/java/org/zerock/puppyrun/notification/controller/request/NotificationAgreeRequest.java
@@ -1,0 +1,12 @@
+package org.zerock.puppyrun.notification.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record NotificationAgreeRequest(
+        @NotNull(message = "수신 동의는 필수입니다.")
+        boolean isPushAgreed,
+        @NotBlank(message = "FCM 토큰은 필수값 입니다.")
+        String fcmToken
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/notification/controller/request/NotificationToggleRequest.java
+++ b/src/main/java/org/zerock/puppyrun/notification/controller/request/NotificationToggleRequest.java
@@ -1,0 +1,13 @@
+package org.zerock.puppyrun.notification.controller.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record NotificationToggleRequest(
+        @NotBlank(message = "알림 코드는 필수입니다.")
+        String optionCode,
+        @NotNull(message = "변경할 상태값(enabled)은 필수입니다.")
+        Boolean enabled
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/notification/controller/response/NotificationOptionsResponse.java
+++ b/src/main/java/org/zerock/puppyrun/notification/controller/response/NotificationOptionsResponse.java
@@ -1,0 +1,48 @@
+package org.zerock.puppyrun.notification.controller.response;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.zerock.puppyrun.notification.entity.NotificationSettings;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+
+public record NotificationOptionsResponse(
+        boolean isPushAgreed,
+        List<NotificationOptions> notificationOptions
+) {
+    record NotificationOptions(
+            String prefix,
+            List<option> options
+    ) {
+        public static List<NotificationOptions> of(Set<NotificationType> optOuts) {
+            // 모든 NotificationType을 순회하면서 허용/차단 여부를 매핑한 뒤,
+            // typeCode의 접두사를 기준으로 그룹화(groupingBy)합니다.
+            return Arrays.stream(NotificationType.values())
+                    .map(type -> new option(
+                            type.getCode(),
+                            !optOuts.contains(type) // optOuts에 없어야(true) 알림 허용
+                    ))
+                    .collect(Collectors.groupingBy(
+                            op -> op.optionCode().split("_")[0] // '_'를 기준으로 자른 뒤 첫 번째 값(접두사) 사용
+                    ))
+                    .entrySet()
+                    .stream()
+                    .map(entry -> new NotificationOptions(
+                            entry.getKey(),
+                            entry.getValue())
+                    ).toList();
+        }
+
+    }
+
+    record option(
+            String optionCode,
+            boolean enabled
+    ) {
+    }
+
+    public static NotificationOptionsResponse of(NotificationSettings setting, Set<NotificationType> optOuts) {
+        return new NotificationOptionsResponse(setting.isPushAgreed(), NotificationOptions.of(optOuts));
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/entity/NotificationSettings.java
+++ b/src/main/java/org/zerock/puppyrun/notification/entity/NotificationSettings.java
@@ -12,9 +12,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,15 +34,15 @@ public class NotificationSettings extends BaseTimeEntity {
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member;
 
     // 푸시 알림을 보낼 기기의 고유 주소
-    @Column(name = "fcm_token")
+    @Column(name = "fcm_token", nullable = false)
     private String fcmToken;
 
     // 알림 수신 동의 여부 (푸시 알림은 법적으로 동의가 필수)
-    @Column(name = "is_push_agreed")
+    @Column(name = "is_push_agreed", nullable = false)
     private boolean isPushAgreed;
 
 
@@ -51,8 +53,8 @@ public class NotificationSettings extends BaseTimeEntity {
             joinColumns = @JoinColumn(name = "settings_id")
     )
     @Enumerated(EnumType.STRING)
-    @Column(name = "notification_type")
-    private Set<NotificationType> optOutTypes = new HashSet<>();
+    @Column(name = "notification_type", length = 50)
+    private Set<NotificationType> optOutTypes;
 
 
     @Builder
@@ -60,10 +62,11 @@ public class NotificationSettings extends BaseTimeEntity {
         this.member = member;
         this.fcmToken = fcmToken;
         this.isPushAgreed = isPushAgreed; // 할당
+        this.optOutTypes = new HashSet<>();
     }
 
 
-    public void Update(String fcmToken, boolean isPushAgreed) {
+    public void update(String fcmToken, boolean isPushAgreed) {
         this.fcmToken = fcmToken;
         this.isPushAgreed = isPushAgreed; // 할당
     }
@@ -76,6 +79,12 @@ public class NotificationSettings extends BaseTimeEntity {
     // 알림 다시 켜기(ON - 차단 목록에서 제거)
     public void enableType(NotificationType type) {
         this.optOutTypes.remove(type);
+    }
+
+    public Set<NotificationType> getAllowedTypes() {
+        return Arrays.stream(NotificationType.values())
+                .filter(type -> !optOutTypes.contains(type))
+                .collect(Collectors.toUnmodifiableSet());
     }
 
 }

--- a/src/main/java/org/zerock/puppyrun/notification/event/NotificationEventListener.java
+++ b/src/main/java/org/zerock/puppyrun/notification/event/NotificationEventListener.java
@@ -8,11 +8,13 @@ import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.SendResponse;
+import com.google.firebase.messaging.TopicManagementResponse;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.zerock.puppyrun.common.exception.BusinessException;
 import org.zerock.puppyrun.common.exception.ErrorCode;
@@ -20,17 +22,21 @@ import org.zerock.puppyrun.notification.service.DTO.PushTask;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class NotificationEventListener {
     // 구글이 허용하는 한 번의 최대 전송량
     private static final int MAX_FCM_BATCH_SIZE = 500;
+
+    private final Executor executor;
+
+    public NotificationEventListener(@Qualifier("notificationTaskExecutor") Executor executor) {
+        this.executor = executor;
+    }
 
     /**
      * FCM 메시지를 비동기적으로 일괄 발송합니다. 이 메서드는 호출 즉시 반환되며, 실제 전송은 백그라운드 스레드에서 처리됩니다.
      *
      * @param pushTasks 내용과 토큰이 각각 세팅된 Message 리스트
      */
-    @Async("notificationTaskExecutor") // 이 메서드 자체를 별도의 스레드에서 실행하도록 지정
     public void sendMessagesInBulk(List<PushTask> pushTasks) {
         if (pushTasks == null || pushTasks.isEmpty()) {
             log.info("푸시 알림이 비어있습니다.");
@@ -69,7 +75,7 @@ public class NotificationEventListener {
                 public void onFailure(Throwable t) {
                     log.error("알림 묶음 전송 중 오류 발생", t);
                 }
-            });
+            }, executor);
 
 
         }
@@ -80,7 +86,6 @@ public class NotificationEventListener {
      *
      * @param pushTask 발송할 메시지
      */
-    @Async("notificationTaskExecutor")
     public void sendTopicMessage(PushTask pushTask) {
         if (pushTask == null) {
             log.info("푸시 알림이 비어있습니다.");
@@ -110,7 +115,43 @@ public class NotificationEventListener {
             public void onFailure(Throwable t) {
                 log.error("토픽 [{}] 알림 전송 중 오류 발생", pushTask.topic(), t);
             }
-        });
+        }, executor);
+    }
+
+
+    /**
+     * 특정 FCM 토큰을 특정 토픽에 구독 또는 구독 취소합니다.
+     *
+     * @param fcmToken    대상 FCM 토큰
+     * @param typeCode    대상 토픽 이름 (예: SYS_001)
+     * @param isSubscribe 구독 여부 (true: 구독, false: 구독 취소)
+     */
+    public void manageTopicSubscription(String fcmToken, String typeCode, boolean isSubscribe) {
+        ApiFuture<TopicManagementResponse> future;
+
+        if (isSubscribe) {
+            future = FirebaseMessaging.getInstance().subscribeToTopicAsync(
+                    Collections.singletonList(fcmToken), typeCode
+            );
+            log.info("FCM 토픽[{}] 구독 요청 완료 (토큰: {})", typeCode, fcmToken);
+        } else {
+            future = FirebaseMessaging.getInstance().unsubscribeFromTopicAsync(
+                    Collections.singletonList(fcmToken), typeCode
+            );
+            log.info("FCM 토픽[{}] 구독 취소 요청 완료 (토큰: {})", typeCode, fcmToken);
+        }
+
+        ApiFutures.addCallback(future, new ApiFutureCallback<TopicManagementResponse>() {
+            @Override
+            public void onSuccess(TopicManagementResponse result) {
+                log.info("FCM 토픽[{}] 처리 완료", typeCode);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                log.error("FCM 토픽[{}] 처리 실패: {}", typeCode, t.getMessage());
+            }
+        }, executor);
     }
 
 

--- a/src/main/java/org/zerock/puppyrun/notification/execption/FCMNotFoundException.java
+++ b/src/main/java/org/zerock/puppyrun/notification/execption/FCMNotFoundException.java
@@ -1,0 +1,14 @@
+package org.zerock.puppyrun.notification.execption;
+
+import org.zerock.puppyrun.common.exception.BusinessException;
+import org.zerock.puppyrun.common.exception.ErrorCode;
+
+public class FCMNotFoundException extends BusinessException {
+    public FCMNotFoundException(String message) {
+        super(ErrorCode.RESOURCE_NOT_FOUND, message);
+    }
+
+    public FCMNotFoundException(String message, Throwable cause) {
+        super(ErrorCode.RESOURCE_NOT_FOUND, message, cause);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/NotificationCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/NotificationCommandService.java
@@ -1,0 +1,164 @@
+package org.zerock.puppyrun.notification.service;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.TopicManagementResponse;
+import java.util.Collections;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.common.exception.BusinessException;
+import org.zerock.puppyrun.common.exception.ExistsResourceException;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.member.exception.UserNotFoundException;
+import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.notification.controller.request.FcmTokenUpdateRequest;
+import org.zerock.puppyrun.notification.controller.request.NotificationAgreeRequest;
+import org.zerock.puppyrun.notification.controller.request.NotificationToggleRequest;
+import org.zerock.puppyrun.notification.entity.NotificationSettings;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.event.NotificationEventListener;
+import org.zerock.puppyrun.notification.execption.FCMNotFoundException;
+import org.zerock.puppyrun.notification.repository.NotificationRepository;
+import org.zerock.puppyrun.common.exception.InvalidValueException;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class NotificationCommandService {
+    private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+    private final NotificationEventListener notificationEventListener;
+
+    /**
+     * 특정 알림 타입의 수신 여부를 개별적으로 켜거나 끕니다. 알림 상태 변경 시, 해당 알림에 매핑된 FCM 토픽 구독 상태도 함께 동기화됩니다.
+     *
+     * @param userPrincipal 현재 인증된 사용자의 정보
+     * @param request       알림 활성화 여부 (true: 켜기, false: 끄기)
+     * @throws InvalidValueException 전체 알림 수신 동의가 꺼져있거나, 잘못된 알림 코드일 때 발생
+     */
+    public void toggle(UserPrincipal userPrincipal, NotificationToggleRequest request) {
+        NotificationSettings setting = findSetting(userPrincipal);
+        String typeCode = request.optionCode();
+        boolean isEnable = request.enabled();
+
+        if (!setting.isPushAgreed()) {
+            throw new InvalidValueException("알림 수신 동의가 필요합니다.");
+        }
+
+        // 알림 코드로 알림 타입 정의
+        NotificationType type;
+        try {
+            type = NotificationType.fromCode(typeCode);
+        } catch (BusinessException e) {
+            throw new InvalidValueException("잘못된 알림 코드입니다: " + typeCode);
+        }
+
+        // 현재 유저가 개별적으로 허용해둔 알림 타입들만 추출
+        Set<NotificationType> optOuts = setting.getOptOutTypes();
+
+        if (isEnable && optOuts.contains(type)) {
+            // 알림 켜기
+            setting.enableType(type);
+            manageTopicSubscription(setting, type, true);
+        } else if (!isEnable && !optOuts.contains(type)) {
+            // 알림 끄기
+            setting.disableType(type);
+            manageTopicSubscription(setting, type, false);
+        } else {
+            log.info("알림 상태가 바꾸려는 상태와 동일합니다.");
+        }
+    }
+
+    /**
+     * 사용자의 전체 알림 수신 동의 여부를 변경하고, 허용된 개별 알림들에 대한 FCM 토픽 구독 상태를 일괄 동기화합니다. 기존의 개별 알림 세부 설정(optOutTypes)은 유지됩니다.
+     *
+     * @param userPrincipal 현재 인증된 사용자의 정보
+     * @param request       전체 알림 수신 동의 활성화 여부 (true: 전체 허용, false: 전체 차단)
+     */
+    public void toggleGlobal(UserPrincipal userPrincipal, NotificationAgreeRequest request) {
+        NotificationSettings setting = findSetting(userPrincipal);
+        boolean isEnable = request.isPushAgreed();
+
+        // 현재 상태와 목표 상태가 같으면 불필요한 쿼리 및 FCM API 호출 방지
+        if (setting.isPushAgreed() == isEnable) {
+            log.info("현재 알림 상태가 바꾸려는 상태와 동일합니다.");
+            return;
+        }
+
+        // DB 상태 업데이트
+        setting.update(request.fcmToken(), isEnable);
+
+        // 현재 유저가 개별적으로 허용해둔 알림 타입들만 추출
+        Set<NotificationType> allowedTypes = setting.getAllowedTypes();
+
+        // 토픽 구독 상태 동기화
+        allowedTypes.forEach(type ->
+                manageTopicSubscription(setting, type, isEnable));
+
+    }
+
+    /**
+     * 알림 설정 저장
+     *
+     * @param userPrincipal 현재 인증된 사용자의 정보
+     * @param request       알림 수신 동의 요청
+     */
+    public void saveNotification(UserPrincipal userPrincipal, NotificationAgreeRequest request) {
+        if (notificationRepository.findByMemberId(userPrincipal.id()).isPresent()) {
+            throw new ExistsResourceException("이미 알림 설정이 존재합니다.");
+        }
+        Member member = memberRepository.findByIdOrThrow(userPrincipal.id());
+
+        NotificationSettings settings = NotificationSettings.builder()
+                .fcmToken(request.fcmToken())
+                .member(member)
+                .isPushAgreed(request.isPushAgreed())
+                .build();
+        notificationRepository.save(settings);
+    }
+
+    public void updateToken(UserPrincipal userPrincipal, FcmTokenUpdateRequest request) {
+        NotificationSettings settings = notificationRepository.findByMemberId(userPrincipal.id())
+                .orElseThrow(() -> new UserNotFoundException("해당 유저의 알림 설정을 찾을 수 없습니다."));
+
+        settings.update(request.fcmToken(), settings.isPushAgreed());
+    }
+
+    /**
+     * 인증된 사용자 정보를 기반으로 NotificationSettings 엔티티를 조회하는 내부 헬퍼 메서드입니다.
+     *
+     * @param userPrincipal 현재 인증된 사용자의 정보
+     * @return 해당 유저의 알림 설정 엔티티
+     * @throws UserNotFoundException 알림 설정을 찾을 수 없을 때 발생
+     * @throws FCMNotFoundException  FCM 토큰이 비어있을 때 발생
+     */
+    private NotificationSettings findSetting(UserPrincipal userPrincipal) {
+        NotificationSettings settings = notificationRepository.findByMemberId(userPrincipal.id())
+                .orElseThrow(() -> new UserNotFoundException("해당 유저의 알림 설정을 찾을 수 없습니다."));
+
+        if (settings.getFcmToken().isBlank()) {
+            throw new FCMNotFoundException("FCM 토큰이 비어있습니다.");
+        }
+
+        return settings;
+    }
+
+    /**
+     * 구글 Firebase 서버에 특정 토픽의 구독 또는 구독 취소를 비동기적으로 요청합니다.
+     *
+     * @param setting     사용자의 알림 설정 엔티티 (FCM 토큰 추출 용도)
+     * @param type        구독 또는 취소할 대상 알림 타입
+     * @param isSubscribe 구독 여부 (true: 구독 요청, false: 구독 취소 요청)
+     */
+    private void manageTopicSubscription(NotificationSettings setting, NotificationType type, boolean isSubscribe) {
+        notificationEventListener.manageTopicSubscription(setting.getFcmToken(), type.getCode(), isSubscribe);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/NotificationQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/NotificationQueryService.java
@@ -1,0 +1,38 @@
+package org.zerock.puppyrun.notification.service;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.member.exception.UserNotFoundException;
+import org.zerock.puppyrun.notification.entity.NotificationSettings;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.execption.FCMNotFoundException;
+import org.zerock.puppyrun.notification.repository.NotificationRepository;
+import org.zerock.puppyrun.notification.controller.response.NotificationOptionsResponse;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationQueryService {
+    private final NotificationRepository notificationRepository;
+
+    /**
+     * 사용자의 현재 알림 설정 및 개별 알림 옵션 상태를 조회합니다.
+     *
+     * @param userPrincipal 현재 인증된 사용자의 정보
+     * @return 전체 알림 동의 여부 및 카테고리별로 그룹화된 개별 알림 설정 상태 응답 객체
+     */
+    public NotificationOptionsResponse getOptions(UserPrincipal userPrincipal) {
+        NotificationSettings setting = notificationRepository.findByMemberId(userPrincipal.id())
+                .orElseThrow(() -> new UserNotFoundException("해당 유저의 알림 설정을 찾을 수 없습니다."));
+
+        // 현재 유저가 개별적으로 허용해둔 알림 타입들만 추출
+        Set<NotificationType> optOuts = setting.getOptOutTypes();
+
+        return NotificationOptionsResponse.of(setting, optOuts);
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request:  사용자 알림 제어 및 FCM 토픽 관리 시스템 구축 (#26)

# 📝 작업 요약 (Summary)

- 사용자가 자신의 알림 설정(Opt-in/Opt-out)을 직접 제어하고 조회할 수 있는 REST API 엔드포인트 구현
- 알림 관련 비즈니스 로직을 Command(쓰기)와 Query(읽기) 서비스로 분리하여 서비스 계층 아키텍처 개선 (CQRS 적용)
- FCM 토픽 구독/해제 처리를 비동기로 위임하여 서버 응답 성능 개선
- `NotificationSettings` 엔티티 구조 최적화 및 알림 상태 응답 시 카테고리별 그룹화 DTO 적용
- FCM 토큰 부재 및 중복 리소스에 대한 안정적인 예외 처리(ErrorCode) 추가

# 🛠️ 변경 사항 (Changes)

## 1. 알림 제어 및 공지 REST API 구현 (Presentation Layer)
- **사용자 알림 컨트롤러 추가**: 개별 알림 토글, 전체 알림 동의 처리, FCM 토큰 업데이트를 담당하는 API 구현
- **관리자 공지 발송 API**: 관리자가 전체 사용자 또는 특정 그룹(토픽)을 대상으로 공지를 발송할 수 있는 컨트롤러 엔드포인트 추가
- **Request/Response DTO 설계 및 검증**: 
  - 클라이언트가 UI를 쉽게 구성할 수 있도록 알림 설정을 카테고리별로 그룹화하여 반환하는 응답 DTO 추가
  - 알림 상태 제어 및 토큰 갱신 요청 시 잘못된 값이 들어오지 않도록 Request DTO에 유효성 검사(`@Valid`) 적용

## 2. 서비스 계층 분리 및 아키텍처 개선 (Service & Async)
- **Command/Query 서비스 분리**: 알림 도메인 서비스를 상태를 변경하는 `NotificationCommandService`와 데이터를 조회하는 `NotificationQueryService`로 분리하여 단일 책임 원칙 준수 및 트랜잭션 관리 최적화
- **FCM 토픽 구독 비동기 처리**: 외부 FCM 서버와 통신해야 하는 토픽 구독/해제 로직을 별도의 비동기 스레드 풀 환경으로 위임하여, 메인 API의 응답 지연(Blocking) 병목 현상 방지

## 3. 엔티티 구조 개선 및 커스텀 예외 처리 (Domain & Exception)
- **`NotificationSettings` 리팩토링**: 사용자 알림 설정 엔티티의 데이터 구조를 개선하고 불필요한 컬럼 설정을 수정하여 확장성 확보
- **신규 커스텀 예외 및 ErrorCode 추가**:
  - 알림 발송 시 사용자의 FCM 토큰이 존재하지 않을 때 발생하는 예외(`FCMNotFoundException`) 추가
  - 이미 존재하는 리소스에 대한 중복 생성 요청 방지를 위한 예외(`ExistsResourceException`) 및 ErrorCode 규격 추가


# 📸 테스트 시나리오 (Test Scenarios)

## 1. 알림 설정 조회

- **Method**: GET
- **URL**: `/api/notifications`
- **Content-Type**: `application/json`
- **Header**: `Authorization: Bearer <Access-Token>`

### ✅ 1-1 : 정상적인 알림 설정 조회 성공

**Request Body**

```
// GET 요청이므로 Body 없음
```

**Response (200 OK)**

```json
{
  "is_push_agreed": true,
  "notification_options": [
    {
      "prefix": "ACT",
      "options": [
        {
          "option_code": "ACT_001",
          "enabled": true
        },
        {
          "option_code": "ACT_002",
          "enabled": true
        }
      ]
    },
    {
      "prefix": "MKT",
      "options": [
        {
          "option_code": "MKT_001",
          "enabled": false
        }
      ]
    },
    {
      "prefix": "SYS",
      "options": [
        {
          "option_code": "SYS_001",
          "enabled": true
        }
      ]
    }
  ]
}
```

---

## 2. 전체 알림 설정 수정

- **Method**: PATCH
- **URL**: `/api/notifications/options/global`
- **Content-Type**: `application/json`
- **Header**: `Authorization: Bearer <Access-Token>`

### ✅ 2-1 : 전체 알림 설정 업데이트 성공

**Request Body**

```json
{
  "is_push_agreed": true,
  "fcm_token": "cl_F2mq6TT2Z5MjOwzztln:APA91bHhGMd-oGW-Q5J8QyquF9Ha_3cDfwaIdwnwNmOy_IrQXUKHSI6XEVGGa_Z0PBXhumzbGMJfyj3FU0FLTJhND8umfZuvsWJVO6pg_t5RQGVtDPJd1UY"
}
```

**Response (200 OK)**

```json
{}
```

---

## 3. 세부 알림 설정 수정

- **Method**: PATCH
- **URL**: `/api/notifications/options`
- **Content-Type**: `application/json`
- **Header**: `Authorization: Bearer <Access-Token>`

### ✅ 3-1 : 세부 알림 옵션 업데이트 성공

**Request Body**

```json
{
  "option_code": "MKT_001",
  "enabled": false
}
```

**Response (200 OK)**

```json
{}
```

### ❌ 3-2 : 잘못된 알림 코드로 요청 (실패 케이스)

**Request Body**

```json
{
  "option_code": "Unknown_001",
  "enabled": false
}
```

**Response (400 Bad Request)**

```json
{
  "code": "CLIENT_001",
  "description": "잘못된 요청입니다.",
  "message": "잘못된 알림 코드입니다: Unknown_001",
  "path": "/api/notifications/options/Unknown_001",
  "timestamp": "2026-04-07T03:36:00.527737"
}
```

### ❌ 3-3 : 전체 알림이 미동의인 경우 (실패 케이스)

**Request Body**

```json
{
  "option_code": "MKT_001",
  "enabled": false
}
```

**Response (400 Bad Request)**

```json
{
    "code": "CLIENT_001",
    "description": "잘못된 요청입니다.",
    "message": "알림 수신 동의가 필요합니다.",
    "path": "/api/notifications/options/MKT_001",
    "timestamp": "2026-04-07T03:39:49.889023"
}
```

---

## 4. 알림 수신 동의

- **Method**: POST
- **URL**: `/api/notifications/agree`
- **Content-Type**: `application/json`
- **Header**: `Authorization: Bearer <Access-Token>`

### ✅ 4-1 : 알림 수신 최초 동의 성공

**Request Body**

```json
{
  "is_push_agreed": true,
  "fcm_token": "cl_F2mq6TT2Z5MjOwzztln:APA91bHhGMd-oGW-Q5J8QyquF9Ha_3cDfwaIdwnwNmOy_IrQXUKHSI6XEVGGa_Z0PBXhumzbGMJfyj3FU0FLTJhND8umfZuvsWJVO6pg_t5RQGVtDPJd1UY"
}
```

**Response (200 OK)**

```json
{}
```

---

## 5. 테스트용 공지 알림 전송

- **Method**: POST
- **URL**: `/api/admin/notice/send-push?title=테스트제목&body=테스트본문`
- **Content-Type**: `application/json`
- **Header**: `Authorization: Bearer <Access-Token>`
- **Para**:
  - `title: String`
  - `body: String`

### ✅ 5-1 : 관리자 푸시 알림 발송 성공

**Request Body**

```
// 쿼리 파라미터로 데이터 전달 (Body 없음)
```

**Response (200 OK)**

```json
{}
```

---

## 6. FCM Token 재등록

- **Method**: POST
- **URL**: `/api/notifications/fcm-token`
- **Content-Type**: `application/json`
- **Header**: `Authorization: Bearer <Access-Token>`

### ✅ 6-1 : 디바이스 FCM 토큰 갱신 성공

**Request Body**

```json
{
  "fcm_token": "cl_F2mq6TT2Z5MjOwzztln:APA91bHhGMd-oGW-Q5J8QyquF9Ha_3cDfwaIdwnwNmOy_IrQXUKHSI6XEVGGa_Z0PBXhumzbGMJfyj3FU0FLTJhND8umfZuvsWJVO6pg_t5RQGVtDPJd1UY"
}
```

**Response (200 OK)**

```json
{}
```