### PR TITLE
Bogyeom/feat/care tab

### DIFF
--- a/src/main/java/org/zerock/puppyrun/care/controller/AllergyController.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/AllergyController.java
@@ -1,0 +1,76 @@
+package org.zerock.puppyrun.care.controller;
+
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.zerock.puppyrun.care.controller.request.RegisterAllergyRequest;
+import org.zerock.puppyrun.care.controller.request.UpdateAllergyRequest;
+import org.zerock.puppyrun.care.controller.response.AllergyListResponse;
+import org.zerock.puppyrun.care.controller.response.AllergyRecordResponse;
+import org.zerock.puppyrun.care.service.AllergyCommandService;
+import org.zerock.puppyrun.care.service.AllergyQueryService;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+
+@RestController
+@RequestMapping("/api/pets/{petId}/allergies")
+@RequiredArgsConstructor
+public class AllergyController {
+
+    private final AllergyCommandService allergyCommandService;
+    private final AllergyQueryService allergyQueryService;
+
+    @PostMapping
+    public ResponseEntity<AllergyRecordResponse> registerAllergy(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @RequestBody @Valid RegisterAllergyRequest request
+    ) {
+        AllergyRecordResponse response = allergyCommandService.registerAllergy(userPrincipal, petId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<AllergyListResponse> getAllergyList(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId
+    ) {
+        AllergyListResponse response = allergyQueryService.getAllergyList(userPrincipal, petId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{allergyId}")
+    public ResponseEntity<AllergyRecordResponse> updateAllergy(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @PathVariable UUID allergyId,
+            @RequestBody @Valid UpdateAllergyRequest request
+    ) {
+        AllergyRecordResponse response = allergyCommandService.updateAllergy(
+                userPrincipal,
+                petId,
+                allergyId,
+                request
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{allergyId}")
+    public ResponseEntity<Void> deleteAllergy(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @PathVariable UUID allergyId
+    ) {
+        allergyCommandService.deleteAllergy(userPrincipal, petId, allergyId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/CareCalendarController.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/CareCalendarController.java
@@ -1,0 +1,35 @@
+package org.zerock.puppyrun.care.controller;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.zerock.puppyrun.care.controller.response.CareCalendarResponse;
+import org.zerock.puppyrun.care.service.CareCalendarQueryService;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+
+@RestController
+@RequestMapping("/api/pets/{petId}/care-calendar")
+@RequiredArgsConstructor
+public class CareCalendarController {
+
+    private final CareCalendarQueryService careCalendarQueryService;
+
+    @GetMapping
+    public ResponseEntity<CareCalendarResponse> getCareCalendar(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        CareCalendarResponse response = careCalendarQueryService.getCareCalendar(userPrincipal, petId, startDate, endDate);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/MedicationController.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/MedicationController.java
@@ -1,0 +1,76 @@
+package org.zerock.puppyrun.care.controller;
+
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.zerock.puppyrun.care.controller.request.RegisterMedicationRequest;
+import org.zerock.puppyrun.care.controller.request.UpdateMedicationRequest;
+import org.zerock.puppyrun.care.controller.response.MedicationListResponse;
+import org.zerock.puppyrun.care.controller.response.MedicationRecordResponse;
+import org.zerock.puppyrun.care.service.MedicationCommandService;
+import org.zerock.puppyrun.care.service.MedicationQueryService;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+
+@RestController
+@RequestMapping("/api/pets/{petId}/medication-logs")
+@RequiredArgsConstructor
+public class MedicationController {
+
+    private final MedicationCommandService medicationCommandService;
+    private final MedicationQueryService medicationQueryService;
+
+    @PostMapping
+    public ResponseEntity<MedicationRecordResponse> registerMedication(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @RequestBody @Valid RegisterMedicationRequest request
+    ) {
+        MedicationRecordResponse response = medicationCommandService.registerMedication(userPrincipal, petId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<MedicationListResponse> getMedicationList(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId
+    ) {
+        MedicationListResponse response = medicationQueryService.getMedicationList(userPrincipal, petId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{medicationLogId}")
+    public ResponseEntity<MedicationRecordResponse> updateMedication(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @PathVariable UUID medicationLogId,
+            @RequestBody @Valid UpdateMedicationRequest request
+    ) {
+        MedicationRecordResponse response = medicationCommandService.updateMedication(
+                userPrincipal,
+                petId,
+                medicationLogId,
+                request
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{medicationLogId}")
+    public ResponseEntity<Void> deleteMedication(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @PathVariable UUID medicationLogId
+    ) {
+        medicationCommandService.deleteMedication(userPrincipal, petId, medicationLogId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/VaccinationController.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/VaccinationController.java
@@ -1,0 +1,76 @@
+package org.zerock.puppyrun.care.controller;
+
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.zerock.puppyrun.care.controller.request.RegisterVaccinationRequest;
+import org.zerock.puppyrun.care.controller.request.UpdateVaccinationRequest;
+import org.zerock.puppyrun.care.controller.response.VaccinationListResponse;
+import org.zerock.puppyrun.care.controller.response.VaccinationRecordResponse;
+import org.zerock.puppyrun.care.service.VaccinationCommandService;
+import org.zerock.puppyrun.care.service.VaccinationQueryService;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+
+@RestController
+@RequestMapping("/api/pets/{petId}/vaccinations")
+@RequiredArgsConstructor
+public class VaccinationController {
+
+    private final VaccinationCommandService vaccinationCommandService;
+    private final VaccinationQueryService vaccinationQueryService;
+
+    @PostMapping
+    public ResponseEntity<VaccinationRecordResponse> registerVaccination(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @RequestBody @Valid RegisterVaccinationRequest request
+    ) {
+        VaccinationRecordResponse response = vaccinationCommandService.registerVaccination(userPrincipal, petId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<VaccinationListResponse> getVaccinationList(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId
+    ) {
+        VaccinationListResponse response = vaccinationQueryService.getVaccinationList(userPrincipal, petId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{vaccinationId}")
+    public ResponseEntity<VaccinationRecordResponse> updateVaccination(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @PathVariable UUID vaccinationId,
+            @RequestBody @Valid UpdateVaccinationRequest request
+    ) {
+        VaccinationRecordResponse response = vaccinationCommandService.updateVaccination(
+                userPrincipal,
+                petId,
+                vaccinationId,
+                request
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{vaccinationId}")
+    public ResponseEntity<Void> deleteVaccination(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @PathVariable UUID vaccinationId
+    ) {
+        vaccinationCommandService.deleteVaccination(userPrincipal, petId, vaccinationId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/request/RegisterAllergyRequest.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/request/RegisterAllergyRequest.java
@@ -1,0 +1,25 @@
+package org.zerock.puppyrun.care.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record RegisterAllergyRequest(
+        @NotBlank(message = "알러지 원인명은 필수입니다.")
+        @Size(max = 100, message = "알러지 원인명은 100자를 초과할 수 없습니다.")
+        String allergenName,
+
+        @Size(max = 255, message = "증상은 255자를 초과할 수 없습니다.")
+        String symptom,
+
+        String severity,
+
+        LocalDate identifiedAt,
+
+        @NotNull(message = "활성 여부는 필수입니다.")
+        Boolean isActive,
+
+        String memo
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/request/RegisterMedicationRequest.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/request/RegisterMedicationRequest.java
@@ -1,0 +1,27 @@
+package org.zerock.puppyrun.care.controller.request;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public record RegisterMedicationRequest(
+        @NotBlank(message = "약 이름은 필수입니다.")
+        @Size(max = 100, message = "약 이름은 100자를 초과할 수 없습니다.")
+        String medicationName,
+
+        @NotNull(message = "투약 시각은 필수입니다.")
+        LocalDateTime administeredAt,
+
+        @NotNull(message = "투약량은 필수입니다.")
+        @DecimalMin(value = "0.0", inclusive = false, message = "투약량은 0보다 커야 합니다.")
+        Double doseAmount,
+
+        @NotBlank(message = "투약 단위는 필수입니다.")
+        @Size(max = 30, message = "투약 단위는 30자를 초과할 수 없습니다.")
+        String doseUnit,
+
+        String memo
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/request/RegisterVaccinationRequest.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/request/RegisterVaccinationRequest.java
@@ -1,0 +1,23 @@
+package org.zerock.puppyrun.care.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record RegisterVaccinationRequest(
+        @NotBlank(message = "접종명은 필수입니다.")
+        @Size(max = 100, message = "접종명은 100자를 초과할 수 없습니다.")
+        String vaccineName,
+
+        @NotNull(message = "접종일은 필수입니다.")
+        LocalDate vaccinatedAt,
+
+        LocalDate nextVaccinationDate,
+
+        @Size(max = 100, message = "병원명은 100자를 초과할 수 없습니다.")
+        String hospitalName,
+
+        String memo
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/request/UpdateAllergyRequest.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/request/UpdateAllergyRequest.java
@@ -1,0 +1,25 @@
+package org.zerock.puppyrun.care.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record UpdateAllergyRequest(
+        @NotBlank(message = "알러지 원인명은 필수입니다.")
+        @Size(max = 100, message = "알러지 원인명은 100자를 초과할 수 없습니다.")
+        String allergenName,
+
+        @Size(max = 255, message = "증상은 255자를 초과할 수 없습니다.")
+        String symptom,
+
+        String severity,
+
+        LocalDate identifiedAt,
+
+        @NotNull(message = "활성 여부는 필수입니다.")
+        Boolean isActive,
+
+        String memo
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/request/UpdateMedicationRequest.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/request/UpdateMedicationRequest.java
@@ -1,0 +1,27 @@
+package org.zerock.puppyrun.care.controller.request;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public record UpdateMedicationRequest(
+        @NotBlank(message = "약 이름은 필수입니다.")
+        @Size(max = 100, message = "약 이름은 100자를 초과할 수 없습니다.")
+        String medicationName,
+
+        @NotNull(message = "투약 시각은 필수입니다.")
+        LocalDateTime administeredAt,
+
+        @NotNull(message = "투약량은 필수입니다.")
+        @DecimalMin(value = "0.0", inclusive = false, message = "투약량은 0보다 커야 합니다.")
+        Double doseAmount,
+
+        @NotBlank(message = "투약 단위는 필수입니다.")
+        @Size(max = 30, message = "투약 단위는 30자를 초과할 수 없습니다.")
+        String doseUnit,
+
+        String memo
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/request/UpdateVaccinationRequest.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/request/UpdateVaccinationRequest.java
@@ -1,0 +1,23 @@
+package org.zerock.puppyrun.care.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record UpdateVaccinationRequest(
+        @NotBlank(message = "접종명은 필수입니다.")
+        @Size(max = 100, message = "접종명은 100자를 초과할 수 없습니다.")
+        String vaccineName,
+
+        @NotNull(message = "접종일은 필수입니다.")
+        LocalDate vaccinatedAt,
+
+        LocalDate nextVaccinationDate,
+
+        @Size(max = 100, message = "병원명은 100자를 초과할 수 없습니다.")
+        String hospitalName,
+
+        String memo
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/response/AllergyListResponse.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/response/AllergyListResponse.java
@@ -1,0 +1,52 @@
+package org.zerock.puppyrun.care.controller.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.care.entity.AllergyRecord;
+import org.zerock.puppyrun.pet.entity.Pet;
+
+@Builder
+public record AllergyListResponse(
+        UUID petId,
+        int totalAllergyCount,
+        List<Allergy> allergyList
+) {
+
+    public static AllergyListResponse of(Pet pet, List<AllergyRecord> allergyRecords) {
+        List<Allergy> allergies = allergyRecords.stream()
+                .map(Allergy::from)
+                .toList();
+
+        return AllergyListResponse.builder()
+                .petId(pet.getId())
+                .totalAllergyCount(allergies.size())
+                .allergyList(allergies)
+                .build();
+    }
+
+    @Builder
+    public record Allergy(
+            UUID allergyId,
+            String allergenName,
+            String symptom,
+            String severity,
+            LocalDate identifiedAt,
+            Boolean isActive,
+            String memo
+    ) {
+
+        public static Allergy from(AllergyRecord allergyRecord) {
+            return Allergy.builder()
+                    .allergyId(allergyRecord.getId())
+                    .allergenName(allergyRecord.getAllergenName())
+                    .symptom(allergyRecord.getSymptom())
+                    .severity(allergyRecord.getSeverity() != null ? allergyRecord.getSeverity().name() : null)
+                    .identifiedAt(allergyRecord.getIdentifiedAt())
+                    .isActive(allergyRecord.getIsActive())
+                    .memo(allergyRecord.getMemo())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/response/AllergyRecordResponse.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/response/AllergyRecordResponse.java
@@ -1,0 +1,32 @@
+package org.zerock.puppyrun.care.controller.response;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.care.entity.AllergyRecord;
+
+@Builder
+public record AllergyRecordResponse(
+        UUID allergyId,
+        UUID petId,
+        String allergenName,
+        String symptom,
+        String severity,
+        LocalDate identifiedAt,
+        Boolean isActive,
+        String memo
+) {
+
+    public static AllergyRecordResponse of(AllergyRecord allergyRecord) {
+        return AllergyRecordResponse.builder()
+                .allergyId(allergyRecord.getId())
+                .petId(allergyRecord.getPet().getId())
+                .allergenName(allergyRecord.getAllergenName())
+                .symptom(allergyRecord.getSymptom())
+                .severity(allergyRecord.getSeverity() != null ? allergyRecord.getSeverity().name() : null)
+                .identifiedAt(allergyRecord.getIdentifiedAt())
+                .isActive(allergyRecord.getIsActive())
+                .memo(allergyRecord.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/response/CareCalendarResponse.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/response/CareCalendarResponse.java
@@ -1,0 +1,38 @@
+package org.zerock.puppyrun.care.controller.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.care.entity.CareEventType;
+import org.zerock.puppyrun.pet.entity.Pet;
+
+@Builder
+public record CareCalendarResponse(
+        UUID petId,
+        LocalDate startDate,
+        LocalDate endDate,
+        int totalEventCount,
+        List<CareEvent> eventList
+) {
+
+    public static CareCalendarResponse of(Pet pet, LocalDate startDate, LocalDate endDate, List<CareEvent> events) {
+        return CareCalendarResponse.builder()
+                .petId(pet.getId())
+                .startDate(startDate)
+                .endDate(endDate)
+                .totalEventCount(events.size())
+                .eventList(events)
+                .build();
+    }
+
+    @Builder
+    public record CareEvent(
+            LocalDate date,
+            CareEventType eventType,
+            String title,
+            UUID relatedId,
+            String displayText
+    ) {
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/response/MedicationListResponse.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/response/MedicationListResponse.java
@@ -1,0 +1,50 @@
+package org.zerock.puppyrun.care.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.care.entity.MedicationRecord;
+import org.zerock.puppyrun.pet.entity.Pet;
+
+@Builder
+public record MedicationListResponse(
+        UUID petId,
+        int totalMedicationCount,
+        List<MedicationLog> medicationLogList
+) {
+
+    public static MedicationListResponse of(Pet pet, List<MedicationRecord> medicationRecords) {
+        List<MedicationLog> medicationLogs = medicationRecords.stream()
+                .map(MedicationLog::from)
+                .toList();
+
+        return MedicationListResponse.builder()
+                .petId(pet.getId())
+                .totalMedicationCount(medicationLogs.size())
+                .medicationLogList(medicationLogs)
+                .build();
+    }
+
+    @Builder
+    public record MedicationLog(
+            UUID medicationLogId,
+            String medicationName,
+            LocalDateTime administeredAt,
+            Double doseAmount,
+            String doseUnit,
+            String memo
+    ) {
+
+        public static MedicationLog from(MedicationRecord medicationRecord) {
+            return MedicationLog.builder()
+                    .medicationLogId(medicationRecord.getId())
+                    .medicationName(medicationRecord.getMedicationName())
+                    .administeredAt(medicationRecord.getAdministeredAt())
+                    .doseAmount(medicationRecord.getDoseAmount())
+                    .doseUnit(medicationRecord.getDoseUnit())
+                    .memo(medicationRecord.getMemo())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/response/MedicationRecordResponse.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/response/MedicationRecordResponse.java
@@ -1,0 +1,30 @@
+package org.zerock.puppyrun.care.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.care.entity.MedicationRecord;
+
+@Builder
+public record MedicationRecordResponse(
+        UUID medicationLogId,
+        UUID petId,
+        String medicationName,
+        LocalDateTime administeredAt,
+        Double doseAmount,
+        String doseUnit,
+        String memo
+) {
+
+    public static MedicationRecordResponse of(MedicationRecord medicationRecord) {
+        return MedicationRecordResponse.builder()
+                .medicationLogId(medicationRecord.getId())
+                .petId(medicationRecord.getPet().getId())
+                .medicationName(medicationRecord.getMedicationName())
+                .administeredAt(medicationRecord.getAdministeredAt())
+                .doseAmount(medicationRecord.getDoseAmount())
+                .doseUnit(medicationRecord.getDoseUnit())
+                .memo(medicationRecord.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/response/VaccinationListResponse.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/response/VaccinationListResponse.java
@@ -1,0 +1,50 @@
+package org.zerock.puppyrun.care.controller.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.care.entity.VaccinationRecord;
+import org.zerock.puppyrun.pet.entity.Pet;
+
+@Builder
+public record VaccinationListResponse(
+        UUID petId,
+        int totalVaccinationCount,
+        List<Vaccination> vaccinationList
+) {
+
+    public static VaccinationListResponse of(Pet pet, List<VaccinationRecord> vaccinationRecords) {
+        List<Vaccination> vaccinations = vaccinationRecords.stream()
+                .map(Vaccination::from)
+                .toList();
+
+        return VaccinationListResponse.builder()
+                .petId(pet.getId())
+                .totalVaccinationCount(vaccinations.size())
+                .vaccinationList(vaccinations)
+                .build();
+    }
+
+    @Builder
+    public record Vaccination(
+            UUID vaccinationId,
+            String vaccineName,
+            LocalDate vaccinatedAt,
+            LocalDate nextVaccinationDate,
+            String hospitalName,
+            String memo
+    ) {
+
+        public static Vaccination from(VaccinationRecord vaccinationRecord) {
+            return Vaccination.builder()
+                    .vaccinationId(vaccinationRecord.getId())
+                    .vaccineName(vaccinationRecord.getVaccineName())
+                    .vaccinatedAt(vaccinationRecord.getVaccinatedAt())
+                    .nextVaccinationDate(vaccinationRecord.getNextVaccinationDate())
+                    .hospitalName(vaccinationRecord.getHospitalName())
+                    .memo(vaccinationRecord.getMemo())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/controller/response/VaccinationRecordResponse.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/response/VaccinationRecordResponse.java
@@ -1,0 +1,30 @@
+package org.zerock.puppyrun.care.controller.response;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.care.entity.VaccinationRecord;
+
+@Builder
+public record VaccinationRecordResponse(
+        UUID vaccinationId,
+        UUID petId,
+        String vaccineName,
+        LocalDate vaccinatedAt,
+        LocalDate nextVaccinationDate,
+        String hospitalName,
+        String memo
+) {
+
+    public static VaccinationRecordResponse of(VaccinationRecord vaccinationRecord) {
+        return VaccinationRecordResponse.builder()
+                .vaccinationId(vaccinationRecord.getId())
+                .petId(vaccinationRecord.getPet().getId())
+                .vaccineName(vaccinationRecord.getVaccineName())
+                .vaccinatedAt(vaccinationRecord.getVaccinatedAt())
+                .nextVaccinationDate(vaccinationRecord.getNextVaccinationDate())
+                .hospitalName(vaccinationRecord.getHospitalName())
+                .memo(vaccinationRecord.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/entity/AllergyRecord.java
+++ b/src/main/java/org/zerock/puppyrun/care/entity/AllergyRecord.java
@@ -1,0 +1,92 @@
+package org.zerock.puppyrun.care.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.zerock.puppyrun.common.entity.BaseEntity;
+import org.zerock.puppyrun.pet.entity.Pet;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "allergy_record")
+public class AllergyRecord extends BaseEntity {
+
+    @Id
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Pet pet;
+
+    @Column(name = "allergen_name", nullable = false, length = 100)
+    private String allergenName;
+
+    @Column(length = 255)
+    private String symptom;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private AllergySeverity severity;
+
+    @Column(name = "identified_at")
+    private LocalDate identifiedAt;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    @Column(columnDefinition = "TEXT")
+    private String memo;
+
+    @Builder
+    public AllergyRecord(
+            UUID id,
+            Pet pet,
+            String allergenName,
+            String symptom,
+            AllergySeverity severity,
+            LocalDate identifiedAt,
+            Boolean isActive,
+            String memo
+    ) {
+        this.id = id != null ? id : UUID.randomUUID();
+        this.pet = pet;
+        this.allergenName = allergenName;
+        this.symptom = symptom;
+        this.severity = severity;
+        this.identifiedAt = identifiedAt;
+        this.isActive = isActive != null ? isActive : Boolean.TRUE;
+        this.memo = memo;
+    }
+
+    public void update(
+            String allergenName,
+            String symptom,
+            AllergySeverity severity,
+            LocalDate identifiedAt,
+            Boolean isActive,
+            String memo
+    ) {
+        this.allergenName = allergenName;
+        this.symptom = symptom;
+        this.severity = severity;
+        this.identifiedAt = identifiedAt;
+        this.isActive = isActive;
+        this.memo = memo;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/entity/AllergySeverity.java
+++ b/src/main/java/org/zerock/puppyrun/care/entity/AllergySeverity.java
@@ -1,0 +1,17 @@
+package org.zerock.puppyrun.care.entity;
+
+import org.zerock.puppyrun.common.exception.InvalidValueException;
+
+public enum AllergySeverity {
+    MILD,
+    MODERATE,
+    SEVERE;
+
+    public static AllergySeverity from(String severity) {
+        try {
+            return AllergySeverity.valueOf(severity);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidValueException("알러지 심각도 값이 올바르지 않습니다. | " + severity);
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/entity/CareEventType.java
+++ b/src/main/java/org/zerock/puppyrun/care/entity/CareEventType.java
@@ -1,0 +1,8 @@
+package org.zerock.puppyrun.care.entity;
+
+public enum CareEventType {
+    WEIGHT,
+    VACCINATION,
+    MEDICATION,
+    ALLERGY
+}

--- a/src/main/java/org/zerock/puppyrun/care/entity/MedicationRecord.java
+++ b/src/main/java/org/zerock/puppyrun/care/entity/MedicationRecord.java
@@ -1,0 +1,82 @@
+package org.zerock.puppyrun.care.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.zerock.puppyrun.common.entity.BaseEntity;
+import org.zerock.puppyrun.pet.entity.Pet;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "medication_record")
+public class MedicationRecord extends BaseEntity {
+
+    @Id
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Pet pet;
+
+    @Column(name = "medication_name", nullable = false, length = 100)
+    private String medicationName;
+
+    @Column(name = "administered_at", nullable = false)
+    private LocalDateTime administeredAt;
+
+    @Column(name = "dose_amount", nullable = false)
+    private Double doseAmount;
+
+    @Column(name = "dose_unit", nullable = false, length = 30)
+    private String doseUnit;
+
+    @Column(columnDefinition = "TEXT")
+    private String memo;
+
+    @Builder
+    public MedicationRecord(
+            UUID id,
+            Pet pet,
+            String medicationName,
+            LocalDateTime administeredAt,
+            Double doseAmount,
+            String doseUnit,
+            String memo
+    ) {
+        this.id = id != null ? id : UUID.randomUUID();
+        this.pet = pet;
+        this.medicationName = medicationName;
+        this.administeredAt = administeredAt;
+        this.doseAmount = doseAmount;
+        this.doseUnit = doseUnit;
+        this.memo = memo;
+    }
+
+    public void update(
+            String medicationName,
+            LocalDateTime administeredAt,
+            Double doseAmount,
+            String doseUnit,
+            String memo
+    ) {
+        this.medicationName = medicationName;
+        this.administeredAt = administeredAt;
+        this.doseAmount = doseAmount;
+        this.doseUnit = doseUnit;
+        this.memo = memo;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/entity/VaccinationRecord.java
+++ b/src/main/java/org/zerock/puppyrun/care/entity/VaccinationRecord.java
@@ -1,0 +1,82 @@
+package org.zerock.puppyrun.care.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.zerock.puppyrun.common.entity.BaseEntity;
+import org.zerock.puppyrun.pet.entity.Pet;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "vaccination_record")
+public class VaccinationRecord extends BaseEntity {
+
+    @Id
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Pet pet;
+
+    @Column(name = "vaccine_name", nullable = false, length = 100)
+    private String vaccineName;
+
+    @Column(name = "vaccinated_at", nullable = false)
+    private LocalDate vaccinatedAt;
+
+    @Column(name = "next_vaccination_date")
+    private LocalDate nextVaccinationDate;
+
+    @Column(name = "hospital_name", length = 100)
+    private String hospitalName;
+
+    @Column(columnDefinition = "TEXT")
+    private String memo;
+
+    @Builder
+    public VaccinationRecord(
+            UUID id,
+            Pet pet,
+            String vaccineName,
+            LocalDate vaccinatedAt,
+            LocalDate nextVaccinationDate,
+            String hospitalName,
+            String memo
+    ) {
+        this.id = id != null ? id : UUID.randomUUID();
+        this.pet = pet;
+        this.vaccineName = vaccineName;
+        this.vaccinatedAt = vaccinatedAt;
+        this.nextVaccinationDate = nextVaccinationDate;
+        this.hospitalName = hospitalName;
+        this.memo = memo;
+    }
+
+    public void update(
+            String vaccineName,
+            LocalDate vaccinatedAt,
+            LocalDate nextVaccinationDate,
+            String hospitalName,
+            String memo
+    ) {
+        this.vaccineName = vaccineName;
+        this.vaccinatedAt = vaccinatedAt;
+        this.nextVaccinationDate = nextVaccinationDate;
+        this.hospitalName = hospitalName;
+        this.memo = memo;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/repository/AllergyRecordRepository.java
+++ b/src/main/java/org/zerock/puppyrun/care/repository/AllergyRecordRepository.java
@@ -1,5 +1,6 @@
 package org.zerock.puppyrun.care.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,6 +18,12 @@ public interface AllergyRecordRepository extends JpaRepository<AllergyRecord, UU
     }
 
     List<AllergyRecord> findAllByPetIdOrderByCreatedAtDesc(UUID petId);
+
+    List<AllergyRecord> findAllByPetIdAndIdentifiedAtIsNotNullAndIdentifiedAtBetweenOrderByIdentifiedAtAscCreatedAtAsc(
+            UUID petId,
+            LocalDate startDate,
+            LocalDate endDate
+    );
 
     Optional<AllergyRecord> findByIdAndPetId(UUID allergyRecordId, UUID petId);
 }

--- a/src/main/java/org/zerock/puppyrun/care/repository/AllergyRecordRepository.java
+++ b/src/main/java/org/zerock/puppyrun/care/repository/AllergyRecordRepository.java
@@ -1,0 +1,16 @@
+package org.zerock.puppyrun.care.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.care.entity.AllergyRecord;
+
+@Repository
+public interface AllergyRecordRepository extends JpaRepository<AllergyRecord, UUID> {
+
+    List<AllergyRecord> findAllByPetIdOrderByCreatedAtDesc(UUID petId);
+
+    Optional<AllergyRecord> findByIdAndPetId(UUID allergyRecordId, UUID petId);
+}

--- a/src/main/java/org/zerock/puppyrun/care/repository/AllergyRecordRepository.java
+++ b/src/main/java/org/zerock/puppyrun/care/repository/AllergyRecordRepository.java
@@ -6,9 +6,15 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.zerock.puppyrun.care.entity.AllergyRecord;
+import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 
 @Repository
 public interface AllergyRecordRepository extends JpaRepository<AllergyRecord, UUID> {
+
+    default AllergyRecord findByIdAndVerifyPet(UUID allergyId, UUID petId) {
+        return findByIdAndPetId(allergyId, petId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 알러지 기록을 찾을 수 없습니다."));
+    }
 
     List<AllergyRecord> findAllByPetIdOrderByCreatedAtDesc(UUID petId);
 

--- a/src/main/java/org/zerock/puppyrun/care/repository/MedicationRecordRepository.java
+++ b/src/main/java/org/zerock/puppyrun/care/repository/MedicationRecordRepository.java
@@ -6,11 +6,17 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.zerock.puppyrun.care.entity.MedicationRecord;
+import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 
 @Repository
 public interface MedicationRecordRepository extends JpaRepository<MedicationRecord, UUID> {
 
-    List<MedicationRecord> findAllByPetIdOrderByAdministeredAtDesc(UUID petId);
+    default MedicationRecord findByIdAndVerifyPet(UUID medicationLogId, UUID petId) {
+        return findByIdAndPetId(medicationLogId, petId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 투약 기록을 찾을 수 없습니다."));
+    }
+
+    List<MedicationRecord> findAllByPetIdOrderByAdministeredAtDescCreatedAtDesc(UUID petId);
 
     Optional<MedicationRecord> findByIdAndPetId(UUID medicationRecordId, UUID petId);
 }

--- a/src/main/java/org/zerock/puppyrun/care/repository/MedicationRecordRepository.java
+++ b/src/main/java/org/zerock/puppyrun/care/repository/MedicationRecordRepository.java
@@ -1,0 +1,16 @@
+package org.zerock.puppyrun.care.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.care.entity.MedicationRecord;
+
+@Repository
+public interface MedicationRecordRepository extends JpaRepository<MedicationRecord, UUID> {
+
+    List<MedicationRecord> findAllByPetIdOrderByAdministeredAtDesc(UUID petId);
+
+    Optional<MedicationRecord> findByIdAndPetId(UUID medicationRecordId, UUID petId);
+}

--- a/src/main/java/org/zerock/puppyrun/care/repository/MedicationRecordRepository.java
+++ b/src/main/java/org/zerock/puppyrun/care/repository/MedicationRecordRepository.java
@@ -1,5 +1,6 @@
 package org.zerock.puppyrun.care.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,6 +18,12 @@ public interface MedicationRecordRepository extends JpaRepository<MedicationReco
     }
 
     List<MedicationRecord> findAllByPetIdOrderByAdministeredAtDescCreatedAtDesc(UUID petId);
+
+    List<MedicationRecord> findAllByPetIdAndAdministeredAtGreaterThanEqualAndAdministeredAtLessThanOrderByAdministeredAtAscCreatedAtAsc(
+            UUID petId,
+            LocalDateTime startDateTime,
+            LocalDateTime endExclusive
+    );
 
     Optional<MedicationRecord> findByIdAndPetId(UUID medicationRecordId, UUID petId);
 }

--- a/src/main/java/org/zerock/puppyrun/care/repository/VaccinationRecordRepository.java
+++ b/src/main/java/org/zerock/puppyrun/care/repository/VaccinationRecordRepository.java
@@ -18,5 +18,11 @@ public interface VaccinationRecordRepository extends JpaRepository<VaccinationRe
 
     List<VaccinationRecord> findAllByPetIdOrderByVaccinatedAtDescCreatedAtDesc(UUID petId);
 
+    List<VaccinationRecord> findAllByPetIdAndVaccinatedAtBetweenOrderByVaccinatedAtAscCreatedAtAsc(
+            UUID petId,
+            java.time.LocalDate startDate,
+            java.time.LocalDate endDate
+    );
+
     Optional<VaccinationRecord> findByIdAndPetId(UUID vaccinationRecordId, UUID petId);
 }

--- a/src/main/java/org/zerock/puppyrun/care/repository/VaccinationRecordRepository.java
+++ b/src/main/java/org/zerock/puppyrun/care/repository/VaccinationRecordRepository.java
@@ -1,0 +1,16 @@
+package org.zerock.puppyrun.care.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.care.entity.VaccinationRecord;
+
+@Repository
+public interface VaccinationRecordRepository extends JpaRepository<VaccinationRecord, UUID> {
+
+    List<VaccinationRecord> findAllByPetIdOrderByVaccinatedAtDesc(UUID petId);
+
+    Optional<VaccinationRecord> findByIdAndPetId(UUID vaccinationRecordId, UUID petId);
+}

--- a/src/main/java/org/zerock/puppyrun/care/repository/VaccinationRecordRepository.java
+++ b/src/main/java/org/zerock/puppyrun/care/repository/VaccinationRecordRepository.java
@@ -6,11 +6,17 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.zerock.puppyrun.care.entity.VaccinationRecord;
+import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 
 @Repository
 public interface VaccinationRecordRepository extends JpaRepository<VaccinationRecord, UUID> {
 
-    List<VaccinationRecord> findAllByPetIdOrderByVaccinatedAtDesc(UUID petId);
+    default VaccinationRecord findByIdAndVerifyPet(UUID vaccinationId, UUID petId) {
+        return findByIdAndPetId(vaccinationId, petId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 접종 기록을 찾을 수 없습니다."));
+    }
+
+    List<VaccinationRecord> findAllByPetIdOrderByVaccinatedAtDescCreatedAtDesc(UUID petId);
 
     Optional<VaccinationRecord> findByIdAndPetId(UUID vaccinationRecordId, UUID petId);
 }

--- a/src/main/java/org/zerock/puppyrun/care/service/AllergyCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/care/service/AllergyCommandService.java
@@ -1,0 +1,83 @@
+package org.zerock.puppyrun.care.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.care.controller.request.RegisterAllergyRequest;
+import org.zerock.puppyrun.care.controller.request.UpdateAllergyRequest;
+import org.zerock.puppyrun.care.controller.response.AllergyRecordResponse;
+import org.zerock.puppyrun.care.entity.AllergyRecord;
+import org.zerock.puppyrun.care.entity.AllergySeverity;
+import org.zerock.puppyrun.care.repository.AllergyRecordRepository;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class AllergyCommandService {
+
+    private final PetRepository petRepository;
+    private final AllergyRecordRepository allergyRecordRepository;
+
+    public AllergyRecordResponse registerAllergy(
+            UserPrincipal userPrincipal,
+            UUID petId,
+            RegisterAllergyRequest request
+    ) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        AllergySeverity severity = toSeverity(request.severity());
+
+        AllergyRecord allergyRecord = AllergyRecord.builder()
+                .pet(pet)
+                .allergenName(request.allergenName())
+                .symptom(request.symptom())
+                .severity(severity)
+                .identifiedAt(request.identifiedAt())
+                .isActive(request.isActive())
+                .memo(request.memo())
+                .build();
+
+        allergyRecordRepository.save(allergyRecord);
+        return AllergyRecordResponse.of(allergyRecord);
+    }
+
+    public AllergyRecordResponse updateAllergy(
+            UserPrincipal userPrincipal,
+            UUID petId,
+            UUID allergyId,
+            UpdateAllergyRequest request
+    ) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        AllergyRecord allergyRecord = allergyRecordRepository.findByIdAndVerifyPet(allergyId, pet.getId());
+        AllergySeverity severity = toSeverity(request.severity());
+
+        allergyRecord.update(
+                request.allergenName(),
+                request.symptom(),
+                severity,
+                request.identifiedAt(),
+                request.isActive(),
+                request.memo()
+        );
+
+        return AllergyRecordResponse.of(allergyRecord);
+    }
+
+    public void deleteAllergy(UserPrincipal userPrincipal, UUID petId, UUID allergyId) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        AllergyRecord allergyRecord = allergyRecordRepository.findByIdAndVerifyPet(allergyId, pet.getId());
+        allergyRecordRepository.delete(allergyRecord);
+    }
+
+    private AllergySeverity toSeverity(String severity) {
+        if (severity == null) {
+            return null;
+        }
+        return AllergySeverity.from(severity);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/service/AllergyQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/care/service/AllergyQueryService.java
@@ -1,0 +1,31 @@
+package org.zerock.puppyrun.care.service;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.care.controller.response.AllergyListResponse;
+import org.zerock.puppyrun.care.entity.AllergyRecord;
+import org.zerock.puppyrun.care.repository.AllergyRecordRepository;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AllergyQueryService {
+
+    private final PetRepository petRepository;
+    private final AllergyRecordRepository allergyRecordRepository;
+
+    public AllergyListResponse getAllergyList(UserPrincipal userPrincipal, UUID petId) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        List<AllergyRecord> allergyRecords = allergyRecordRepository.findAllByPetIdOrderByCreatedAtDesc(pet.getId());
+
+        return AllergyListResponse.of(pet, allergyRecords);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/service/CareCalendarQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/care/service/CareCalendarQueryService.java
@@ -1,0 +1,198 @@
+package org.zerock.puppyrun.care.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.care.controller.response.CareCalendarResponse;
+import org.zerock.puppyrun.care.entity.AllergyRecord;
+import org.zerock.puppyrun.care.entity.CareEventType;
+import org.zerock.puppyrun.care.entity.MedicationRecord;
+import org.zerock.puppyrun.care.entity.VaccinationRecord;
+import org.zerock.puppyrun.care.repository.AllergyRecordRepository;
+import org.zerock.puppyrun.care.repository.MedicationRecordRepository;
+import org.zerock.puppyrun.care.repository.VaccinationRecordRepository;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.common.exception.InvalidValueException;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.entity.PetWeightLog;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+import org.zerock.puppyrun.pet.repository.PetWeightLogRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CareCalendarQueryService {
+
+    private final PetRepository petRepository;
+    private final PetWeightLogRepository petWeightLogRepository;
+    private final VaccinationRecordRepository vaccinationRecordRepository;
+    private final MedicationRecordRepository medicationRecordRepository;
+    private final AllergyRecordRepository allergyRecordRepository;
+
+    public CareCalendarResponse getCareCalendar(
+            UserPrincipal userPrincipal,
+            UUID petId,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        validateDateRange(startDate, endDate);
+
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endExclusive = endDate.plusDays(1).atStartOfDay();
+
+        List<CalendarEventCandidate> events = new ArrayList<>(getWeightEvents(petId, startDateTime, endExclusive));
+        events.addAll(getVaccinationEvents(petId, startDate, endDate));
+        events.addAll(getMedicationEvents(petId, startDateTime, endExclusive));
+        events.addAll(getAllergyEvents(petId, startDate, endDate));
+
+        List<CareCalendarResponse.CareEvent> sortedEvents = events.stream()
+                .sorted(Comparator
+                        .comparing(CalendarEventCandidate::sortDateTime)
+                        .thenComparing(candidate -> candidate.event().eventType().name())
+                        .thenComparing(candidate -> candidate.event().relatedId()))
+                .map(CalendarEventCandidate::event)
+                .toList();
+
+        return CareCalendarResponse.of(pet, startDate, endDate, sortedEvents);
+    }
+
+    private void validateDateRange(LocalDate startDate, LocalDate endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new InvalidValueException("조회 시작일은 종료일보다 늦을 수 없습니다.");
+        }
+    }
+
+    private List<CalendarEventCandidate> getWeightEvents(
+            UUID petId,
+            LocalDateTime startDateTime,
+            LocalDateTime endExclusive
+    ) {
+        return petWeightLogRepository
+                .findAllByPetIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(
+                        petId,
+                        startDateTime,
+                        endExclusive
+                )
+                .stream()
+                .map(this::toWeightEvent)
+                .toList();
+    }
+
+    private List<CalendarEventCandidate> getVaccinationEvents(UUID petId, LocalDate startDate, LocalDate endDate) {
+        return vaccinationRecordRepository.findAllByPetIdAndVaccinatedAtBetweenOrderByVaccinatedAtAscCreatedAtAsc(
+                        petId,
+                        startDate,
+                        endDate
+                )
+                .stream()
+                .map(this::toVaccinationEvent)
+                .toList();
+    }
+
+    private List<CalendarEventCandidate> getMedicationEvents(
+            UUID petId,
+            LocalDateTime startDateTime,
+            LocalDateTime endExclusive
+    ) {
+        return medicationRecordRepository
+                .findAllByPetIdAndAdministeredAtGreaterThanEqualAndAdministeredAtLessThanOrderByAdministeredAtAscCreatedAtAsc(
+                        petId,
+                        startDateTime,
+                        endExclusive
+                )
+                .stream()
+                .map(this::toMedicationEvent)
+                .toList();
+    }
+
+    private List<CalendarEventCandidate> getAllergyEvents(UUID petId, LocalDate startDate, LocalDate endDate) {
+        return allergyRecordRepository
+                .findAllByPetIdAndIdentifiedAtIsNotNullAndIdentifiedAtBetweenOrderByIdentifiedAtAscCreatedAtAsc(
+                        petId,
+                        startDate,
+                        endDate
+                )
+                .stream()
+                .map(this::toAllergyEvent)
+                .toList();
+    }
+
+    private CalendarEventCandidate toWeightEvent(PetWeightLog petWeightLog) {
+        CareCalendarResponse.CareEvent event = CareCalendarResponse.CareEvent.builder()
+                .date(petWeightLog.getCreatedAt().toLocalDate())
+                .eventType(CareEventType.WEIGHT)
+                .title("체중 기록")
+                .relatedId(petWeightLog.getId())
+                .displayText(petWeightLog.getWeight() + "kg")
+                .build();
+
+        return new CalendarEventCandidate(petWeightLog.getCreatedAt(), event);
+    }
+
+    private CalendarEventCandidate toVaccinationEvent(VaccinationRecord vaccinationRecord) {
+        CareCalendarResponse.CareEvent event = CareCalendarResponse.CareEvent.builder()
+                .date(vaccinationRecord.getVaccinatedAt())
+                .eventType(CareEventType.VACCINATION)
+                .title(vaccinationRecord.getVaccineName())
+                .relatedId(vaccinationRecord.getId())
+                .displayText(resolveVaccinationDisplayText(vaccinationRecord))
+                .build();
+
+        return new CalendarEventCandidate(vaccinationRecord.getVaccinatedAt().atStartOfDay(), event);
+    }
+
+    private CalendarEventCandidate toMedicationEvent(MedicationRecord medicationRecord) {
+        CareCalendarResponse.CareEvent event = CareCalendarResponse.CareEvent.builder()
+                .date(medicationRecord.getAdministeredAt().toLocalDate())
+                .eventType(CareEventType.MEDICATION)
+                .title(medicationRecord.getMedicationName())
+                .relatedId(medicationRecord.getId())
+                .displayText(medicationRecord.getDoseAmount() + " " + medicationRecord.getDoseUnit())
+                .build();
+
+        return new CalendarEventCandidate(medicationRecord.getAdministeredAt(), event);
+    }
+
+    private CalendarEventCandidate toAllergyEvent(AllergyRecord allergyRecord) {
+        CareCalendarResponse.CareEvent event = CareCalendarResponse.CareEvent.builder()
+                .date(allergyRecord.getIdentifiedAt())
+                .eventType(CareEventType.ALLERGY)
+                .title(allergyRecord.getAllergenName())
+                .relatedId(allergyRecord.getId())
+                .displayText(resolveAllergyDisplayText(allergyRecord))
+                .build();
+
+        return new CalendarEventCandidate(allergyRecord.getIdentifiedAt().atStartOfDay(), event);
+    }
+
+    private String resolveVaccinationDisplayText(VaccinationRecord vaccinationRecord) {
+        if (vaccinationRecord.getMemo() != null && !vaccinationRecord.getMemo().isBlank()) {
+            return vaccinationRecord.getMemo();
+        }
+
+        return vaccinationRecord.getHospitalName();
+    }
+
+    private String resolveAllergyDisplayText(AllergyRecord allergyRecord) {
+        if (allergyRecord.getSymptom() != null && !allergyRecord.getSymptom().isBlank()) {
+            return allergyRecord.getSymptom();
+        }
+
+        return allergyRecord.getMemo();
+    }
+
+    private record CalendarEventCandidate(
+            LocalDateTime sortDateTime,
+            CareCalendarResponse.CareEvent event
+    ) {
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/service/MedicationCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/care/service/MedicationCommandService.java
@@ -1,0 +1,71 @@
+package org.zerock.puppyrun.care.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.care.controller.request.RegisterMedicationRequest;
+import org.zerock.puppyrun.care.controller.request.UpdateMedicationRequest;
+import org.zerock.puppyrun.care.controller.response.MedicationRecordResponse;
+import org.zerock.puppyrun.care.entity.MedicationRecord;
+import org.zerock.puppyrun.care.repository.MedicationRecordRepository;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class MedicationCommandService {
+
+    private final PetRepository petRepository;
+    private final MedicationRecordRepository medicationRecordRepository;
+
+    public MedicationRecordResponse registerMedication(
+            UserPrincipal userPrincipal,
+            UUID petId,
+            RegisterMedicationRequest request
+    ) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+
+        MedicationRecord medicationRecord = MedicationRecord.builder()
+                .pet(pet)
+                .medicationName(request.medicationName())
+                .administeredAt(request.administeredAt())
+                .doseAmount(request.doseAmount())
+                .doseUnit(request.doseUnit())
+                .memo(request.memo())
+                .build();
+
+        medicationRecordRepository.save(medicationRecord);
+        return MedicationRecordResponse.of(medicationRecord);
+    }
+
+    public MedicationRecordResponse updateMedication(
+            UserPrincipal userPrincipal,
+            UUID petId,
+            UUID medicationLogId,
+            UpdateMedicationRequest request
+    ) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        MedicationRecord medicationRecord = medicationRecordRepository.findByIdAndVerifyPet(medicationLogId, pet.getId());
+
+        medicationRecord.update(
+                request.medicationName(),
+                request.administeredAt(),
+                request.doseAmount(),
+                request.doseUnit(),
+                request.memo()
+        );
+
+        return MedicationRecordResponse.of(medicationRecord);
+    }
+
+    public void deleteMedication(UserPrincipal userPrincipal, UUID petId, UUID medicationLogId) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        MedicationRecord medicationRecord = medicationRecordRepository.findByIdAndVerifyPet(medicationLogId, pet.getId());
+        medicationRecordRepository.delete(medicationRecord);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/service/MedicationQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/care/service/MedicationQueryService.java
@@ -1,0 +1,32 @@
+package org.zerock.puppyrun.care.service;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.care.controller.response.MedicationListResponse;
+import org.zerock.puppyrun.care.entity.MedicationRecord;
+import org.zerock.puppyrun.care.repository.MedicationRecordRepository;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MedicationQueryService {
+
+    private final PetRepository petRepository;
+    private final MedicationRecordRepository medicationRecordRepository;
+
+    public MedicationListResponse getMedicationList(UserPrincipal userPrincipal, UUID petId) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        List<MedicationRecord> medicationRecords =
+                medicationRecordRepository.findAllByPetIdOrderByAdministeredAtDescCreatedAtDesc(pet.getId());
+
+        return MedicationListResponse.of(pet, medicationRecords);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/service/VaccinationCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/care/service/VaccinationCommandService.java
@@ -1,0 +1,81 @@
+package org.zerock.puppyrun.care.service;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.care.controller.request.RegisterVaccinationRequest;
+import org.zerock.puppyrun.care.controller.request.UpdateVaccinationRequest;
+import org.zerock.puppyrun.care.controller.response.VaccinationRecordResponse;
+import org.zerock.puppyrun.care.entity.VaccinationRecord;
+import org.zerock.puppyrun.care.repository.VaccinationRecordRepository;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.common.exception.InvalidValueException;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class VaccinationCommandService {
+
+    private final PetRepository petRepository;
+    private final VaccinationRecordRepository vaccinationRecordRepository;
+
+    public VaccinationRecordResponse registerVaccination(
+            UserPrincipal userPrincipal,
+            UUID petId,
+            RegisterVaccinationRequest request
+    ) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        validateDateRange(request.vaccinatedAt(), request.nextVaccinationDate());
+
+        VaccinationRecord vaccinationRecord = VaccinationRecord.builder()
+                .pet(pet)
+                .vaccineName(request.vaccineName())
+                .vaccinatedAt(request.vaccinatedAt())
+                .nextVaccinationDate(request.nextVaccinationDate())
+                .hospitalName(request.hospitalName())
+                .memo(request.memo())
+                .build();
+
+        vaccinationRecordRepository.save(vaccinationRecord);
+        return VaccinationRecordResponse.of(vaccinationRecord);
+    }
+
+    public VaccinationRecordResponse updateVaccination(
+            UserPrincipal userPrincipal,
+            UUID petId,
+            UUID vaccinationId,
+            UpdateVaccinationRequest request
+    ) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        validateDateRange(request.vaccinatedAt(), request.nextVaccinationDate());
+
+        VaccinationRecord vaccinationRecord = vaccinationRecordRepository.findByIdAndVerifyPet(vaccinationId, pet.getId());
+        vaccinationRecord.update(
+                request.vaccineName(),
+                request.vaccinatedAt(),
+                request.nextVaccinationDate(),
+                request.hospitalName(),
+                request.memo()
+        );
+
+        return VaccinationRecordResponse.of(vaccinationRecord);
+    }
+
+    public void deleteVaccination(UserPrincipal userPrincipal, UUID petId, UUID vaccinationId) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        VaccinationRecord vaccinationRecord = vaccinationRecordRepository.findByIdAndVerifyPet(vaccinationId, pet.getId());
+        vaccinationRecordRepository.delete(vaccinationRecord);
+    }
+
+    private void validateDateRange(LocalDate vaccinatedAt, LocalDate nextVaccinationDate) {
+        if (nextVaccinationDate != null && nextVaccinationDate.isBefore(vaccinatedAt)) {
+            throw new InvalidValueException("다음 접종 예정일은 접종일보다 이전일 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/care/service/VaccinationQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/care/service/VaccinationQueryService.java
@@ -1,0 +1,32 @@
+package org.zerock.puppyrun.care.service;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.care.controller.response.VaccinationListResponse;
+import org.zerock.puppyrun.care.entity.VaccinationRecord;
+import org.zerock.puppyrun.care.repository.VaccinationRecordRepository;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VaccinationQueryService {
+
+    private final PetRepository petRepository;
+    private final VaccinationRecordRepository vaccinationRecordRepository;
+
+    public VaccinationListResponse getVaccinationList(UserPrincipal userPrincipal, UUID petId) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        List<VaccinationRecord> vaccinationRecords =
+                vaccinationRecordRepository.findAllByPetIdOrderByVaccinatedAtDescCreatedAtDesc(pet.getId());
+
+        return VaccinationListResponse.of(pet, vaccinationRecords);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/pet/controller/PetController.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/PetController.java
@@ -17,10 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.pet.controller.request.RegisterPetRequest;
+import org.zerock.puppyrun.pet.controller.request.RegisterPetWeightLogRequest;
 import org.zerock.puppyrun.pet.controller.request.UpdatePetRequest;
 import org.zerock.puppyrun.pet.controller.response.PetDetailResponse;
 import org.zerock.puppyrun.pet.controller.response.PetListResponse;
 import org.zerock.puppyrun.pet.controller.response.PetUpdateResponse;
+import org.zerock.puppyrun.pet.controller.response.PetWeightRecordResponse;
 import org.zerock.puppyrun.pet.controller.response.PetWeightLogResponse;
 import org.zerock.puppyrun.pet.service.PetCommandService;
 import org.zerock.puppyrun.pet.service.PetQueryService;
@@ -117,6 +119,19 @@ public class PetController {
     ) {
         petCommandService.deletePet(userPrincipal, petId);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 펫 몸무게 기록 등록
+     */
+    @PostMapping("/{petId}/weight-logs")
+    public ResponseEntity<PetWeightRecordResponse> registerPetWeightLog(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID petId,
+            @RequestBody @Valid RegisterPetWeightLogRequest request
+    ) {
+        PetWeightRecordResponse response = petCommandService.registerPetWeightLog(userPrincipal, petId, request);
+        return ResponseEntity.ok(response);
     }
 
     /**

--- a/src/main/java/org/zerock/puppyrun/pet/controller/request/RegisterPetWeightLogRequest.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/request/RegisterPetWeightLogRequest.java
@@ -1,0 +1,11 @@
+package org.zerock.puppyrun.pet.controller.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record RegisterPetWeightLogRequest(
+        @NotNull(message = "몸무게는 필수입니다.")
+        @Min(value = 1, message = "몸무게는 1kg 이상이어야 합니다.")
+        Double weight
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetWeightRecordResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetWeightRecordResponse.java
@@ -1,0 +1,23 @@
+package org.zerock.puppyrun.pet.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.pet.entity.PetWeightLog;
+
+@Builder
+public record PetWeightRecordResponse(
+        UUID weightLogId,
+        UUID petId,
+        Double weight,
+        LocalDateTime recordedAt
+) {
+    public static PetWeightRecordResponse of(PetWeightLog petWeightLog) {
+        return PetWeightRecordResponse.builder()
+                .weightLogId(petWeightLog.getId())
+                .petId(petWeightLog.getPet().getId())
+                .weight(petWeightLog.getWeight())
+                .recordedAt(petWeightLog.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
+++ b/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
@@ -91,6 +91,9 @@ public class Pet extends BaseEntity {
         this.gender = dto.gender();
     }
 
+    public void updateWeight(Double weight) {
+        this.weight = weight;
+    }
 
     public void setDefaultProfile() {
         this.profileImageUrl = null;

--- a/src/main/java/org/zerock/puppyrun/pet/repository/PetWeightLogRepository.java
+++ b/src/main/java/org/zerock/puppyrun/pet/repository/PetWeightLogRepository.java
@@ -1,5 +1,6 @@
 package org.zerock.puppyrun.pet.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -12,6 +13,12 @@ public interface PetWeightLogRepository extends JpaRepository<PetWeightLog, UUID
 
     // 전체 조회
     List<PetWeightLog> findAllByPetIdOrderByCreatedAt(UUID petId);
+
+    List<PetWeightLog> findAllByPetIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(
+            UUID petId,
+            LocalDateTime startDateTime,
+            LocalDateTime endExclusive
+    );
 
     // 최신 데이터 1건만 조회
     Optional<PetWeightLog> findFirstByPetIdOrderByCreatedAtDesc(UUID petId);

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetCommandService.java
@@ -13,11 +13,14 @@ import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.member.repository.MemberRepository;
 import org.zerock.puppyrun.pet.DTO.UpdatePetDTO;
 import org.zerock.puppyrun.pet.controller.request.RegisterPetRequest;
+import org.zerock.puppyrun.pet.controller.request.RegisterPetWeightLogRequest;
 import org.zerock.puppyrun.pet.controller.request.UpdatePetRequest;
 import org.zerock.puppyrun.pet.controller.response.PetDetailResponse;
 import org.zerock.puppyrun.pet.controller.response.PetUpdateResponse;
+import org.zerock.puppyrun.pet.controller.response.PetWeightRecordResponse;
 import org.zerock.puppyrun.pet.entity.Breed;
 import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.entity.PetWeightLog;
 import org.zerock.puppyrun.pet.repository.PetRepository;
 import org.zerock.puppyrun.statistics.service.PetStatistics;
 
@@ -85,6 +88,21 @@ public class PetCommandService {
         petStatistics.savePetWeightLog(pet, request.weight());
 
         return PetUpdateResponse.of(pet);
+    }
+
+    public PetWeightRecordResponse registerPetWeightLog(
+            UserPrincipal userPrincipal,
+            UUID petId,
+            RegisterPetWeightLogRequest request
+    ) {
+        Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
+        pet.updateWeight(request.weight());
+        petRepository.save(pet);
+
+        petStatistics.savePetWeightLog(pet, request.weight());
+
+        PetWeightLog latestPetWeightLog = petStatistics.getLatestPetWeightLog(pet.getId());
+        return PetWeightRecordResponse.of(latestPetWeightLog);
     }
 
 

--- a/src/main/java/org/zerock/puppyrun/statistics/service/PetStatistics.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/service/PetStatistics.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.pet.entity.Pet;
 import org.zerock.puppyrun.pet.entity.PetWeightLog;
 import org.zerock.puppyrun.pet.repository.PetWeightLogRepository;
@@ -57,6 +58,11 @@ public class PetStatistics {
      */
     public List<PetWeightLog> getPetWeightLog(UUID petId) {
         return petWeightLogRepository.findAllByPetIdOrderByCreatedAt(petId);
+    }
+
+    public PetWeightLog getLatestPetWeightLog(UUID petId) {
+        return petWeightLogRepository.findFirstByPetIdOrderByCreatedAtDesc(petId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 펫의 몸무게 기록을 찾을 수 없습니다."));
     }
 
     /**

--- a/src/test/java/org/zerock/puppyrun/care/controller/AllergyControllerTest.java
+++ b/src/test/java/org/zerock/puppyrun/care/controller/AllergyControllerTest.java
@@ -1,0 +1,598 @@
+package org.zerock.puppyrun.care.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.zerock.puppyrun.care.controller.request.RegisterAllergyRequest;
+import org.zerock.puppyrun.care.controller.request.UpdateAllergyRequest;
+import org.zerock.puppyrun.care.entity.AllergyRecord;
+import org.zerock.puppyrun.care.entity.AllergySeverity;
+import org.zerock.puppyrun.care.repository.AllergyRecordRepository;
+import org.zerock.puppyrun.common.auth.jwt.JwtTokenProvider;
+import org.zerock.puppyrun.common.exception.ErrorCode;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.pet.entity.Breed;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AllergyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @Autowired
+    private AllergyRecordRepository allergyRecordRepository;
+
+    @BeforeEach
+    void setUp() {
+        allergyRecordRepository.deleteAll();
+        petRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("알러지 기록 등록 API")
+    void registerAllergy() throws Exception {
+        Member member = createMember("register-allergy@test.com", "registerAllergyUser");
+        Pet pet = createPet(member, "몽이");
+        String accessToken = createAccessToken(member);
+
+        RegisterAllergyRequest request = new RegisterAllergyRequest(
+                "닭고기",
+                "피부 가려움",
+                "MODERATE",
+                LocalDate.of(2026, 4, 20),
+                true,
+                "간식 섭취 후 반응 확인"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/allergies", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.allergen_name").value("닭고기"))
+                .andExpect(jsonPath("$.symptom").value("피부 가려움"))
+                .andExpect(jsonPath("$.severity").value("MODERATE"))
+                .andExpect(jsonPath("$.identified_at").value("2026-04-20"))
+                .andExpect(jsonPath("$.is_active").value(true))
+                .andExpect(jsonPath("$.memo").value("간식 섭취 후 반응 확인"));
+
+        assertThat(allergyRecordRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("알러지 기록 목록 조회 API")
+    void getAllergyList() throws Exception {
+        Member member = createMember("list-allergy@test.com", "listAllergyUser");
+        Pet pet = createPet(member, "두부");
+        String accessToken = createAccessToken(member);
+
+        AllergyRecord olderCreatedRecord = allergyRecordRepository.save(AllergyRecord.builder()
+                .pet(pet)
+                .allergenName("유제품")
+                .symptom("설사")
+                .severity(AllergySeverity.MILD)
+                .identifiedAt(LocalDate.of(2025, 12, 1))
+                .isActive(false)
+                .memo(null)
+                .build());
+
+        Thread.sleep(10);
+
+        AllergyRecord latestCreatedRecord = allergyRecordRepository.save(AllergyRecord.builder()
+                .pet(pet)
+                .allergenName("닭고기")
+                .symptom("피부 가려움")
+                .severity(AllergySeverity.MODERATE)
+                .identifiedAt(LocalDate.of(2026, 4, 20))
+                .isActive(true)
+                .memo("간식 섭취 후 반응 확인")
+                .build());
+
+        mockMvc.perform(get("/api/pets/{petId}/allergies", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.total_allergy_count").value(2))
+                .andExpect(jsonPath("$.allergy_list[0].allergy_id").value(latestCreatedRecord.getId().toString()))
+                .andExpect(jsonPath("$.allergy_list[0].allergen_name").value("닭고기"))
+                .andExpect(jsonPath("$.allergy_list[0].severity").value("MODERATE"))
+                .andExpect(jsonPath("$.allergy_list[1].allergy_id").value(olderCreatedRecord.getId().toString()))
+                .andExpect(jsonPath("$.allergy_list[1].allergen_name").value("유제품"))
+                .andExpect(jsonPath("$.allergy_list[1].severity").value("MILD"));
+    }
+
+    @Test
+    @DisplayName("알러지 기록이 없으면 빈 목록을 반환한다")
+    void getAllergyList_whenEmpty() throws Exception {
+        Member member = createMember("empty-list-allergy@test.com", "emptyListAllergyUser");
+        Pet pet = createPet(member, "초코");
+        String accessToken = createAccessToken(member);
+
+        mockMvc.perform(get("/api/pets/{petId}/allergies", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.total_allergy_count").value(0))
+                .andExpect(jsonPath("$.allergy_list").isArray())
+                .andExpect(jsonPath("$.allergy_list").isEmpty());
+
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("알러지 기록 수정 API")
+    void updateAllergy() throws Exception {
+        Member member = createMember("update-allergy@test.com", "updateAllergyUser");
+        Pet pet = createPet(member, "보리");
+        String accessToken = createAccessToken(member);
+
+        AllergyRecord allergyRecord = allergyRecordRepository.save(AllergyRecord.builder()
+                .pet(pet)
+                .allergenName("유제품")
+                .symptom("설사")
+                .severity(AllergySeverity.MILD)
+                .identifiedAt(LocalDate.of(2025, 12, 1))
+                .isActive(true)
+                .memo("초기 메모")
+                .build());
+
+        UpdateAllergyRequest request = new UpdateAllergyRequest(
+                "닭고기",
+                "피부 가려움",
+                "SEVERE",
+                LocalDate.of(2026, 4, 20),
+                false,
+                "사료 변경 후 비활성 처리"
+        );
+
+        mockMvc.perform(put("/api/pets/{petId}/allergies/{allergyId}", pet.getId(), allergyRecord.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allergy_id").value(allergyRecord.getId().toString()))
+                .andExpect(jsonPath("$.allergen_name").value("닭고기"))
+                .andExpect(jsonPath("$.symptom").value("피부 가려움"))
+                .andExpect(jsonPath("$.severity").value("SEVERE"))
+                .andExpect(jsonPath("$.identified_at").value("2026-04-20"))
+                .andExpect(jsonPath("$.is_active").value(false))
+                .andExpect(jsonPath("$.memo").value("사료 변경 후 비활성 처리"));
+
+        AllergyRecord updated = allergyRecordRepository.findById(allergyRecord.getId()).orElseThrow();
+        assertThat(updated.getAllergenName()).isEqualTo("닭고기");
+        assertThat(updated.getSymptom()).isEqualTo("피부 가려움");
+        assertThat(updated.getSeverity()).isEqualTo(AllergySeverity.SEVERE);
+        assertThat(updated.getIsActive()).isFalse();
+        assertThat(updated.getMemo()).isEqualTo("사료 변경 후 비활성 처리");
+    }
+
+    @Test
+    @DisplayName("알러지 기록 삭제 API")
+    void deleteAllergy() throws Exception {
+        Member member = createMember("delete-allergy@test.com", "deleteAllergyUser");
+        Pet pet = createPet(member, "해피");
+        String accessToken = createAccessToken(member);
+
+        AllergyRecord allergyRecord = allergyRecordRepository.save(AllergyRecord.builder()
+                .pet(pet)
+                .allergenName("닭고기")
+                .symptom("피부 가려움")
+                .severity(AllergySeverity.MODERATE)
+                .identifiedAt(LocalDate.of(2026, 4, 20))
+                .isActive(true)
+                .memo("삭제 대상")
+                .build());
+
+        mockMvc.perform(delete("/api/pets/{petId}/allergies/{allergyId}", pet.getId(), allergyRecord.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        assertThat(allergyRecordRepository.findById(allergyRecord.getId())).isEmpty();
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 펫으로 알러지 기록 등록 요청 시 404를 반환한다")
+    void registerAllergy_whenPetNotFound() throws Exception {
+        Member member = createMember("pet-not-found-allergy@test.com", "petNotFoundAllergyUser");
+        String accessToken = createAccessToken(member);
+        UUID notFoundPetId = UUID.randomUUID();
+
+        RegisterAllergyRequest request = new RegisterAllergyRequest(
+                "닭고기",
+                "피부 가려움",
+                "MODERATE",
+                LocalDate.of(2026, 4, 20),
+                true,
+                "등록 실패 케이스"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/allergies", notFoundPetId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESOURCE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + notFoundPetId + "/allergies"));
+
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 알러지 기록 수정 요청 시 404를 반환한다")
+    void updateAllergy_whenAllergyNotFound() throws Exception {
+        Member member = createMember("allergy-not-found@test.com", "allergyNotFoundUser");
+        Pet pet = createPet(member, "콩이");
+        String accessToken = createAccessToken(member);
+        UUID notFoundAllergyId = UUID.randomUUID();
+
+        UpdateAllergyRequest request = new UpdateAllergyRequest(
+                "닭고기",
+                "피부 가려움",
+                "MODERATE",
+                LocalDate.of(2026, 4, 20),
+                true,
+                "수정 시도"
+        );
+
+        mockMvc.perform(put("/api/pets/{petId}/allergies/{allergyId}", pet.getId(), notFoundAllergyId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESOURCE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 알러지 기록을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/allergies/" + notFoundAllergyId));
+
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 펫 알러지 기록 조회 요청 시 403을 반환한다")
+    void getAllergyList_whenPetOwnedByOtherUser() throws Exception {
+        Member owner = createMember("allergy-owner@test.com", "allergyOwnerUser");
+        Member stranger = createMember("allergy-stranger@test.com", "allergyStrangerUser");
+        Pet ownerPet = createPet(owner, "주인강아지");
+        String strangerAccessToken = createAccessToken(stranger);
+
+        allergyRecordRepository.save(AllergyRecord.builder()
+                .pet(ownerPet)
+                .allergenName("닭고기")
+                .symptom("피부 가려움")
+                .severity(AllergySeverity.MODERATE)
+                .identifiedAt(LocalDate.of(2026, 4, 20))
+                .isActive(true)
+                .memo("권한 테스트")
+                .build());
+
+        mockMvc.perform(get("/api/pets/{petId}/allergies", ownerPet.getId())
+                        .header("Authorization", "Bearer " + strangerAccessToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_FORBIDDEN.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫에 대한 권한이 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + ownerPet.getId() + "/allergies"));
+
+        assertThat(allergyRecordRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 펫 알러지 기록 수정 요청 시 403을 반환한다")
+    void updateAllergy_whenPetOwnedByOtherUser() throws Exception {
+        Member owner = createMember("allergy-update-owner@test.com", "allergyUpdateOwnerUser");
+        Member stranger = createMember("allergy-update-stranger@test.com", "allergyUpdateStrangerUser");
+        Pet ownerPet = createPet(owner, "주인강아지");
+        String strangerAccessToken = createAccessToken(stranger);
+
+        AllergyRecord allergyRecord = allergyRecordRepository.save(AllergyRecord.builder()
+                .pet(ownerPet)
+                .allergenName("유제품")
+                .symptom("설사")
+                .severity(AllergySeverity.MILD)
+                .identifiedAt(LocalDate.of(2025, 12, 1))
+                .isActive(true)
+                .memo("권한 테스트")
+                .build());
+
+        UpdateAllergyRequest request = new UpdateAllergyRequest(
+                "닭고기",
+                "피부 가려움",
+                "SEVERE",
+                LocalDate.of(2026, 4, 20),
+                false,
+                "타인 수정 시도"
+        );
+
+        mockMvc.perform(put("/api/pets/{petId}/allergies/{allergyId}", ownerPet.getId(), allergyRecord.getId())
+                        .header("Authorization", "Bearer " + strangerAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_FORBIDDEN.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫에 대한 권한이 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + ownerPet.getId() + "/allergies/" + allergyRecord.getId()));
+
+        AllergyRecord notUpdated = allergyRecordRepository.findById(allergyRecord.getId()).orElseThrow();
+        assertThat(notUpdated.getAllergenName()).isEqualTo("유제품");
+        assertThat(notUpdated.getSeverity()).isEqualTo(AllergySeverity.MILD);
+    }
+
+    @Test
+    @DisplayName("잘못된 알러지 심각도면 등록에 실패한다")
+    void registerAllergy_whenSeverityIsInvalid() throws Exception {
+        Member member = createMember("invalid-severity@test.com", "invalidSeverityUser");
+        Pet pet = createPet(member, "토리");
+        String accessToken = createAccessToken(member);
+
+        RegisterAllergyRequest request = new RegisterAllergyRequest(
+                "닭고기",
+                "피부 가려움",
+                "INVALID",
+                LocalDate.of(2026, 4, 20),
+                true,
+                "잘못된 심각도"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/allergies", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("알러지 심각도 값이 올바르지 않습니다. | INVALID"))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/allergies"));
+
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("심각도 값이 없어도 알러지 기록 등록에 성공한다")
+    void registerAllergy_whenSeverityIsNull() throws Exception {
+        Member member = createMember("null-severity@test.com", "nullSeverityUser");
+        Pet pet = createPet(member, "하늘");
+        String accessToken = createAccessToken(member);
+
+        RegisterAllergyRequest request = new RegisterAllergyRequest(
+                "밀가루",
+                "귀 주변 발진",
+                null,
+                LocalDate.of(2026, 4, 21),
+                true,
+                "심각도 미정"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/allergies", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.allergen_name").value("밀가루"))
+                .andExpect(jsonPath("$.severity").isEmpty())
+                .andExpect(jsonPath("$.is_active").value(true));
+
+        AllergyRecord saved = allergyRecordRepository.findAll().getFirst();
+        assertThat(saved.getSeverity()).isNull();
+        assertThat(saved.getAllergenName()).isEqualTo("밀가루");
+    }
+
+    @Test
+    @DisplayName("알러지 원인명이 비어 있으면 등록에 실패한다")
+    void registerAllergy_whenAllergenNameIsBlank() throws Exception {
+        Member member = createMember("blank-allergen@test.com", "blankAllergenUser");
+        Pet pet = createPet(member, "담이");
+        String accessToken = createAccessToken(member);
+
+        RegisterAllergyRequest request = new RegisterAllergyRequest(
+                "",
+                "피부 가려움",
+                "MODERATE",
+                LocalDate.of(2026, 4, 20),
+                true,
+                "잘못된 원인명"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/allergies", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("알러지 원인명은 필수입니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/allergies"));
+
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("활성 여부가 없으면 등록에 실패한다")
+    void registerAllergy_whenIsActiveIsMissing() throws Exception {
+        Member member = createMember("missing-active@test.com", "missingActiveUser");
+        Pet pet = createPet(member, "마루");
+        String accessToken = createAccessToken(member);
+
+        String requestJson = """
+                {
+                  "allergen_name": "닭고기",
+                  "symptom": "피부 가려움",
+                  "severity": "MODERATE",
+                  "identified_at": "2026-04-20",
+                  "memo": "활성 여부 누락"
+                }
+                """;
+
+        mockMvc.perform(post("/api/pets/{petId}/allergies", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("활성 여부는 필수입니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/allergies"));
+
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("인증 없이 알러지 기록 등록 요청 시 401을 반환한다")
+    void registerAllergy_whenUnauthenticated() throws Exception {
+        Member member = createMember("unauthenticated-allergy@test.com", "unauthenticatedAllergyUser");
+        Pet pet = createPet(member, "나비");
+
+        RegisterAllergyRequest request = new RegisterAllergyRequest(
+                "닭고기",
+                "피부 가려움",
+                "MODERATE",
+                LocalDate.of(2026, 4, 20),
+                true,
+                "인증 없음"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/allergies", pet.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.MISSING_AUTHORIZATION_HEADER.getCode()))
+                .andExpect(jsonPath("$.message").value(""))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/allergies"));
+
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 알러지 기록 등록 요청 시 401을 반환한다")
+    void registerAllergy_whenInvalidToken() throws Exception {
+        Member member = createMember("invalid-token-allergy@test.com", "invalidTokenAllergyUser");
+        Pet pet = createPet(member, "구름");
+
+        RegisterAllergyRequest request = new RegisterAllergyRequest(
+                "닭고기",
+                "피부 가려움",
+                "MODERATE",
+                LocalDate.of(2026, 4, 20),
+                true,
+                "잘못된 토큰"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/allergies", pet.getId())
+                        .header("Authorization", "Bearer invalid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(""))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/allergies"));
+
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 알러지 기록 삭제 요청 시 404를 반환한다")
+    void deleteAllergy_whenAllergyNotFound() throws Exception {
+        Member member = createMember("delete-not-found-allergy@test.com", "deleteNotFoundAllergyUser");
+        Pet pet = createPet(member, "별이");
+        String accessToken = createAccessToken(member);
+        UUID notFoundAllergyId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/pets/{petId}/allergies/{allergyId}", pet.getId(), notFoundAllergyId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESOURCE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 알러지 기록을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/allergies/" + notFoundAllergyId));
+
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 펫 알러지 기록 삭제 요청 시 403을 반환한다")
+    void deleteAllergy_whenPetOwnedByOtherUser() throws Exception {
+        Member owner = createMember("allergy-delete-owner@test.com", "allergyDeleteOwnerUser");
+        Member stranger = createMember("allergy-delete-stranger@test.com", "allergyDeleteStrangerUser");
+        Pet ownerPet = createPet(owner, "주인강아지");
+        String strangerAccessToken = createAccessToken(stranger);
+
+        AllergyRecord allergyRecord = allergyRecordRepository.save(AllergyRecord.builder()
+                .pet(ownerPet)
+                .allergenName("유제품")
+                .symptom("설사")
+                .severity(AllergySeverity.MILD)
+                .identifiedAt(LocalDate.of(2025, 12, 1))
+                .isActive(true)
+                .memo("삭제 권한 테스트")
+                .build());
+
+        mockMvc.perform(delete("/api/pets/{petId}/allergies/{allergyId}", ownerPet.getId(), allergyRecord.getId())
+                        .header("Authorization", "Bearer " + strangerAccessToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_FORBIDDEN.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫에 대한 권한이 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + ownerPet.getId() + "/allergies/" + allergyRecord.getId()));
+
+        assertThat(allergyRecordRepository.findById(allergyRecord.getId())).isPresent();
+        assertThat(allergyRecordRepository.count()).isEqualTo(1);
+    }
+
+    private Member createMember(String email, String nickname) {
+        Member member = Member.builder()
+                .email(email)
+                .nickName(nickname)
+                .password("password")
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private Pet createPet(Member member, String name) {
+        Pet pet = Pet.builder()
+                .member(member)
+                .name(name)
+                .birthYear(LocalDate.of(2022, 1, 1))
+                .breed(Breed.MALTESE)
+                .color(null)
+                .weight(3.4)
+                .isNeutered(true)
+                .gender("M")
+                .build();
+        return petRepository.save(pet);
+    }
+
+    private String createAccessToken(Member member) {
+        return jwtTokenProvider.generateAccessToken(member.toDto());
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/care/controller/CareCalendarControllerTest.java
+++ b/src/test/java/org/zerock/puppyrun/care/controller/CareCalendarControllerTest.java
@@ -1,0 +1,272 @@
+package org.zerock.puppyrun.care.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.zerock.puppyrun.care.entity.AllergyRecord;
+import org.zerock.puppyrun.care.entity.AllergySeverity;
+import org.zerock.puppyrun.care.entity.MedicationRecord;
+import org.zerock.puppyrun.care.entity.VaccinationRecord;
+import org.zerock.puppyrun.care.repository.AllergyRecordRepository;
+import org.zerock.puppyrun.care.repository.MedicationRecordRepository;
+import org.zerock.puppyrun.care.repository.VaccinationRecordRepository;
+import org.zerock.puppyrun.common.auth.jwt.JwtTokenProvider;
+import org.zerock.puppyrun.common.exception.ErrorCode;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.pet.entity.Breed;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.entity.PetWeightLog;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+import org.zerock.puppyrun.pet.repository.PetWeightLogRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CareCalendarControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @Autowired
+    private PetWeightLogRepository petWeightLogRepository;
+
+    @Autowired
+    private VaccinationRecordRepository vaccinationRecordRepository;
+
+    @Autowired
+    private MedicationRecordRepository medicationRecordRepository;
+
+    @Autowired
+    private AllergyRecordRepository allergyRecordRepository;
+
+    @BeforeEach
+    void setUp() {
+        allergyRecordRepository.deleteAll();
+        medicationRecordRepository.deleteAll();
+        vaccinationRecordRepository.deleteAll();
+        petWeightLogRepository.deleteAll();
+        petRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("케어 캘린더 통합 조회 API")
+    void getCareCalendar() throws Exception {
+        Member member = createMember("calendar@test.com", "calendarUser");
+        Pet pet = createPet(member, "몽이");
+        String accessToken = createAccessToken(member);
+        LocalDate today = LocalDate.now();
+        LocalDate startDate = today.minusDays(1);
+        LocalDate endDate = today.plusDays(1);
+
+        PetWeightLog weightLog = petWeightLogRepository.save(PetWeightLog.builder()
+                .pet(pet)
+                .weight(4.2)
+                .build());
+
+        VaccinationRecord vaccinationRecord = vaccinationRecordRepository.save(VaccinationRecord.builder()
+                .pet(pet)
+                .vaccineName("종합백신")
+                .vaccinatedAt(today.minusDays(1))
+                .nextVaccinationDate(today.plusYears(1).minusDays(1))
+                .hospitalName("퍼피동물병원")
+                .memo("특이 반응 없음")
+                .build());
+
+        AllergyRecord allergyRecord = allergyRecordRepository.save(AllergyRecord.builder()
+                .pet(pet)
+                .allergenName("닭고기")
+                .symptom("피부 가려움")
+                .severity(AllergySeverity.MODERATE)
+                .identifiedAt(today)
+                .isActive(true)
+                .memo("간식 섭취 후 반응")
+                .build());
+
+        medicationRecordRepository.save(MedicationRecord.builder()
+                .pet(pet)
+                .medicationName("심장사상충 예방약")
+                .administeredAt(today.plusDays(1).atTime(9, 0))
+                .doseAmount(1.0)
+                .doseUnit("tablet")
+                .memo("식후 투약")
+                .build());
+
+        allergyRecordRepository.save(AllergyRecord.builder()
+                .pet(pet)
+                .allergenName("우유")
+                .symptom("설사")
+                .severity(AllergySeverity.MILD)
+                .identifiedAt(null)
+                .isActive(true)
+                .memo("날짜 없음")
+                .build());
+
+        mockMvc.perform(get("/api/pets/{petId}/care-calendar", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("startDate", startDate.toString())
+                        .param("endDate", endDate.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.start_date").value(startDate.toString()))
+                .andExpect(jsonPath("$.end_date").value(endDate.toString()))
+                .andExpect(jsonPath("$.total_event_count").value(4))
+                .andExpect(jsonPath("$.event_list[0].date").value(today.minusDays(1).toString()))
+                .andExpect(jsonPath("$.event_list[0].event_type").value("VACCINATION"))
+                .andExpect(jsonPath("$.event_list[0].title").value("종합백신"))
+                .andExpect(jsonPath("$.event_list[0].related_id").value(vaccinationRecord.getId().toString()))
+                .andExpect(jsonPath("$.event_list[1].date").value(today.toString()))
+                .andExpect(jsonPath("$.event_list[1].event_type").value("ALLERGY"))
+                .andExpect(jsonPath("$.event_list[1].title").value("닭고기"))
+                .andExpect(jsonPath("$.event_list[1].related_id").value(allergyRecord.getId().toString()))
+                .andExpect(jsonPath("$.event_list[2].date").value(today.toString()))
+                .andExpect(jsonPath("$.event_list[2].event_type").value("WEIGHT"))
+                .andExpect(jsonPath("$.event_list[2].title").value("체중 기록"))
+                .andExpect(jsonPath("$.event_list[2].related_id").value(weightLog.getId().toString()))
+                .andExpect(jsonPath("$.event_list[3].date").value(today.plusDays(1).toString()))
+                .andExpect(jsonPath("$.event_list[3].event_type").value("MEDICATION"))
+                .andExpect(jsonPath("$.event_list[3].title").value("심장사상충 예방약"));
+
+        assertThat(allergyRecordRepository.count()).isEqualTo(2);
+        assertThat(vaccinationRecordRepository.count()).isEqualTo(1);
+        assertThat(medicationRecordRepository.count()).isEqualTo(1);
+        assertThat(petWeightLogRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 펫으로 케어 캘린더 조회 요청 시 404를 반환한다")
+    void getCareCalendar_whenPetNotFound() throws Exception {
+        Member member = createMember("calendar-not-found@test.com", "calendarNotFoundUser");
+        String accessToken = createAccessToken(member);
+        LocalDate today = LocalDate.now();
+        UUID notFoundPetId = UUID.randomUUID();
+
+        mockMvc.perform(get("/api/pets/{petId}/care-calendar", notFoundPetId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("startDate", today.minusDays(1).toString())
+                        .param("endDate", today.plusDays(1).toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESOURCE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + notFoundPetId + "/care-calendar"));
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 펫 케어 캘린더 조회 요청 시 403을 반환한다")
+    void getCareCalendar_whenPetOwnedByOtherUser() throws Exception {
+        Member owner = createMember("calendar-owner@test.com", "calendarOwnerUser");
+        Member stranger = createMember("calendar-stranger@test.com", "calendarStrangerUser");
+        Pet ownerPet = createPet(owner, "주인강아지");
+        String strangerAccessToken = createAccessToken(stranger);
+        LocalDate today = LocalDate.now();
+
+        mockMvc.perform(get("/api/pets/{petId}/care-calendar", ownerPet.getId())
+                        .header("Authorization", "Bearer " + strangerAccessToken)
+                        .param("startDate", today.minusDays(1).toString())
+                        .param("endDate", today.plusDays(1).toString()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_FORBIDDEN.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫에 대한 권한이 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + ownerPet.getId() + "/care-calendar"));
+    }
+
+    @Test
+    @DisplayName("조회 시작일이 종료일보다 늦으면 케어 캘린더 조회에 실패한다")
+    void getCareCalendar_whenDateRangeIsInvalid() throws Exception {
+        Member member = createMember("calendar-invalid-date@test.com", "calendarInvalidDateUser");
+        Pet pet = createPet(member, "보리");
+        String accessToken = createAccessToken(member);
+        LocalDate today = LocalDate.now();
+
+        mockMvc.perform(get("/api/pets/{petId}/care-calendar", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("startDate", today.plusDays(1).toString())
+                        .param("endDate", today.minusDays(1).toString()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("조회 시작일은 종료일보다 늦을 수 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/care-calendar"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 케어 캘린더 조회 요청 시 401을 반환한다")
+    void getCareCalendar_whenUnauthenticated() throws Exception {
+        Member member = createMember("calendar-unauthenticated@test.com", "calendarUnauthenticatedUser");
+        Pet pet = createPet(member, "나비");
+        LocalDate today = LocalDate.now();
+
+        mockMvc.perform(get("/api/pets/{petId}/care-calendar", pet.getId())
+                        .param("startDate", today.minusDays(1).toString())
+                        .param("endDate", today.plusDays(1).toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.MISSING_AUTHORIZATION_HEADER.getCode()))
+                .andExpect(jsonPath("$.message").value(""))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/care-calendar"));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 케어 캘린더 조회 요청 시 401을 반환한다")
+    void getCareCalendar_whenInvalidToken() throws Exception {
+        Member member = createMember("calendar-invalid-token@test.com", "calendarInvalidTokenUser");
+        Pet pet = createPet(member, "구름");
+        LocalDate today = LocalDate.now();
+
+        mockMvc.perform(get("/api/pets/{petId}/care-calendar", pet.getId())
+                        .header("Authorization", "Bearer invalid-token")
+                        .param("startDate", today.minusDays(1).toString())
+                        .param("endDate", today.plusDays(1).toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(""))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/care-calendar"));
+    }
+
+    private Member createMember(String email, String nickname) {
+        Member member = Member.builder()
+                .email(email)
+                .nickName(nickname)
+                .password("password")
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private Pet createPet(Member member, String name) {
+        Pet pet = Pet.builder()
+                .member(member)
+                .name(name)
+                .birthYear(LocalDate.of(2022, 1, 1))
+                .breed(Breed.MALTESE)
+                .color(null)
+                .weight(3.4)
+                .isNeutered(true)
+                .gender("M")
+                .build();
+        return petRepository.save(pet);
+    }
+
+    private String createAccessToken(Member member) {
+        return jwtTokenProvider.generateAccessToken(member.toDto());
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/care/controller/MedicationControllerTest.java
+++ b/src/test/java/org/zerock/puppyrun/care/controller/MedicationControllerTest.java
@@ -1,0 +1,522 @@
+package org.zerock.puppyrun.care.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.zerock.puppyrun.care.controller.request.RegisterMedicationRequest;
+import org.zerock.puppyrun.care.controller.request.UpdateMedicationRequest;
+import org.zerock.puppyrun.care.entity.MedicationRecord;
+import org.zerock.puppyrun.care.repository.MedicationRecordRepository;
+import org.zerock.puppyrun.common.auth.jwt.JwtTokenProvider;
+import org.zerock.puppyrun.common.exception.ErrorCode;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.pet.entity.Breed;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MedicationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @Autowired
+    private MedicationRecordRepository medicationRecordRepository;
+
+    @BeforeEach
+    void setUp() {
+        medicationRecordRepository.deleteAll();
+        petRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("투약 기록 등록 API")
+    void registerMedication() throws Exception {
+        Member member = createMember("register-medication@test.com", "registerMedicationUser");
+        Pet pet = createPet(member, "몽이");
+        String accessToken = createAccessToken(member);
+
+        RegisterMedicationRequest request = new RegisterMedicationRequest(
+                "심장사상충 예방약",
+                LocalDateTime.of(2026, 4, 20, 9, 0, 0),
+                1.0,
+                "tablet",
+                "식후 투약"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/medication-logs", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.medication_name").value("심장사상충 예방약"))
+                .andExpect(jsonPath("$.administered_at").value("2026-04-20T09:00:00"))
+                .andExpect(jsonPath("$.dose_amount").value(1.0))
+                .andExpect(jsonPath("$.dose_unit").value("tablet"))
+                .andExpect(jsonPath("$.memo").value("식후 투약"));
+
+        assertThat(medicationRecordRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("투약 기록 목록 조회 API")
+    void getMedicationList() throws Exception {
+        Member member = createMember("list-medication@test.com", "listMedicationUser");
+        Pet pet = createPet(member, "두부");
+        String accessToken = createAccessToken(member);
+
+        LocalDateTime sameAdministeredAt = LocalDateTime.of(2026, 4, 20, 9, 0, 0);
+
+        medicationRecordRepository.save(MedicationRecord.builder()
+                .pet(pet)
+                .medicationName("항생제")
+                .administeredAt(LocalDateTime.of(2026, 4, 19, 20, 30, 0))
+                .doseAmount(0.5)
+                .doseUnit("ml")
+                .memo(null)
+                .build());
+
+        MedicationRecord olderCreatedRecord = medicationRecordRepository.save(MedicationRecord.builder()
+                .pet(pet)
+                .medicationName("영양제")
+                .administeredAt(sameAdministeredAt)
+                .doseAmount(1.0)
+                .doseUnit("tablet")
+                .memo("먼저 저장됨")
+                .build());
+
+        Thread.sleep(10);
+
+        MedicationRecord latestCreatedRecord = medicationRecordRepository.save(MedicationRecord.builder()
+                .pet(pet)
+                .medicationName("심장사상충 예방약")
+                .administeredAt(sameAdministeredAt)
+                .doseAmount(1.0)
+                .doseUnit("tablet")
+                .memo("나중에 저장됨")
+                .build());
+
+        mockMvc.perform(get("/api/pets/{petId}/medication-logs", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.total_medication_count").value(3))
+                .andExpect(jsonPath("$.medication_log_list[0].medication_log_id")
+                        .value(latestCreatedRecord.getId().toString()))
+                .andExpect(jsonPath("$.medication_log_list[0].medication_name").value("심장사상충 예방약"))
+                .andExpect(jsonPath("$.medication_log_list[0].administered_at").value("2026-04-20T09:00:00"))
+                .andExpect(jsonPath("$.medication_log_list[1].medication_log_id")
+                        .value(olderCreatedRecord.getId().toString()))
+                .andExpect(jsonPath("$.medication_log_list[1].medication_name").value("영양제"))
+                .andExpect(jsonPath("$.medication_log_list[2].medication_name").value("항생제"))
+                .andExpect(jsonPath("$.medication_log_list[2].administered_at").value("2026-04-19T20:30:00"));
+    }
+
+    @Test
+    @DisplayName("투약 기록이 없으면 빈 목록을 반환한다")
+    void getMedicationList_whenEmpty() throws Exception {
+        Member member = createMember("empty-list-medication@test.com", "emptyListMedicationUser");
+        Pet pet = createPet(member, "초코");
+        String accessToken = createAccessToken(member);
+
+        mockMvc.perform(get("/api/pets/{petId}/medication-logs", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.total_medication_count").value(0))
+                .andExpect(jsonPath("$.medication_log_list").isArray())
+                .andExpect(jsonPath("$.medication_log_list").isEmpty());
+
+        assertThat(medicationRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("투약 기록 수정 API")
+    void updateMedication() throws Exception {
+        Member member = createMember("update-medication@test.com", "updateMedicationUser");
+        Pet pet = createPet(member, "보리");
+        String accessToken = createAccessToken(member);
+
+        MedicationRecord medicationRecord = medicationRecordRepository.save(MedicationRecord.builder()
+                .pet(pet)
+                .medicationName("항생제")
+                .administeredAt(LocalDateTime.of(2026, 4, 20, 8, 30, 0))
+                .doseAmount(0.5)
+                .doseUnit("ml")
+                .memo("초기 메모")
+                .build());
+
+        UpdateMedicationRequest request = new UpdateMedicationRequest(
+                "심장사상충 예방약",
+                LocalDateTime.of(2026, 4, 20, 9, 0, 0),
+                1.0,
+                "tablet",
+                "식후 투약으로 변경"
+        );
+
+        mockMvc.perform(put("/api/pets/{petId}/medication-logs/{medicationLogId}", pet.getId(), medicationRecord.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.medication_log_id").value(medicationRecord.getId().toString()))
+                .andExpect(jsonPath("$.medication_name").value("심장사상충 예방약"))
+                .andExpect(jsonPath("$.administered_at").value("2026-04-20T09:00:00"))
+                .andExpect(jsonPath("$.dose_amount").value(1.0))
+                .andExpect(jsonPath("$.dose_unit").value("tablet"))
+                .andExpect(jsonPath("$.memo").value("식후 투약으로 변경"));
+
+        MedicationRecord updated = medicationRecordRepository.findById(medicationRecord.getId()).orElseThrow();
+        assertThat(updated.getMedicationName()).isEqualTo("심장사상충 예방약");
+        assertThat(updated.getAdministeredAt()).isEqualTo(LocalDateTime.of(2026, 4, 20, 9, 0, 0));
+        assertThat(updated.getDoseAmount()).isEqualTo(1.0);
+        assertThat(updated.getDoseUnit()).isEqualTo("tablet");
+        assertThat(updated.getMemo()).isEqualTo("식후 투약으로 변경");
+    }
+
+    @Test
+    @DisplayName("투약 기록 삭제 API")
+    void deleteMedication() throws Exception {
+        Member member = createMember("delete-medication@test.com", "deleteMedicationUser");
+        Pet pet = createPet(member, "해피");
+        String accessToken = createAccessToken(member);
+
+        MedicationRecord medicationRecord = medicationRecordRepository.save(MedicationRecord.builder()
+                .pet(pet)
+                .medicationName("항생제")
+                .administeredAt(LocalDateTime.of(2026, 4, 20, 20, 0, 0))
+                .doseAmount(0.5)
+                .doseUnit("ml")
+                .memo("삭제 대상")
+                .build());
+
+        mockMvc.perform(delete("/api/pets/{petId}/medication-logs/{medicationLogId}", pet.getId(), medicationRecord.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        assertThat(medicationRecordRepository.findById(medicationRecord.getId())).isEmpty();
+        assertThat(medicationRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 펫으로 투약 기록 등록 요청 시 404를 반환한다")
+    void registerMedication_whenPetNotFound() throws Exception {
+        Member member = createMember("pet-not-found-medication@test.com", "petNotFoundMedicationUser");
+        String accessToken = createAccessToken(member);
+        UUID notFoundPetId = UUID.randomUUID();
+
+        RegisterMedicationRequest request = new RegisterMedicationRequest(
+                "심장사상충 예방약",
+                LocalDateTime.of(2026, 4, 20, 9, 0, 0),
+                1.0,
+                "tablet",
+                "등록 실패 케이스"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/medication-logs", notFoundPetId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESOURCE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + notFoundPetId + "/medication-logs"));
+
+        assertThat(medicationRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 투약 기록 수정 요청 시 404를 반환한다")
+    void updateMedication_whenMedicationNotFound() throws Exception {
+        Member member = createMember("medication-not-found@test.com", "medicationNotFoundUser");
+        Pet pet = createPet(member, "콩이");
+        String accessToken = createAccessToken(member);
+        UUID notFoundMedicationLogId = UUID.randomUUID();
+
+        UpdateMedicationRequest request = new UpdateMedicationRequest(
+                "심장사상충 예방약",
+                LocalDateTime.of(2026, 4, 20, 9, 0, 0),
+                1.0,
+                "tablet",
+                "수정 시도"
+        );
+
+        mockMvc.perform(put("/api/pets/{petId}/medication-logs/{medicationLogId}", pet.getId(), notFoundMedicationLogId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESOURCE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 투약 기록을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.path")
+                        .value("/api/pets/" + pet.getId() + "/medication-logs/" + notFoundMedicationLogId));
+
+        assertThat(medicationRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("투약량이 0 이하이면 수정에 실패한다")
+    void updateMedication_whenDoseAmountIsInvalid() throws Exception {
+        Member member = createMember("invalid-update-dose@test.com", "invalidUpdateDoseUser");
+        Pet pet = createPet(member, "보리");
+        String accessToken = createAccessToken(member);
+
+        MedicationRecord medicationRecord = medicationRecordRepository.save(MedicationRecord.builder()
+                .pet(pet)
+                .medicationName("항생제")
+                .administeredAt(LocalDateTime.of(2026, 4, 20, 8, 30, 0))
+                .doseAmount(0.5)
+                .doseUnit("ml")
+                .memo("초기 메모")
+                .build());
+
+        UpdateMedicationRequest request = new UpdateMedicationRequest(
+                "심장사상충 예방약",
+                LocalDateTime.of(2026, 4, 20, 9, 0, 0),
+                0.0,
+                "tablet",
+                "잘못된 투약량으로 수정"
+        );
+
+        mockMvc.perform(put("/api/pets/{petId}/medication-logs/{medicationLogId}", pet.getId(), medicationRecord.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("투약량은 0보다 커야 합니다."))
+                .andExpect(jsonPath("$.path")
+                        .value("/api/pets/" + pet.getId() + "/medication-logs/" + medicationRecord.getId()));
+
+        MedicationRecord notUpdated = medicationRecordRepository.findById(medicationRecord.getId()).orElseThrow();
+        assertThat(notUpdated.getMedicationName()).isEqualTo("항생제");
+        assertThat(notUpdated.getDoseAmount()).isEqualTo(0.5);
+        assertThat(notUpdated.getDoseUnit()).isEqualTo("ml");
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 펫 투약 기록 수정 요청 시 403을 반환한다")
+    void updateMedication_whenPetOwnedByOtherUser() throws Exception {
+        Member owner = createMember("medication-update-owner@test.com", "medicationUpdateOwnerUser");
+        Member stranger = createMember("medication-update-stranger@test.com", "medicationUpdateStrangerUser");
+        Pet ownerPet = createPet(owner, "주인강아지");
+        String strangerAccessToken = createAccessToken(stranger);
+
+        MedicationRecord medicationRecord = medicationRecordRepository.save(MedicationRecord.builder()
+                .pet(ownerPet)
+                .medicationName("항생제")
+                .administeredAt(LocalDateTime.of(2026, 4, 20, 9, 0, 0))
+                .doseAmount(0.5)
+                .doseUnit("ml")
+                .memo("권한 테스트")
+                .build());
+
+        UpdateMedicationRequest request = new UpdateMedicationRequest(
+                "심장사상충 예방약",
+                LocalDateTime.of(2026, 4, 20, 10, 0, 0),
+                1.0,
+                "tablet",
+                "타인 수정 시도"
+        );
+
+        mockMvc.perform(put("/api/pets/{petId}/medication-logs/{medicationLogId}", ownerPet.getId(), medicationRecord.getId())
+                        .header("Authorization", "Bearer " + strangerAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_FORBIDDEN.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫에 대한 권한이 없습니다."))
+                .andExpect(jsonPath("$.path")
+                        .value("/api/pets/" + ownerPet.getId() + "/medication-logs/" + medicationRecord.getId()));
+
+        MedicationRecord notUpdated = medicationRecordRepository.findById(medicationRecord.getId()).orElseThrow();
+        assertThat(notUpdated.getMedicationName()).isEqualTo("항생제");
+        assertThat(notUpdated.getDoseAmount()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 펫 투약 기록 조회 요청 시 403을 반환한다")
+    void getMedicationList_whenPetOwnedByOtherUser() throws Exception {
+        Member owner = createMember("medication-owner@test.com", "medicationOwnerUser");
+        Member stranger = createMember("medication-stranger@test.com", "medicationStrangerUser");
+        Pet ownerPet = createPet(owner, "주인강아지");
+        String strangerAccessToken = createAccessToken(stranger);
+
+        medicationRecordRepository.save(MedicationRecord.builder()
+                .pet(ownerPet)
+                .medicationName("항생제")
+                .administeredAt(LocalDateTime.of(2026, 4, 20, 9, 0, 0))
+                .doseAmount(0.5)
+                .doseUnit("ml")
+                .memo("권한 테스트")
+                .build());
+
+        mockMvc.perform(get("/api/pets/{petId}/medication-logs", ownerPet.getId())
+                        .header("Authorization", "Bearer " + strangerAccessToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_FORBIDDEN.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫에 대한 권한이 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + ownerPet.getId() + "/medication-logs"));
+
+        assertThat(medicationRecordRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("투약량이 0 이하이면 등록에 실패한다")
+    void registerMedication_whenDoseAmountIsInvalid() throws Exception {
+        Member member = createMember("invalid-dose@test.com", "invalidDoseUser");
+        Pet pet = createPet(member, "토리");
+        String accessToken = createAccessToken(member);
+
+        RegisterMedicationRequest request = new RegisterMedicationRequest(
+                "심장사상충 예방약",
+                LocalDateTime.of(2026, 4, 20, 9, 0, 0),
+                0.0,
+                "tablet",
+                "잘못된 투약량"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/medication-logs", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("투약량은 0보다 커야 합니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/medication-logs"));
+
+        assertThat(medicationRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 투약 기록 삭제 요청 시 404를 반환한다")
+    void deleteMedication_whenMedicationNotFound() throws Exception {
+        Member member = createMember("delete-not-found-medication@test.com", "deleteNotFoundMedicationUser");
+        Pet pet = createPet(member, "까미");
+        String accessToken = createAccessToken(member);
+        UUID notFoundMedicationLogId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/pets/{petId}/medication-logs/{medicationLogId}", pet.getId(), notFoundMedicationLogId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESOURCE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 투약 기록을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.path")
+                        .value("/api/pets/" + pet.getId() + "/medication-logs/" + notFoundMedicationLogId));
+
+        assertThat(medicationRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("인증 없이 투약 기록 등록 요청 시 401을 반환한다")
+    void registerMedication_whenUnauthenticated() throws Exception {
+        Member member = createMember("unauthenticated@test.com", "unauthenticatedUser");
+        Pet pet = createPet(member, "나비");
+
+        RegisterMedicationRequest request = new RegisterMedicationRequest(
+                "심장사상충 예방약",
+                LocalDateTime.of(2026, 4, 20, 9, 0, 0),
+                1.0,
+                "tablet",
+                "인증 없음"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/medication-logs", pet.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.MISSING_AUTHORIZATION_HEADER.getCode()))
+                .andExpect(jsonPath("$.message").value(""))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/medication-logs"));
+
+        assertThat(medicationRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 투약 기록 등록 요청 시 401을 반환한다")
+    void registerMedication_whenInvalidToken() throws Exception {
+        Member member = createMember("invalid-token@test.com", "invalidTokenUser");
+        Pet pet = createPet(member, "구름");
+
+        RegisterMedicationRequest request = new RegisterMedicationRequest(
+                "심장사상충 예방약",
+                LocalDateTime.of(2026, 4, 20, 9, 0, 0),
+                1.0,
+                "tablet",
+                "잘못된 토큰"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/medication-logs", pet.getId())
+                        .header("Authorization", "Bearer invalid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(""))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/medication-logs"));
+
+        assertThat(medicationRecordRepository.count()).isZero();
+    }
+
+    private Member createMember(String email, String nickname) {
+        Member member = Member.builder()
+                .email(email)
+                .nickName(nickname)
+                .password("password")
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private Pet createPet(Member member, String name) {
+        Pet pet = Pet.builder()
+                .member(member)
+                .name(name)
+                .birthYear(LocalDate.of(2022, 1, 1))
+                .breed(Breed.MALTESE)
+                .color(null)
+                .weight(3.4)
+                .isNeutered(true)
+                .gender("M")
+                .build();
+        return petRepository.save(pet);
+    }
+
+    private String createAccessToken(Member member) {
+        return jwtTokenProvider.generateAccessToken(member.toDto());
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/care/controller/VaccinationControllerTest.java
+++ b/src/test/java/org/zerock/puppyrun/care/controller/VaccinationControllerTest.java
@@ -1,0 +1,333 @@
+package org.zerock.puppyrun.care.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.zerock.puppyrun.care.controller.request.RegisterVaccinationRequest;
+import org.zerock.puppyrun.care.controller.request.UpdateVaccinationRequest;
+import org.zerock.puppyrun.care.entity.VaccinationRecord;
+import org.zerock.puppyrun.care.repository.VaccinationRecordRepository;
+import org.zerock.puppyrun.common.auth.jwt.JwtTokenProvider;
+import org.zerock.puppyrun.common.exception.ErrorCode;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.pet.entity.Breed;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class VaccinationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @Autowired
+    private VaccinationRecordRepository vaccinationRecordRepository;
+
+    @BeforeEach
+    void setUp() {
+        vaccinationRecordRepository.deleteAll();
+        petRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("접종 기록 등록 API")
+    void registerVaccination() throws Exception {
+        Member member = createMember("register@test.com", "registerUser");
+        Pet pet = createPet(member, "몽이");
+        String accessToken = createAccessToken(member);
+
+        RegisterVaccinationRequest request = new RegisterVaccinationRequest(
+                "종합백신 5차",
+                LocalDate.of(2026, 4, 20),
+                LocalDate.of(2027, 4, 20),
+                "퍼피동물병원",
+                "특이 반응 없음"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/vaccinations", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.vaccine_name").value("종합백신 5차"))
+                .andExpect(jsonPath("$.vaccinated_at").value("2026-04-20"))
+                .andExpect(jsonPath("$.next_vaccination_date").value("2027-04-20"))
+                .andExpect(jsonPath("$.hospital_name").value("퍼피동물병원"))
+                .andExpect(jsonPath("$.memo").value("특이 반응 없음"));
+
+        assertThat(vaccinationRecordRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("접종 기록 목록 조회 API")
+    void getVaccinationList() throws Exception {
+        Member member = createMember("list@test.com", "listUser");
+        Pet pet = createPet(member, "두부");
+        String accessToken = createAccessToken(member);
+
+        vaccinationRecordRepository.save(VaccinationRecord.builder()
+                .pet(pet)
+                .vaccineName("광견병")
+                .vaccinatedAt(LocalDate.of(2025, 10, 1))
+                .nextVaccinationDate(LocalDate.of(2026, 10, 1))
+                .hospitalName("퍼피동물병원")
+                .memo(null)
+                .build());
+
+        vaccinationRecordRepository.save(VaccinationRecord.builder()
+                .pet(pet)
+                .vaccineName("종합백신 5차")
+                .vaccinatedAt(LocalDate.of(2026, 4, 20))
+                .nextVaccinationDate(LocalDate.of(2027, 4, 20))
+                .hospitalName("퍼피동물병원")
+                .memo("특이 반응 없음")
+                .build());
+
+        mockMvc.perform(get("/api/pets/{petId}/vaccinations", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.total_vaccination_count").value(2))
+                .andExpect(jsonPath("$.vaccination_list[0].vaccine_name").value("종합백신 5차"))
+                .andExpect(jsonPath("$.vaccination_list[0].vaccinated_at").value("2026-04-20"))
+                .andExpect(jsonPath("$.vaccination_list[1].vaccine_name").value("광견병"))
+                .andExpect(jsonPath("$.vaccination_list[1].vaccinated_at").value("2025-10-01"));
+    }
+
+    @Test
+    @DisplayName("접종 기록 수정 API")
+    void updateVaccination() throws Exception {
+        Member member = createMember("update@test.com", "updateUser");
+        Pet pet = createPet(member, "보리");
+        String accessToken = createAccessToken(member);
+
+        VaccinationRecord vaccinationRecord = vaccinationRecordRepository.save(VaccinationRecord.builder()
+                .pet(pet)
+                .vaccineName("종합백신 4차")
+                .vaccinatedAt(LocalDate.of(2025, 4, 20))
+                .nextVaccinationDate(LocalDate.of(2026, 4, 20))
+                .hospitalName("기존동물병원")
+                .memo("초기 메모")
+                .build());
+
+        UpdateVaccinationRequest request = new UpdateVaccinationRequest(
+                "종합백신 5차",
+                LocalDate.of(2026, 4, 20),
+                LocalDate.of(2027, 5, 1),
+                "퍼피동물병원",
+                "추가 경과 관찰 예정"
+        );
+
+        mockMvc.perform(put("/api/pets/{petId}/vaccinations/{vaccinationId}", pet.getId(), vaccinationRecord.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.vaccination_id").value(vaccinationRecord.getId().toString()))
+                .andExpect(jsonPath("$.vaccine_name").value("종합백신 5차"))
+                .andExpect(jsonPath("$.vaccinated_at").value("2026-04-20"))
+                .andExpect(jsonPath("$.next_vaccination_date").value("2027-05-01"))
+                .andExpect(jsonPath("$.hospital_name").value("퍼피동물병원"))
+                .andExpect(jsonPath("$.memo").value("추가 경과 관찰 예정"));
+
+        VaccinationRecord updated = vaccinationRecordRepository.findById(vaccinationRecord.getId()).orElseThrow();
+        assertThat(updated.getVaccineName()).isEqualTo("종합백신 5차");
+        assertThat(updated.getHospitalName()).isEqualTo("퍼피동물병원");
+        assertThat(updated.getNextVaccinationDate()).isEqualTo(LocalDate.of(2027, 5, 1));
+    }
+
+    @Test
+    @DisplayName("접종 기록 삭제 API")
+    void deleteVaccination() throws Exception {
+        Member member = createMember("delete@test.com", "deleteUser");
+        Pet pet = createPet(member, "해피");
+        String accessToken = createAccessToken(member);
+
+        VaccinationRecord vaccinationRecord = vaccinationRecordRepository.save(VaccinationRecord.builder()
+                .pet(pet)
+                .vaccineName("광견병")
+                .vaccinatedAt(LocalDate.of(2026, 1, 10))
+                .nextVaccinationDate(LocalDate.of(2027, 1, 10))
+                .hospitalName("퍼피동물병원")
+                .memo("삭제 대상")
+                .build());
+
+        mockMvc.perform(delete("/api/pets/{petId}/vaccinations/{vaccinationId}", pet.getId(), vaccinationRecord.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        assertThat(vaccinationRecordRepository.findById(vaccinationRecord.getId())).isEmpty();
+        assertThat(vaccinationRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 펫으로 접종 기록 등록 요청 시 404를 반환한다")
+    void registerVaccination_whenPetNotFound() throws Exception {
+        Member member = createMember("pet-not-found@test.com", "petNotFoundUser");
+        String accessToken = createAccessToken(member);
+        UUID notFoundPetId = UUID.randomUUID();
+
+        RegisterVaccinationRequest request = new RegisterVaccinationRequest(
+                "종합백신 5차",
+                LocalDate.of(2026, 4, 20),
+                LocalDate.of(2027, 4, 20),
+                "퍼피동물병원",
+                "특이 반응 없음"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/vaccinations", notFoundPetId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESOURCE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + notFoundPetId + "/vaccinations"));
+
+        assertThat(vaccinationRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 접종 기록 수정 요청 시 404를 반환한다")
+    void updateVaccination_whenVaccinationNotFound() throws Exception {
+        Member member = createMember("vaccination-not-found@test.com", "vaccinationNotFoundUser");
+        Pet pet = createPet(member, "콩이");
+        String accessToken = createAccessToken(member);
+        UUID notFoundVaccinationId = UUID.randomUUID();
+
+        UpdateVaccinationRequest request = new UpdateVaccinationRequest(
+                "종합백신 5차",
+                LocalDate.of(2026, 4, 20),
+                LocalDate.of(2027, 4, 20),
+                "퍼피동물병원",
+                "수정 시도"
+        );
+
+        mockMvc.perform(put("/api/pets/{petId}/vaccinations/{vaccinationId}", pet.getId(), notFoundVaccinationId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESOURCE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 접종 기록을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.path")
+                        .value("/api/pets/" + pet.getId() + "/vaccinations/" + notFoundVaccinationId));
+
+        assertThat(vaccinationRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 펫 접종 기록 조회 요청 시 403을 반환한다")
+    void getVaccinationList_whenPetOwnedByOtherUser() throws Exception {
+        Member owner = createMember("owner@test.com", "ownerUser");
+        Member stranger = createMember("stranger@test.com", "strangerUser");
+        Pet ownerPet = createPet(owner, "주인강아지");
+        String strangerAccessToken = createAccessToken(stranger);
+
+        vaccinationRecordRepository.save(VaccinationRecord.builder()
+                .pet(ownerPet)
+                .vaccineName("광견병")
+                .vaccinatedAt(LocalDate.of(2026, 4, 20))
+                .nextVaccinationDate(LocalDate.of(2027, 4, 20))
+                .hospitalName("퍼피동물병원")
+                .memo("권한 테스트")
+                .build());
+
+        mockMvc.perform(get("/api/pets/{petId}/vaccinations", ownerPet.getId())
+                        .header("Authorization", "Bearer " + strangerAccessToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_FORBIDDEN.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫에 대한 권한이 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + ownerPet.getId() + "/vaccinations"));
+
+        assertThat(vaccinationRecordRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("다음 접종 예정일이 접종일보다 이전이면 등록에 실패한다")
+    void registerVaccination_whenNextVaccinationDateBeforeVaccinatedAt() throws Exception {
+        Member member = createMember("invalid-date@test.com", "invalidDateUser");
+        Pet pet = createPet(member, "토리");
+        String accessToken = createAccessToken(member);
+
+        RegisterVaccinationRequest request = new RegisterVaccinationRequest(
+                "종합백신 5차",
+                LocalDate.of(2026, 4, 20),
+                LocalDate.of(2026, 4, 19),
+                "퍼피동물병원",
+                "잘못된 날짜"
+        );
+
+        mockMvc.perform(post("/api/pets/{petId}/vaccinations", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("다음 접종 예정일은 접종일보다 이전일 수 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/vaccinations"));
+
+        assertThat(vaccinationRecordRepository.count()).isZero();
+    }
+
+    private Member createMember(String email, String nickname) {
+        Member member = Member.builder()
+                .email(email)
+                .nickName(nickname)
+                .password("password")
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private Pet createPet(Member member, String name) {
+        Pet pet = Pet.builder()
+                .member(member)
+                .name(name)
+                .birthYear(LocalDate.of(2022, 1, 1))
+                .breed(Breed.MALTESE)
+                .color(null)
+                .weight(3.4)
+                .isNeutered(true)
+                .gender("M")
+                .build();
+        return petRepository.save(pet);
+    }
+
+    private String createAccessToken(Member member) {
+        return jwtTokenProvider.generateAccessToken(member.toDto());
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/pet/controller/PetControllerTest.java
+++ b/src/test/java/org/zerock/puppyrun/pet/controller/PetControllerTest.java
@@ -1,0 +1,291 @@
+package org.zerock.puppyrun.pet.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.zerock.puppyrun.common.auth.jwt.JwtTokenProvider;
+import org.zerock.puppyrun.common.exception.ErrorCode;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.pet.controller.request.RegisterPetWeightLogRequest;
+import org.zerock.puppyrun.pet.entity.Breed;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.entity.PetWeightLog;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+import org.zerock.puppyrun.pet.repository.PetWeightLogRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PetControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @Autowired
+    private PetWeightLogRepository petWeightLogRepository;
+
+    @BeforeEach
+    void setUp() {
+        petWeightLogRepository.deleteAll();
+        petRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("체중 기록 등록 API")
+    void registerPetWeightLog() throws Exception {
+        Member member = createMember("register-weight@test.com", "registerWeightUser");
+        Pet pet = createPet(member, "몽이", 3.4);
+        String accessToken = createAccessToken(member);
+
+        RegisterPetWeightLogRequest request = new RegisterPetWeightLogRequest(4.2);
+
+        mockMvc.perform(post("/api/pets/{petId}/weight-logs", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.weight_log_id").exists())
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.weight").value(4.2))
+                .andExpect(jsonPath("$.recorded_at").exists());
+
+        Pet updatedPet = petRepository.findById(pet.getId()).orElseThrow();
+        assertThat(updatedPet.getWeight()).isEqualTo(4.2);
+
+        assertThat(petWeightLogRepository.count()).isEqualTo(1);
+        PetWeightLog savedLog = petWeightLogRepository.findAll().getFirst();
+        assertThat(savedLog.getPet().getId()).isEqualTo(pet.getId());
+        assertThat(savedLog.getWeight()).isEqualTo(4.2);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 펫으로 체중 기록 등록 요청 시 404를 반환한다")
+    void registerPetWeightLog_whenPetNotFound() throws Exception {
+        Member member = createMember("pet-not-found-weight@test.com", "petNotFoundWeightUser");
+        String accessToken = createAccessToken(member);
+        UUID notFoundPetId = UUID.randomUUID();
+
+        RegisterPetWeightLogRequest request = new RegisterPetWeightLogRequest(4.2);
+
+        mockMvc.perform(post("/api/pets/{petId}/weight-logs", notFoundPetId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESOURCE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + notFoundPetId + "/weight-logs"));
+
+        assertThat(petWeightLogRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 펫에 체중 기록 요청 시 403을 반환한다")
+    void registerPetWeightLog_whenPetOwnedByOtherUser() throws Exception {
+        Member owner = createMember("weight-owner@test.com", "weightOwnerUser");
+        Member stranger = createMember("weight-stranger@test.com", "weightStrangerUser");
+        Pet ownerPet = createPet(owner, "주인강아지", 3.4);
+        PetWeightLog existingLog = createWeightLog(ownerPet, 3.4);
+        String strangerAccessToken = createAccessToken(stranger);
+
+        RegisterPetWeightLogRequest request = new RegisterPetWeightLogRequest(4.2);
+
+        mockMvc.perform(post("/api/pets/{petId}/weight-logs", ownerPet.getId())
+                        .header("Authorization", "Bearer " + strangerAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_FORBIDDEN.getCode()))
+                .andExpect(jsonPath("$.message").value("해당 펫에 대한 권한이 없습니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + ownerPet.getId() + "/weight-logs"));
+
+        Pet notUpdatedPet = petRepository.findById(ownerPet.getId()).orElseThrow();
+        PetWeightLog notUpdatedLog = petWeightLogRepository.findById(existingLog.getId()).orElseThrow();
+        assertThat(notUpdatedPet.getWeight()).isEqualTo(3.4);
+        assertThat(notUpdatedLog.getWeight()).isEqualTo(3.4);
+        assertThat(petWeightLogRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("인증 없이 체중 기록 등록 요청 시 401을 반환한다")
+    void registerPetWeightLog_whenUnauthenticated() throws Exception {
+        Member member = createMember("unauthenticated-weight@test.com", "unauthenticatedWeightUser");
+        Pet pet = createPet(member, "나비", 3.4);
+
+        RegisterPetWeightLogRequest request = new RegisterPetWeightLogRequest(4.2);
+
+        mockMvc.perform(post("/api/pets/{petId}/weight-logs", pet.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.MISSING_AUTHORIZATION_HEADER.getCode()))
+                .andExpect(jsonPath("$.message").value(""))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/weight-logs"));
+
+        Pet notUpdatedPet = petRepository.findById(pet.getId()).orElseThrow();
+        assertThat(notUpdatedPet.getWeight()).isEqualTo(3.4);
+        assertThat(petWeightLogRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 체중 기록 등록 요청 시 401을 반환한다")
+    void registerPetWeightLog_whenInvalidToken() throws Exception {
+        Member member = createMember("invalid-token-weight@test.com", "invalidTokenWeightUser");
+        Pet pet = createPet(member, "구름", 3.4);
+
+        RegisterPetWeightLogRequest request = new RegisterPetWeightLogRequest(4.2);
+
+        mockMvc.perform(post("/api/pets/{petId}/weight-logs", pet.getId())
+                        .header("Authorization", "Bearer invalid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(""))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/weight-logs"));
+
+        Pet notUpdatedPet = petRepository.findById(pet.getId()).orElseThrow();
+        assertThat(notUpdatedPet.getWeight()).isEqualTo(3.4);
+        assertThat(petWeightLogRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("체중이 0 이하이면 등록에 실패한다")
+    void registerPetWeightLog_whenWeightIsInvalid() throws Exception {
+        Member member = createMember("invalid-weight@test.com", "invalidWeightUser");
+        Pet pet = createPet(member, "토리", 3.4);
+        String accessToken = createAccessToken(member);
+
+        RegisterPetWeightLogRequest request = new RegisterPetWeightLogRequest(0.0);
+
+        mockMvc.perform(post("/api/pets/{petId}/weight-logs", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("몸무게는 1kg 이상이어야 합니다."))
+                .andExpect(jsonPath("$.path").value("/api/pets/" + pet.getId() + "/weight-logs"));
+
+        Pet notUpdatedPet = petRepository.findById(pet.getId()).orElseThrow();
+        assertThat(notUpdatedPet.getWeight()).isEqualTo(3.4);
+        assertThat(petWeightLogRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("같은 날 이미 체중 기록이 있으면 새 로그를 만들지 않고 기존 로그를 수정한다")
+    void registerPetWeightLog_whenSameDayLogExists() throws Exception {
+        Member member = createMember("same-day-weight@test.com", "sameDayWeightUser");
+        Pet pet = createPet(member, "보리", 3.4);
+        PetWeightLog existingLog = createWeightLog(pet, 3.4);
+        String accessToken = createAccessToken(member);
+
+        RegisterPetWeightLogRequest request = new RegisterPetWeightLogRequest(4.1);
+
+        mockMvc.perform(post("/api/pets/{petId}/weight-logs", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.weight_log_id").value(existingLog.getId().toString()))
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.weight").value(4.1))
+                .andExpect(jsonPath("$.recorded_at").exists());
+
+        Pet updatedPet = petRepository.findById(pet.getId()).orElseThrow();
+        PetWeightLog updatedLog = petWeightLogRepository.findById(existingLog.getId()).orElseThrow();
+        assertThat(updatedPet.getWeight()).isEqualTo(4.1);
+        assertThat(updatedLog.getWeight()).isEqualTo(4.1);
+        assertThat(petWeightLogRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("직전 로그와 같은 체중이면 중복 로그를 추가하지 않는다")
+    void registerPetWeightLog_whenWeightIsSameAsLatestLog() throws Exception {
+        Member member = createMember("duplicate-weight@test.com", "duplicateWeightUser");
+        Pet pet = createPet(member, "하늘", 3.4);
+        PetWeightLog existingLog = createWeightLog(pet, 3.4);
+        String accessToken = createAccessToken(member);
+
+        RegisterPetWeightLogRequest request = new RegisterPetWeightLogRequest(3.4);
+
+        mockMvc.perform(post("/api/pets/{petId}/weight-logs", pet.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.weight_log_id").value(existingLog.getId().toString()))
+                .andExpect(jsonPath("$.pet_id").value(pet.getId().toString()))
+                .andExpect(jsonPath("$.weight").value(3.4))
+                .andExpect(jsonPath("$.recorded_at").exists());
+
+        Pet notChangedPet = petRepository.findById(pet.getId()).orElseThrow();
+        PetWeightLog notChangedLog = petWeightLogRepository.findById(existingLog.getId()).orElseThrow();
+        assertThat(notChangedPet.getWeight()).isEqualTo(3.4);
+        assertThat(notChangedLog.getWeight()).isEqualTo(3.4);
+        assertThat(petWeightLogRepository.count()).isEqualTo(1);
+    }
+
+    private Member createMember(String email, String nickname) {
+        Member member = Member.builder()
+                .email(email)
+                .nickName(nickname)
+                .password("password")
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private Pet createPet(Member member, String name, double weight) {
+        Pet pet = Pet.builder()
+                .member(member)
+                .name(name)
+                .birthYear(LocalDate.of(2022, 1, 1))
+                .breed(Breed.MALTESE)
+                .color(null)
+                .weight(weight)
+                .isNeutered(true)
+                .gender("M")
+                .build();
+        return petRepository.save(pet);
+    }
+
+    private PetWeightLog createWeightLog(Pet pet, double weight) {
+        PetWeightLog petWeightLog = PetWeightLog.builder()
+                .pet(pet)
+                .weight(weight)
+                .build();
+        return petWeightLogRepository.save(petWeightLog);
+    }
+
+    private String createAccessToken(Member member) {
+        return jwtTokenProvider.generateAccessToken(member.toDto());
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request: care 탭 백엔드 MVP 구현

# 📝 작업 요약 (Summary)

기존 PuppyRun 백엔드에 `care` 도메인을 추가하여 케어탭 MVP 범위의 기능을 구현했습니다.

이번 PR에서 포함한 범위는 아래와 같습니다.

- 접종 기록 CRUD API 추가
- 투약 기록 CRUD API 추가
- 알러지 기록 CRUD API 추가
- 기존 `Pet.weight + PetWeightLog`를 재사용한 체중 입력 API 추가
- 반려견 기준 기간 조회형 케어 캘린더 통합 조회 API 추가
- 각 기능에 대한 `MockMvc + JWT + H2` 기반 통합 테스트 추가

이번 구현에서는 아래 원칙을 유지했습니다.

- `Pet` 기본 프로필 필드는 중복 생성하지 않음
- 체중은 새 엔티티 없이 기존 `Pet.weight`, `PetWeightLog`를 재사용
- 케어 캘린더는 새 영속 엔티티 없이 조회 DTO로만 구성
- 기존 JWT 인증, 예외 처리, `record` DTO, `snake_case` 응답 규칙 유지
- 소유권 검증은 `PetRepository.findByIdAndVerifyOwnership(...)` 패턴 재사용

식단 분석 기능은 이번 PR 범위에 포함하지 않았습니다.

# 🛠️ 변경 사항 (Changes)

## 1. care 도메인 엔티티 및 CRUD API 추가

- `care` 패키지 추가
- `VaccinationRecord`, `MedicationRecord`, `AllergyRecord` 엔티티 추가
- `AllergySeverity` enum 추가
- 접종/투약/알러지 등록, 조회, 수정, 삭제 API 추가
- request/response DTO를 `record` 기반으로 추가
- validation annotation 적용
- `member_id`는 care 엔티티에 중복 저장하지 않고 `pet_id`만 사용
- 소유권 검증은 `PetRepository.findByIdAndVerifyOwnership(...)`로 통일

추가된 API는 아래와 같습니다.

- `POST /api/pets/{petId}/vaccinations`
- `GET /api/pets/{petId}/vaccinations`
- `PUT /api/pets/{petId}/vaccinations/{vaccinationId}`
- `DELETE /api/pets/{petId}/vaccinations/{vaccinationId}`
- `POST /api/pets/{petId}/medication-logs`
- `GET /api/pets/{petId}/medication-logs`
- `PUT /api/pets/{petId}/medication-logs/{medicationLogId}`
- `DELETE /api/pets/{petId}/medication-logs/{medicationLogId}`
- `POST /api/pets/{petId}/allergies`
- `GET /api/pets/{petId}/allergies`
- `PUT /api/pets/{petId}/allergies/{allergyId}`
- `DELETE /api/pets/{petId}/allergies/{allergyId}`

## 2. 체중 기록 입력 API 추가

- `POST /api/pets/{petId}/weight-logs` 추가
- 요청 body는 `weight`만 받는 최소 구조로 설계
- 내부 구현은 새 엔티티 없이 기존 구조를 그대로 재사용
- 체중 입력 시 `Pet.weight`를 갱신한 뒤 `petStatistics.savePetWeightLog(...)` 호출
- 기존 당일 로그 수정 정책, 동일 체중 중복 저장 스킵 정책을 그대로 따름

## 3. 케어 캘린더 통합 조회 API 추가

- `GET /api/pets/{petId}/care-calendar?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD` 추가
- 아래 4개 소스를 기간 기준으로 통합 조회
- `PetWeightLog`
- `VaccinationRecord`
- `MedicationRecord`
- `AllergyRecord`

응답은 조회 전용 DTO로 구성했습니다.

- `event_type` 포함
- 각 이벤트에 `date`, `event_type`, `title`, `related_id`, `display_text` 제공
- 날짜 기준 오름차순 정렬
- 같은 날짜 내에서는 실제 기록 시각 기준으로 안정 정렬
- `AllergyRecord.identifiedAt`이 `null`인 경우 캘린더에 배치할 날짜가 없으므로 제외

`event_type`은 아래 enum으로 정의했습니다.

- `WEIGHT`
- `VACCINATION`
- `MEDICATION`
- `ALLERGY`

## 4. 통합 테스트 추가

아래 테스트를 `MockMvc + @SpringBootTest + @ActiveProfiles("test") + JWT + H2` 패턴으로 추가했습니다.

- `VaccinationControllerTest`
- `MedicationControllerTest`
- `AllergyControllerTest`
- `PetControllerTest`
- `CareCalendarControllerTest`

검증 범위는 아래와 같습니다.

- CRUD 성공 케이스
- 존재하지 않는 리소스 실패 케이스
- 타인 펫 접근 차단 케이스
- validation 실패 케이스
- 미인증/잘못된 토큰 실패 케이스
- 체중 로그 정책 검증
- 케어 캘린더 통합 조회 및 알러지 `identifiedAt = null` 제외 검증

# 📸 테스트 시나리오 (Test Scenarios)

## 1. 접종 기록 등록

* **Method**: `POST`
* **URL**: `/api/pets/{petId}/vaccinations`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### ✅ 1-1 : 정상 등록

**Request Body**

```json
{
  "vaccine_name": "종합백신 5차",
  "vaccinated_at": "2026-04-20",
  "next_vaccination_date": "2027-04-20",
  "hospital_name": "퍼피동물병원",
  "memo": "특이 반응 없음"
}
```

**Response (200 OK)**

```json
{
  "vaccination_id": "11111111-1111-1111-1111-111111111111",
  "pet_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
  "vaccine_name": "종합백신 5차",
  "vaccinated_at": "2026-04-20",
  "next_vaccination_date": "2027-04-20",
  "hospital_name": "퍼피동물병원",
  "memo": "특이 반응 없음"
}
```

### ❌ 1-2 : 접종 예정일이 접종일보다 이전인 경우

**Request Body**

```json
{
  "vaccine_name": "종합백신 5차",
  "vaccinated_at": "2026-04-20",
  "next_vaccination_date": "2026-04-19",
  "hospital_name": "퍼피동물병원",
  "memo": "잘못된 요청"
}
```

**Response (400 Bad Request)**

```json
{
  "code": "CLIENT_001",
  "description": "잘못된 요청입니다.",
  "message": "다음 접종 예정일은 접종일보다 이전일 수 없습니다.",
  "path": "/api/pets/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/vaccinations"
}
```

## 2. 투약 기록 등록

* **Method**: `POST`
* **URL**: `/api/pets/{petId}/medication-logs`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### ✅ 2-1 : 정상 등록

**Request Body**

```json
{
  "medication_name": "심장사상충 예방약",
  "administered_at": "2026-04-20T09:00:00",
  "dose_amount": 1.0,
  "dose_unit": "tablet",
  "memo": "식후 투약"
}
```

**Response (200 OK)**

```json
{
  "medication_log_id": "22222222-2222-2222-2222-222222222222",
  "pet_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
  "medication_name": "심장사상충 예방약",
  "administered_at": "2026-04-20T09:00:00",
  "dose_amount": 1.0,
  "dose_unit": "tablet",
  "memo": "식후 투약"
}
```

### ❌ 2-2 : 투약량이 0 이하인 경우

**Request Body**

```json
{
  "medication_name": "심장사상충 예방약",
  "administered_at": "2026-04-20T09:00:00",
  "dose_amount": 0.0,
  "dose_unit": "tablet",
  "memo": "잘못된 요청"
}
```

**Response (400 Bad Request)**

```json
{
  "code": "CLIENT_001",
  "description": "잘못된 요청입니다.",
  "message": "투약량은 0보다 커야 합니다.",
  "path": "/api/pets/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/medication-logs"
}
```

## 3. 알러지 기록 등록

* **Method**: `POST`
* **URL**: `/api/pets/{petId}/allergies`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### ✅ 3-1 : 정상 등록

**Request Body**

```json
{
  "allergen_name": "닭고기",
  "symptom": "피부 가려움",
  "severity": "MODERATE",
  "identified_at": "2026-04-20",
  "is_active": true,
  "memo": "간식 섭취 후 반응"
}
```

**Response (200 OK)**

```json
{
  "allergy_id": "33333333-3333-3333-3333-333333333333",
  "pet_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
  "allergen_name": "닭고기",
  "symptom": "피부 가려움",
  "severity": "MODERATE",
  "identified_at": "2026-04-20",
  "is_active": true,
  "memo": "간식 섭취 후 반응"
}
```

### ❌ 3-2 : 잘못된 severity 값인 경우

**Request Body**

```json
{
  "allergen_name": "닭고기",
  "symptom": "피부 가려움",
  "severity": "INVALID",
  "identified_at": "2026-04-20",
  "is_active": true,
  "memo": "잘못된 요청"
}
```

**Response (400 Bad Request)**

```json
{
  "code": "CLIENT_001",
  "description": "잘못된 요청입니다.",
  "message": "알러지 심각도 값이 올바르지 않습니다. | INVALID",
  "path": "/api/pets/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/allergies"
}
```

## 4. 체중 기록 입력

* **Method**: `POST`
* **URL**: `/api/pets/{petId}/weight-logs`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### ✅ 4-1 : 정상 등록

**Request Body**

```json
{
  "weight": 4.2
}
```

**Response (200 OK)**

```json
{
  "weight_log_id": "44444444-4444-4444-4444-444444444444",
  "pet_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
  "weight": 4.2,
  "recorded_at": "2026-04-20T14:30:00"
}
```

### ❌ 4-2 : 잘못된 체중 값인 경우

**Request Body**

```json
{
  "weight": 0.0
}
```

**Response (400 Bad Request)**

```json
{
  "code": "CLIENT_001",
  "description": "잘못된 요청입니다.",
  "message": "몸무게는 1kg 이상이어야 합니다.",
  "path": "/api/pets/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/weight-logs"
}
```

## 5. 케어 캘린더 통합 조회

* **Method**: `GET`
* **URL**: `/api/pets/{petId}/care-calendar?startDate=2026-04-19&endDate=2026-04-21`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### ✅ 5-1 : 정상 조회

**Request Body**

```json
{}
```

**Response (200 OK)**

```json
{
  "pet_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
  "start_date": "2026-04-19",
  "end_date": "2026-04-21",
  "total_event_count": 4,
  "event_list": [
    {
      "date": "2026-04-19",
      "event_type": "VACCINATION",
      "title": "종합백신",
      "related_id": "11111111-1111-1111-1111-111111111111",
      "display_text": "특이 반응 없음"
    },
    {
      "date": "2026-04-20",
      "event_type": "ALLERGY",
      "title": "닭고기",
      "related_id": "33333333-3333-3333-3333-333333333333",
      "display_text": "피부 가려움"
    },
    {
      "date": "2026-04-20",
      "event_type": "WEIGHT",
      "title": "체중 기록",
      "related_id": "44444444-4444-4444-4444-444444444444",
      "display_text": "4.2kg"
    },
    {
      "date": "2026-04-21",
      "event_type": "MEDICATION",
      "title": "심장사상충 예방약",
      "related_id": "22222222-2222-2222-2222-222222222222",
      "display_text": "1.0 tablet"
    }
  ]
}
```

### ❌ 5-2 : 조회 시작일이 종료일보다 늦은 경우

**Request Body**

```json
{}
```

**Response (400 Bad Request)**

```json
{
  "code": "CLIENT_001",
  "description": "잘못된 요청입니다.",
  "message": "조회 시작일은 종료일보다 늦을 수 없습니다.",
  "path": "/api/pets/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/care-calendar"
}
```