### PR TITLE
Chae joo/refactor/s3 image upload (#9)

### DIFF
--- a/src/main/java/org/zerock/puppyrun/common/s3/S3Service.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/S3Service.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import org.zerock.puppyrun.common.exception.DataIntegrityException;
 import org.zerock.puppyrun.common.s3.rollback.S3RollbackEvent;
 
@@ -50,15 +51,8 @@ public class S3Service {
             return null; // 이미지가 null이거나 비어있으면 넘어감 (skip)
         }
 
-        // 고유한 저장 키 생성 (중복 방지용 UUID 포함)
-        String key = generateKey(file, path);
-
-        // 실제 S3 업로드 수행
-        uploadToS3(file, key);
-
-        //  트랜잭션 롤백을 대비한 이벤트 발행
-        // DB 저장 실패 시 S3 찌꺼기 파일을 지우기 위한 보상 트랜잭션 예약
-        eventPublisher.publishEvent(S3RollbackEvent.of(key));
+        String key = uploadOne(file, path);
+        publishRollbackEvent(List.of(key));
 
         return key;
     }
@@ -78,25 +72,47 @@ public class S3Service {
         // null이거나 비어있는 파일은 "첨부하지 않은 것"으로 간주하여 필터링 (skip)
         List<CompletableFuture<String>> futures = files.stream()
                 .filter(file -> file != null && !file.isEmpty())
-                .map(file -> CompletableFuture.supplyAsync(() -> {
-                    String key = generateKey(file, path);
-                    return uploadToS3(file, key);
-                }))
+                .map(file -> CompletableFuture.supplyAsync(() -> uploadOne(file, path)))
                 .toList();
 
         if (futures.isEmpty()) {
             return List.of();
         }
 
-        // 모든 업로드가 완료될 때까지 대기
-        List<String> urls = futures.stream()
+        // 일부 업로드가 실패해도 나머지 작업까지 모두 끝나야 정확한 보상 대상을 알 수 있음
+        try {
+            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
+        } catch (CompletionException e) {
+            List<String> uploadedKeys = futures.stream()
+                    .filter(future -> !future.isCompletedExceptionally())
+                    .map(CompletableFuture::join)
+                    .toList();
+
+            // 성공한 파일은 현재 트랜잭션이 롤백될 때 함께 삭제되도록 등록
+            publishRollbackEvent(uploadedKeys);
+            log.warn("다중 S3 업로드가 일부 실패했습니다. 롤백 대상: {}건", uploadedKeys.size(), e);
+            throw e;
+        }
+
+        List<String> uploadedKeys = futures.stream()
                 .map(CompletableFuture::join)
                 .toList();
 
         // 업로드된 모든 파일에 대해 통합 롤백 이벤트 발행
-        eventPublisher.publishEvent(S3RollbackEvent.listOf(urls));
+        publishRollbackEvent(uploadedKeys);
 
-        return urls;
+        return uploadedKeys;
+    }
+
+    private String uploadOne(MultipartFile file, PathContext path) {
+        String key = generateKey(file, path);
+        return uploadToS3(file, key);
+    }
+
+    private void publishRollbackEvent(List<String> uploadedKeys) {
+        if (!uploadedKeys.isEmpty()) {
+            eventPublisher.publishEvent(new S3RollbackEvent(uploadedKeys));
+        }
     }
 
     /**
@@ -110,10 +126,7 @@ public class S3Service {
             return;
         }
 
-        // null 요소는 제외하고 실제 삭제 수행
-        files.stream()
-                .filter(Objects::nonNull)
-                .forEach(this::deleteToS3);
+        deleteFiles(files);
     }
 
     /**
@@ -126,7 +139,13 @@ public class S3Service {
         if (file == null) {
             return; // null이면 넘어감
         }
-        deleteToS3(file);
+        deleteFiles(List.of(file));
+    }
+
+    private void deleteFiles(List<String> files) {
+        files.stream()
+                .filter(Objects::nonNull)
+                .forEach(this::deleteToS3);
     }
 
     /**

--- a/src/main/java/org/zerock/puppyrun/common/s3/rollback/S3RollbackEvent.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/rollback/S3RollbackEvent.java
@@ -8,17 +8,7 @@ import java.util.List;
  */
 public record S3RollbackEvent(List<String> filePaths) {
 
-    /**
-     * 단일 파일 경로로 이벤트를 생성합니다.
-     */
-    public static S3RollbackEvent of(String filePath) {
-        return new S3RollbackEvent(List.of(filePath));
-    }
-
-    /**
-     * 여러 파일 경로 리스트로 이벤트를 생성합니다.
-     */
-    public static S3RollbackEvent listOf(List<String> filePaths) {
-        return new S3RollbackEvent(filePaths);
+    public S3RollbackEvent {
+        filePaths = List.copyOf(filePaths);
     }
 }

--- a/src/main/java/org/zerock/puppyrun/diary/service/DiaryService.java
+++ b/src/main/java/org/zerock/puppyrun/diary/service/DiaryService.java
@@ -58,9 +58,10 @@ public class DiaryService {
         UUID newDiaryId = UUID.randomUUID();
         LocalDate today = LocalDate.now();
 
-        List<String> imagesUrl = imageFiles.stream()
-                .map(file -> s3Service.upload(file, new DiaryPhotoContext(newDiaryId, today)))
-                .toList();
+        List<String> imagesUrl = s3Service.uploadAll(
+                imageFiles,
+                new DiaryPhotoContext(newDiaryId, today)
+        );
 
         SkyType skyType = SkyType.fromCode(request.weather().sky());  // 날씨 코드 변환
         PrecipitationType precipitationType = PrecipitationType.fromCode(request.weather().pty()); // 날씨 코드 변환

--- a/src/test/java/org/zerock/puppyrun/s3/S3ServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/s3/S3ServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,6 +22,7 @@ import org.zerock.puppyrun.common.s3.rollback.S3RollbackEvent;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -80,7 +82,9 @@ class S3ServiceTest {
 
             assertThat(result).isNotNull();
             verify(s3Template, times(1)).upload(any(), any(), any(), any());
-            verify(eventPublisher, times(1)).publishEvent(any(S3RollbackEvent.class));
+            ArgumentCaptor<S3RollbackEvent> eventCaptor = ArgumentCaptor.forClass(S3RollbackEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            assertThat(eventCaptor.getValue().filePaths()).containsExactly(result);
         }
     }
 
@@ -106,7 +110,9 @@ class S3ServiceTest {
 
             assertThat(results).hasSize(1);
             verify(s3Template, times(1)).upload(any(), any(), any(), any());
-            verify(eventPublisher, times(1)).publishEvent(any(S3RollbackEvent.class));
+            ArgumentCaptor<S3RollbackEvent> eventCaptor = ArgumentCaptor.forClass(S3RollbackEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            assertThat(eventCaptor.getValue().filePaths()).containsExactlyElementsOf(results);
         }
 
         @Test
@@ -121,6 +127,32 @@ class S3ServiceTest {
             assertThat(results).hasSize(1); // 정상 파일 1개만 성공
             verify(s3Template, times(1)).upload(any(), any(), any(), any());
             verify(eventPublisher, times(1)).publishEvent(any(S3RollbackEvent.class));
+        }
+
+        @Test
+        @DisplayName("다중 업로드가 일부 실패하면 성공한 파일을 롤백 이벤트에 등록한다")
+        void uploadAll_partial_failure_registers_successful_files_for_rollback() {
+            MockMultipartFile successFile =
+                    new MockMultipartFile("file", "success.png", "image/png", "success".getBytes());
+            MockMultipartFile failFile =
+                    new MockMultipartFile("file", "fail.png", "image/png", "fail".getBytes());
+
+            doAnswer(invocation -> {
+                String key = invocation.getArgument(1, String.class);
+                if (key.endsWith("_fail.png")) {
+                    throw new RuntimeException("S3 upload failed");
+                }
+                return null;
+            }).when(s3Template).upload(any(), any(), any(), any());
+
+            assertThatThrownBy(() -> s3Service.uploadAll(List.of(successFile, failFile), dummyPath))
+                    .isInstanceOf(CompletionException.class)
+                    .hasRootCauseMessage("S3 upload failed");
+
+            ArgumentCaptor<S3RollbackEvent> eventCaptor = ArgumentCaptor.forClass(S3RollbackEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            assertThat(eventCaptor.getValue().filePaths()).hasSize(1);
+            assertThat(eventCaptor.getValue().filePaths().getFirst()).endsWith("_success.png");
         }
     }
 


### PR DESCRIPTION
 # 📌 Pull Request: S3 이미지 업로드 및 롤백 이벤트 처리 통합

  # 📝 작업 요약 (Summary)

  단일·다중 이미지 업로드에서 중복되던 S3 처리와 롤백 이벤트 발행 로직을 공통화했습니다.

  다이어리 이미지 등록도 파일별 단일 업로드 대신 다중 업로드 API를 사용하도록 변경하여, 여러 이미지의 롤백 대상을 하나의 이벤트로 관리할 수 있도록 개선했습니다.

  # 🛠️ 변경 사항 (Changes)

  ## 1. S3 업로드 처리 공통화

  - 단일·다중 업로드가 공통 `uploadOne()` 메서드를 사용하도록 변경
  - S3 Key 생성과 실제 업로드 호출의 중복 제거
  - 단일 업로드도 `publishRollbackEvent(List<String>)`를 통해 롤백 이벤트 발행
  - 단일·다중 삭제가 공통 `deleteFiles()` 메서드를 사용하도록 정리

  ## 2. 다중 업로드 실패 보상 강화

  - `CompletableFuture.allOf()`로 전체 업로드 작업 완료 확인
  - 일부 파일 업로드가 실패한 경우 성공한 파일 Key 수집
  - 성공한 파일만 롤백 이벤트에 등록한 후 기존 예외 재전파
  - 정상 완료 시 전체 업로드 Key를 하나의 롤백 이벤트로 발행

  ## 3. S3 롤백 이벤트 단순화

  - 단일 파일용 `of()`와 다중 파일용 `listOf()` 팩토리 메서드 제거
  - 모든 롤백 대상을 `List<String>`으로 통일
  - `List.copyOf()`를 사용해 이벤트 생성 이후 파일 경로가 변경되지 않도록 보호

  ## 4. 다이어리 이미지 업로드 통합

  - `DiaryService`에서 이미지별 `upload()` 반복 호출 제거
  - `uploadAll()`을 한 번 호출하도록 변경
  - 여러 이미지가 등록되어도 하나의 롤백 이벤트로 관리
  - null 또는 비어 있는 이미지 파일은 다중 업로드 정책에 따라 제외

  ## 5. 테스트 보강

  - 단일 업로드 이벤트에 업로드된 Key 하나가 포함되는지 검증
  - 다중 업로드 이벤트에 실제 업로드 결과 전체가 포함되는지 검증
  - 일부 업로드 실패 시 성공한 파일만 롤백 이벤트에 포함되는지 검증

  ## 6. 영향 범위

  - API 요청 및 응답 형식 변경 없음
  - Entity 및 DDL 변경 없음
  - S3 Object Key 형식 변경 없음
  - 다이어리 이미지 업로드 및 트랜잭션 롤백 시 S3 보상 처리에 영향

  # 📸 테스트 시나리오 (Test Scenarios)

  ## 1. 단일 이미지 업로드

  ### ✅ 1-1: 정상 파일 업로드

  - S3에 파일이 한 번 업로드되는지 확인
  - 업로드된 Key가 반환되는지 확인
  - 롤백 이벤트가 한 번 발행되는지 확인
  - 이벤트에 반환된 Key 하나만 포함되는지 확인

  ### ✅ 1-2: null 또는 빈 파일

  - S3 업로드를 실행하지 않는지 확인
  - 롤백 이벤트를 발행하지 않는지 확인
  - `null`을 반환하는지 확인

  ## 2. 다중 이미지 업로드

  ### ✅ 2-1: 여러 파일 정상 업로드

  - 유효한 파일이 모두 업로드되는지 확인
  - 업로드 결과가 Key 목록으로 반환되는지 확인
  - 전체 Key를 포함한 롤백 이벤트가 한 번만 발행되는지 확인

  ### ✅ 2-2: null 또는 빈 파일이 포함된 경우

  - null 또는 빈 파일만 제외되는지 확인
  - 유효한 파일은 정상적으로 업로드되는지 확인
  - 실제 업로드된 Key만 롤백 이벤트에 포함되는지 확인

  ### ❌ 2-3: 일부 파일 업로드 실패

  - 모든 비동기 업로드 작업이 완료될 때까지 대기하는지 확인
  - 성공한 파일 Key만 롤백 이벤트에 포함되는지 확인
  - 업로드 실패 예외가 호출자에게 다시 전달되는지 확인

  ## 3. 다이어리 이미지 등록

  ### ✅ 3-1: 여러 이미지 등록

  - `DiaryService`가 `uploadAll()`을 한 번 호출하는지 확인
  - 반환된 전체 이미지 Key가 다이어리에 저장되는지 확인
  - DB 트랜잭션 롤백 시 등록된 이미지가 보상 삭제 대상에 포함되는지 확인

  ## 4. 검증 결과

  - 변경 파일 `git diff --check` 통과
  - 대상 커밋:
    - `5f0aa7c` — S3 업로드 및 롤백 이벤트 처리 통합
    - `bdf7753` — 다이어리 이미지 업로드 처리 통합
  - `./gradlew test --tests org.zerock.puppyrun.s3.S3ServiceTest` 실행 시 관련 없는 `WeatherWalkingRemindSender`의 누락 타입으로 `compileJava` 단계가 실패하여 단위 테스트는 실행되지
  못함
    - `WalkingPreference`
    - `WalkingPreferenceRepository`
    - `WeatherForecast.VilageFcst`
