### PR TITLE
feat: S3 파일 인프라 구축 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,7 @@ dependencies {
     testAndDevelopmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.1'
+    id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -28,7 +28,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testAndDevelopmentOnly 'org.springframework.boot:spring-boot-docker-compose'
@@ -36,7 +36,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
@@ -72,6 +71,9 @@ dependencies {
 
     // Firebase 알림 의존성
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+    // Spring Cloud AWS Starter
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/zerock/puppyrun/common/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/zerock/puppyrun/common/auth/security/JwtAuthenticationFilter.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpMethod;
@@ -24,8 +23,7 @@ import org.zerock.puppyrun.common.auth.jwt.exception.InvalidTokenException;
 import org.zerock.puppyrun.common.auth.jwt.exception.TokenExpirationException;
 import org.zerock.puppyrun.common.exception.ErrorCode;
 import org.zerock.puppyrun.common.exception.ErrorResponse;
-import org.zerock.puppyrun.member.entity.UserRole;
-import tools.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component

--- a/src/main/java/org/zerock/puppyrun/common/config/S3Config.java
+++ b/src/main/java/org/zerock/puppyrun/common/config/S3Config.java
@@ -1,0 +1,34 @@
+package org.zerock.puppyrun.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        // 자격 증명 객체 생성
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        // S3Client 빌더 사용
+        return S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/s3/PathContext.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/PathContext.java
@@ -1,0 +1,66 @@
+package org.zerock.puppyrun.common.s3;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import org.zerock.puppyrun.common.s3.PathContext.DiaryPhotoContext;
+import org.zerock.puppyrun.common.s3.PathContext.PetProfileContext;
+import org.zerock.puppyrun.common.s3.PathContext.TrackingPhotoContext;
+import org.zerock.puppyrun.common.s3.PathContext.UserProfileContext;
+
+/**
+ * S3 이미지 업로드 시, 각 도메인별로 표준화된 저장 경로(Path)를 생성하는 인터페이스입니다.
+ */
+public sealed interface PathContext
+        permits DiaryPhotoContext, TrackingPhotoContext, PetProfileContext, UserProfileContext {
+
+    // yyyy/MM/dd 형식을 공통으로 관리합니다.
+    static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+
+    /**
+     * 도메인별 규칙에 따라 생성된 S3 디렉토리 경로(Prefix)를 반환합니다.
+     */
+    String getPath();
+
+    /**
+     * [사용자 프로필] 저장 경로 컨텍스트 경로 형식: public/users/{userId}/profile
+     */
+    record UserProfileContext(UUID userId) implements PathContext {
+        @Override
+        public String getPath() {
+            return String.format("public/users/%s/profile", userId);
+        }
+    }
+
+    /**
+     * [반려동물 프로필] 저장 경로 컨텍스트 경로 형식: public/pets/{petId}/profiles
+     */
+    record PetProfileContext(UUID petId) implements PathContext {
+        @Override
+        public String getPath() {
+            return String.format("public/pets/%s/profiles", petId);
+        }
+    }
+
+    /**
+     * [다이어리 사진] 저장 경로 컨텍스트 경로 형식: diaries/{yyyy/MM/dd}/{diaryId}
+     */
+    record DiaryPhotoContext(UUID diaryId, LocalDate date) implements PathContext {
+        @Override
+        public String getPath() {
+            String datePath = date.format(DATE_FORMATTER);
+            return String.format("diaries/%s/%s", datePath, diaryId);
+        }
+    }
+
+    /**
+     * [산책 트래킹 사진] 저장 경로 컨텍스트 경로 형식: tracking/{yyyy/MM/dd}/{trackingId}
+     */
+    record TrackingPhotoContext(UUID trackingId, LocalDate date) implements PathContext {
+        @Override
+        public String getPath() {
+            String datePath = date.format(DATE_FORMATTER);
+            return String.format("tracking/%s/%s", datePath, trackingId);
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/s3/S3Service.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/S3Service.java
@@ -1,0 +1,123 @@
+package org.zerock.puppyrun.common.s3;
+
+import io.awspring.cloud.s3.ObjectMetadata;
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.zerock.puppyrun.common.exception.DataIntegrityException;
+import org.zerock.puppyrun.common.s3.rollback.S3UploadRollback;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Template s3Template;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${spring.profiles.active:local}")
+    private String activeProfile;
+
+    /**
+     * 파일 업로드
+     */
+    @S3UploadRollback
+    public String upload(MultipartFile file, PathContext path) {
+        validateFile(file);
+
+        // Key만 추출
+        String key = generateKey(file, path);
+
+        // 업로드 실행
+        return uploadToS3(file, key);
+    }
+
+    /**
+     * 파일 삭제
+     *
+     * @param fileData DB에 저장된 Key 또는 만약의 경우를 대비한 Full URL
+     */
+    @Async
+    public void delete(String fileData) {
+        if (fileData == null || fileData.isBlank()) {
+            log.warn("삭제하려는 S3 파일 경로가 비어있습니다.");
+            return;
+        }
+
+        // URL이 들어와도, Key가 들어와도 안전하게 Key만 추출
+        String key = extractKey(fileData);
+
+        try {
+            if (!s3Template.objectExists(bucket, key)) {
+                log.warn("삭제 시도 실패: S3에 파일이 존재하지 않습니다. Key: {}", key);
+                return;
+            }
+
+            s3Template.deleteObject(bucket, key);
+            log.info("S3 파일 삭제 성공: {}", key);
+
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 중 오류 발생 - Key: {}, 메시지: {}", key, e.getMessage());
+        }
+    }
+
+    private String uploadToS3(MultipartFile file, String key) {
+        try (InputStream inputStream = file.getInputStream()) {
+            ObjectMetadata metadata = ObjectMetadata.builder()
+                    .contentType(file.getContentType())
+                    .build();
+
+            // S3Template으로 업로드
+            s3Template.upload(bucket, key, inputStream, metadata);
+
+            log.info("S3 파일 업로드 성공 (Key): {}", key);
+            return key;
+
+        } catch (IOException e) {
+            log.error("S3 업로드 중 실패 - Key: {}, 에러: {}", key, e.getMessage());
+            throw new RuntimeException("S3 업로드 중 오류 발생", e);
+        }
+    }
+
+    private String generateKey(MultipartFile file, PathContext path) {
+        String folderPath = path.getPath();
+        String originalName = file.getOriginalFilename();
+
+        String savedName = UUID.randomUUID() + "_" +
+                (originalName != null ? originalName.replaceAll("\\s", "_") : "unnamed");
+
+        return String.format("%s/%s/%s", activeProfile, folderPath, savedName);
+    }
+
+    private String extractKey(String fileData) {
+        try {
+            // URL 형태라면 Key 부분만 잘라냄
+            if (fileData.contains(bucket)) {
+                String key = fileData.substring(fileData.lastIndexOf(bucket) + bucket.length() + 1);
+                return URLDecoder.decode(key, StandardCharsets.UTF_8);
+            }
+            // 이미 Key 형태라면 디코딩만 수행
+            return URLDecoder.decode(fileData, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return fileData;
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new DataIntegrityException("업로드할 파일이 비어있습니다.");
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/s3/rollback/S3RollbackAspect.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/rollback/S3RollbackAspect.java
@@ -1,0 +1,30 @@
+package org.zerock.puppyrun.common.s3.rollback;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.zerock.puppyrun.common.s3.S3Service;
+import org.zerock.puppyrun.common.s3.rollback.S3UploadRollback.S3RollbackEvent;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class S3RollbackAspect {
+
+    private final ApplicationEventPublisher eventPublisher;
+    private final S3Service s3Service;
+
+
+    // @S3Rollback 어노테이션이 붙은 메서드의 실행 결과(URL)를 감시합니다.
+    @AfterReturning(pointcut = "@annotation(org.zerock.puppyrun.common.s3.rollback.S3UploadRollback)", returning = "url")
+    public void afterS3Upload(Object url) {
+        if (url instanceof String s3Url) {
+            // 메서드가 성공적으로 URL을 반환하면, 자동으로 이벤트를 발행합니다.
+            eventPublisher.publishEvent(new S3RollbackEvent(s3Url));
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/s3/rollback/S3RollbackHandler.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/rollback/S3RollbackHandler.java
@@ -1,0 +1,23 @@
+package org.zerock.puppyrun.common.s3.rollback;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.zerock.puppyrun.common.s3.S3Service;
+import org.zerock.puppyrun.common.s3.rollback.S3UploadRollback.S3RollbackEvent;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class S3RollbackHandler {
+    private final S3Service s3Service;
+
+    // phase = AFTER_ROLLBACK: DB 트랜잭션이 최종적으로 실패했을 때만 실행
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+    public void handleRollback(S3RollbackEvent event) {
+        log.warn("DB 저장 트랜잭션 실패로 인해 S3 파일을 롤백합니다: {}", event.filePath());
+        s3Service.delete(event.filePath());
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/s3/rollback/S3UploadRollback.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/rollback/S3UploadRollback.java
@@ -1,0 +1,13 @@
+package org.zerock.puppyrun.common.s3.rollback;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface S3UploadRollback {
+    public record S3RollbackEvent(String filePath) {
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/s3/support/S3Serializer.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/support/S3Serializer.java
@@ -1,0 +1,29 @@
+package org.zerock.puppyrun.common.s3.support;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class S3Serializer extends JsonSerializer<String> {
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Override
+    public void serialize(String value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (value != null && !value.isBlank() && !value.startsWith("http")) {
+            String fullUrl = String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, value);
+            gen.writeString(fullUrl);
+        } else {
+            gen.writeString(value);
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/s3/support/S3Url.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/support/S3Url.java
@@ -1,0 +1,15 @@
+package org.zerock.puppyrun.common.s3.support;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.RECORD_COMPONENT})
+@JacksonAnnotationsInside
+@JsonSerialize(using = S3Serializer.class)
+public @interface S3Url {
+}

--- a/src/main/java/org/zerock/puppyrun/pet/controller/PetController.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/PetController.java
@@ -1,7 +1,6 @@
 package org.zerock.puppyrun.pet.controller;
 
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +12,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.pet.controller.request.RegisterPetRequest;
 import org.zerock.puppyrun.pet.controller.request.UpdatePetRequest;
@@ -78,6 +79,31 @@ public class PetController {
             @RequestBody @Valid UpdatePetRequest request
     ) {
         PetUpdateResponse response = petCommandService.updatePet(userPrincipal, petId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 펫 프로필 이미지 수정
+     */
+    @PutMapping("/{petId}/profile")
+    public ResponseEntity<PetUpdateResponse> updatePetProfile(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @RequestPart MultipartFile profile
+    ) {
+        PetUpdateResponse response = petCommandService.updatePetProfile(userPrincipal, petId, profile);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 펫 프로필 이미지 수정
+     */
+    @PutMapping("/{petId}/profile/default")
+    public ResponseEntity<PetUpdateResponse> setPetDefaultProfile(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId
+    ) {
+        PetUpdateResponse response = petCommandService.setDefaultProfile(userPrincipal, petId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetListResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetListResponse.java
@@ -30,7 +30,9 @@ public record PetListResponse(
             String color,
             String profileImageUrl,
             String breedCode,
-            String badgeCode
+            String badgeCode,
+            String gender,
+            boolean isNeutered
     ) {
         public static PetSummary from(Pet pet) {
             return PetSummary.builder()
@@ -42,6 +44,8 @@ public record PetListResponse(
                     .profileImageUrl(pet.getProfileImageUrl())
                     .breedCode(pet.getBreed().getCode())
                     .badgeCode(pet.getBadge().getCode())
+                    .gender(pet.getGender())
+                    .isNeutered(pet.getIsNeutered())
                     .build();
         }
 

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetUpdateResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetUpdateResponse.java
@@ -2,6 +2,7 @@ package org.zerock.puppyrun.pet.controller.response;
 
 import java.time.LocalDate;
 import lombok.Builder;
+import org.zerock.puppyrun.common.s3.support.S3Url;
 import org.zerock.puppyrun.pet.entity.Pet;
 
 @Builder
@@ -18,6 +19,7 @@ public record PetUpdateResponse(
 
         String gender,
 
+        @S3Url
         String profileImageUrl
 ) {
     public static PetUpdateResponse of(Pet pet) {

--- a/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
+++ b/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
@@ -39,7 +39,7 @@ public class Pet extends BaseTimeEntity {
     @Column(name = "breed")
     private Breed breed;
 
-    @Column(name = "profile_image_url")
+    @Column(name = "profile_image_url", length = 1000)
     private String profileImageUrl;
 
     @Column(name = "color")

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetCommandService.java
@@ -5,6 +5,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.zerock.puppyrun.common.s3.PathContext.PetProfileContext;
+import org.zerock.puppyrun.common.s3.S3Service;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.member.repository.MemberRepository;
@@ -26,6 +29,8 @@ public class PetCommandService {
     private final PetRepository petRepository;
     private final MemberRepository memberRepository;
     private final PetStatistics petStatistics;
+
+    private final S3Service s3Service;
 
     /**
      * 새로운 펫을 등록합니다.
@@ -79,6 +84,26 @@ public class PetCommandService {
         // 현재 몸무게와 비교 후 저장
         petStatistics.savePetWeightLog(pet, request.weight());
 
+        return PetUpdateResponse.of(pet);
+    }
+
+
+    public PetUpdateResponse updatePetProfile(UserPrincipal userPrincipal, UUID petId, MultipartFile file) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+
+        String profilePath = s3Service.upload(file, new PetProfileContext(petId));
+        pet.updateProfile(profilePath);
+        return PetUpdateResponse.of(pet);
+    }
+
+
+    public PetUpdateResponse setDefaultProfile(UserPrincipal userPrincipal, UUID petId) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        String profileUrl = pet.getProfileImageUrl();
+        pet.setDefaultProfile();
+
+        // todo: 추후 배치를 통한 고아 객체 제거 예정
+        s3Service.delete(profileUrl);
         return PetUpdateResponse.of(pet);
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,3 +6,16 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_TOKEN_VALIDITY:900000}    # 15분 (900밀리초)
   refresh-token-expiration: ${JWT_REFRESH_TOKEN_VALIDITY:1209600000} # 14일 (1209600밀리초)
+
+spring:
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
+      region:
+        static: ${AWS_REGION}
+      s3:
+        bucket: ${AWS_S3_BUCKET_NAME}
+      stack:
+        auto: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,3 +6,16 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_TOKEN_VALIDITY:900000}    # 15분 (900밀리초)
   refresh-token-expiration: ${JWT_REFRESH_TOKEN_VALIDITY:1209600000} # 14일 (1209600밀리초)
+
+spring:
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
+      region:
+        static: ${AWS_REGION}
+      s3:
+        bucket: ${AWS_S3_BUCKET_NAME}
+      stack:
+        auto: false

--- a/src/test/java/org/zerock/puppyrun/discordNotice/DiscordNotificationTest.java
+++ b/src/test/java/org/zerock/puppyrun/discordNotice/DiscordNotificationTest.java
@@ -1,32 +1,71 @@
 package org.zerock.puppyrun.discordNotice;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles("test")
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class DiscordNotificationTest {
 
-    // 로그백 로거 설정
-    private static final Logger log = LoggerFactory.getLogger(DiscordNotificationTest.class);
+    // 테스트 대상이 되는 Logger 객체를 가져옵니다.
+    private final Logger testLogger = (Logger) LoggerFactory.getLogger(DiscordNotificationTest.class);
+
+    // 로그 이벤트를 메모리에 저장할 가짜 Appender(ListAppender)를 선언합니다.
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUp() {
+        // 각 테스트 실행 전에 ListAppender를 생성하고 시작합니다.
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        // 실제 로거에 가짜 Appender를 붙여 로그 이벤트를 가로챌 준비를 합니다.
+        testLogger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 테스트 종료 후에는 로거에서 Appender를 분리하여 다른 테스트에 영향을 주지 않도록 합니다.
+        testLogger.detachAppender(listAppender);
+    }
 
     @Test
-    @DisplayName("디스코드 에러 알림 전송 테스트")
-    void discordAlarmTest() throws InterruptedException {
-        // ERROR 레벨 로그 기록
-        log.error("🚨 [Test] 디스코드 알림 테스트 메시지입니다.");
-        log.error("사유: 시스템 테스트 중 강제 에러 발생");
-
-        // 예외 객체를 포함한 로그 테스트 (스택 트레이스 확인)
+    @DisplayName("ERROR 레벨 로그가 정상적으로 기록되는지 유닛 테스트")
+    void discordAlarmUnitTest() {
+        // given
+        String errorMessage = "디스코드 알림 테스트 메시지입니다.";
         RuntimeException dummyException = new RuntimeException("테스트용 예외 발생!");
-        log.error("🚨 [Test] 예외 포함 알림 테스트", dummyException);
+        String exceptionLogMessage = "예외 포함 알림 테스트";
 
-        // 전송되기 전에 테스트가 종료될 수 있으므로 잠시 대기
-        System.out.println("디스코드로 로그를 전송 중입니다... 채널을 확인하세요.");
-        Thread.sleep(5000);
+        // when
+        // 실제 로직처럼 log.error()를 호출합니다.
+        testLogger.error(errorMessage);
+        testLogger.error(exceptionLogMessage, dummyException);
+
+        // then
+        // ListAppender에 기록된 모든 로그 이벤트를 가져옵니다.
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        // 1. 총 2개의 ERROR 로그가 기록되었는지 확인합니다.
+        assertThat(logsList).hasSize(2);
+
+        // 2. 첫 번째 로그의 레벨과 메시지를 검증합니다.
+        ILoggingEvent firstLog = logsList.getFirst();
+        assertThat(firstLog.getLevel().toString()).isEqualTo("ERROR");
+        assertThat(firstLog.getFormattedMessage()).isEqualTo(errorMessage);
+        assertThat(firstLog.getThrowableProxy()).isNull(); // 예외가 없어야 함
+
+        // 3. 두 번째 로그에 예외 정보가 포함되었는지 검증합니다.
+        ILoggingEvent secondLog = logsList.get(1);
+        assertThat(secondLog.getLevel().toString()).isEqualTo("ERROR");
+        assertThat(secondLog.getFormattedMessage()).isEqualTo(exceptionLogMessage);
+        assertThat(secondLog.getThrowableProxy()).isNotNull(); // 예외가 있어야 함
+        assertThat(secondLog.getThrowableProxy().getMessage()).isEqualTo(dummyException.getMessage());
     }
 }

--- a/src/test/java/org/zerock/puppyrun/s3/PetCommandServiceRollbackTest.java
+++ b/src/test/java/org/zerock/puppyrun/s3/PetCommandServiceRollbackTest.java
@@ -1,0 +1,81 @@
+package org.zerock.puppyrun.s3;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.awspring.cloud.s3.S3Template;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.common.s3.S3Service;
+import org.zerock.puppyrun.member.entity.UserRole;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+import org.zerock.puppyrun.pet.service.PetCommandService;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PetCommandServiceRollbackTest {
+
+    @Autowired
+    private PetCommandService petCommandService;
+
+    // 실제 AOP 로직을 타야 하므로 @SpyBean 사용 (호출 여부 검증용)
+    @SpyBean
+    private S3Service s3Service;
+
+    // 실제 AWS S3에 파일이 올라가거나 삭제되지 않도록 S3Template은 Mock 처리
+    @MockBean
+    private S3Template s3Template;
+
+    // 예외를 강제로 발생시키기 위해 Repository를 Mock 처리
+    @MockBean
+    private PetRepository petRepository;
+
+    @Test
+    @DisplayName("S3 이미지 업로드 후, DB 업데이트 중 예외가 발생하면 트랜잭션이 롤백되고 S3 삭제 로직이 실행되어야 한다.")
+    void s3UploadRollbackTest() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        UUID petId = UUID.randomUUID();
+        UserPrincipal userPrincipal = new UserPrincipal(memberId, "test@test.com", UserRole.USER);
+
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file", "test.jpg", "image/jpeg", "image data".getBytes()
+        );
+
+        // Pet 객체 Mocking
+        Pet mockPet = mock(Pet.class);
+        when(petRepository.findByIdAndVerifyOwnership(petId, memberId)).thenReturn(mockPet);
+
+        // S3Template의 실제 업로드 기능 비활성화 (아무 동작도 하지 않음)
+        when(s3Template.upload(any(), any(), any(), any())).thenReturn(null);
+
+        // S3 업로드는 성공했지만, 그 직후 DB 정보 업데이트 과정에서 강제로 예외 발생 유도
+        doThrow(new RuntimeException("강제 롤백 유발"))
+                .when(mockPet).updateProfile(anyString());
+
+        // when & then
+        // 예외가 정상적으로 던져지는지 검증
+        assertThatThrownBy(() -> petCommandService.updatePetProfile(userPrincipal, petId, mockFile))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("강제 롤백 유발");
+
+        // 트랜잭션 롤백에 의해 S3RollbackHandler가 동작하여 s3Service.delete()를 호출했는지 검증
+        // 업로드 시 생성된 정확한 Key 경로로 1회 호출되어야 함
+        verify(s3Service, times(1)).delete(anyString());
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/weather/WeatherServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/weather/WeatherServiceTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean; // 변경된 import
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.CacheManager;
@@ -42,11 +42,11 @@ class WeatherServiceTest {
     private CacheManager cacheManager;
 
     // 외부 API 호출을 흉내 낼 Mock 객체
-    @MockitoBean
+    @MockBean
     private WeatherApiClient weatherApiClient;
 
     // 응답 변환을 흉내 낼 Mock 객체
-    @MockitoBean
+    @MockBean
     private WeatherMapper weatherMapper;
 
     private WeatherDTO mockWeatherDTO;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -23,6 +23,18 @@ spring:
   jackson:
     property-naming-strategy: SNAKE_CASE
 
+  cloud:
+    aws:
+      credentials:
+        access-key: AWS_ACCESS_KEY_ID
+        secret-key: AWS_SECRET_ACCESS_KEY
+      region:
+        static: AWS_REGION
+      s3:
+        bucket: AWS_S3_BUCKET_NAME
+      stack:
+        auto: false
+
 app:
   base-url: http://localhost:8080
 
@@ -43,3 +55,5 @@ logging:
     root: INFO
     com.puppyrun: DEBUG
     org.hibernate: WARN
+
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -29,7 +29,7 @@ spring:
         access-key: AWS_ACCESS_KEY_ID
         secret-key: AWS_SECRET_ACCESS_KEY
       region:
-        static: AWS_REGION
+        static: aws-global
       s3:
         bucket: AWS_S3_BUCKET_NAME
       stack:


### PR DESCRIPTION
# 📌 Pull Request: [#33] S3 파일 관리 인프라 구축 

# 📝 작업 요약 (Summary)

- 이번 PR은 **AWS S3를 연동한 파일 업로드 인프라 구축(#33)**   과 이를 활용한 **강아지 프로필 이미지 관리 기능(#9)** 도입을 핵심으로 합니다.

단순한 파일 업로드를 넘어, 타입 안전한 S3 경로 관리(PathContext), DB 트랜잭션과 연동된 S3 업로드 롤백 기능, 어노테이션 기반의 S3 URL 자동 변환 로직 등을 도입하여 업로드 인프라의 안정성과 편의성을 대폭 강화했습니다. 또한, 통합 테스트 환경을 격리하여 외부 의존성 없이 안정적인 테스트가 가능하도록 개선했습니다.

<br>

# 🛠️ 변경 사항 (Changes)

## 1. 안정적인 S3 파일 업로드 인프라 구축 (#33)

AWS S3 연동을 위한 기본 설정과 함께, 시스템의 안정성과 유지보수성을 높이기 위한 고도화된 기능을 구현했습니다.

- **트랜잭션 동기화 롤백 (Compensating Transaction)**
  - **문제점**: 파일 업로드(S3) 성공 후 DB 저장(JPA) 과정에서 예외가 발생하면, S3에만 파일이 남는 '고아 파일(Orphaned File)' 문제가 발생합니다.
  - **해결**: AOP와 Spring Event를 활용하여 DB 트랜잭션이 롤백될 때 S3 파일을 자동으로 삭제하는 보상 트랜잭션 기능을 구현했습니다.
    - `@S3UploadRollback`: S3 업로드 메서드에 부착하는 커스텀 어노테이션입니다.
    - `S3RollbackAspect`: `@AfterReturning`을 통해 파일 업로드 성공 시 `S3RollbackEvent`를 발행합니다.
    - `S3RollbackHandler`: `@TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)`을 통해 DB 트랜잭션이 **최종 롤백될 때만** 이벤트를 수신하여 `s3Service.delete()`를 호출합니다.

- **타입-세이프 경로 관리 (`PathContext`)**
  - **문제점**: `String.format("pets/%s/profile", petId)`와 같이 문자열을 직접 조합하여 S3 경로를 생성하면 오타에 취약하고 경로 규칙을 파악하기 어렵습니다.
  - **해결**: `sealed interface PathContext`를 도입하여 도메인별 경로 생성 로직을 표준화하고 캡슐화했습니다.
    - `PetProfileContext`, `DiaryPhotoContext` 등 `record` 구현체를 통해 컴파일 시점에 경로 타입을 검증하고, `new PetProfileContext(petId)`와 같이 명시적으로 경로를 생성하여 코드 가독성과 안정성을 높였습니다.

- **비동기 삭제 및 환경 분리**
  - `S3Service.delete()` 메서드를 `@Async`로 처리하여, 외부 I/O 작업으로 인한 서버 응답 지연을 방지했습니다.
  - S3에 파일을 저장할 때 `local/`, `prod/`와 같이 실행 환경(Profile)에 따라 경로를 분리하여 개발/운영 환경의 데이터가 섞이지 않도록 격리했습니다.

## 2. 강아지 프로필 이미지 관리 기능 (#9)

구축된 S3 인프라를 활용하여 사용자가 강아지 프로필 이미지를 관리할 수 있는 기능을 추가했습니다.

- **API 엔드포인트 추가 (`PetController`)**
  - `PUT /api/pets/{petId}/profile`: 프로필 이미지를 업로드하고 변경합니다.
  - `PUT /api/pets/{petId}/profile/default`: 기존 이미지를 S3에서 삭제하고 DB를 `null`로 업데이트하여 기본 이미지로 되돌립니다.

- **S3 URL 자동 변환 (`@S3Url`)**
  - **문제점**: DB에는 `prod/pets/{id}/image.jpg`와 같은 S3 Key 값만 저장되므로, API 응답 시 클라이언트가 바로 사용 가능한 전체 URL(`https://...`)로 변환해주는 로직이 반복적으로 필요합니다.
  - **해결**: `@S3Url` 커스텀 어노테이션과 `JsonSerializer`를 구현했습니다. 응답 DTO의 이미지 필드에 `@S3Url`만 붙여주면, JSON 직렬화 과정에서 자동으로 전체 URL로 변환되어 코드 중복을 제거하고 편의성을 높였습니다.

## 3. 테스트 환경 개선

- **통합 테스트 환경 격리**
  - `@MockBean`을 활용하여 `S3Template`, `DiscordApiClient` 등 외부 API 의존성을 Mocking 처리하여, 네트워크 통신 없이 안정적이고 빠른 테스트가 가능하도록 구성했습니다.
  - **S3 롤백 시나리오 테스트**: `PetCommandServiceRollbackTest`를 통해 DB 롤백 시 S3 파일 삭제 로직이 정상 동작하는지 검증하는 통합 테스트를 추가했습니다.


