### PR TITLE
feat: Actuator 헬스 체크 파이프라인 구축 및 CD 자동 배포 활성화 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,16 @@
 name: Deploy to EC2
 
 on:
+  push:
+    branches:
+      - dev
   workflow_dispatch:
-#  push:
-#    branches:
-#      - dev
-#  workflow_dispatch:
-#    inputs:
-#      build_required:
-#        description: '코드 변경 시 필수 체크 (단순 .env 수정 시에는 해제하세요)'
-#        required: true
-#        default: true
-#        type: boolean
+    inputs:
+      build_required:
+        description: '코드 변경 시 필수 체크 (단순 .env 수정 시에는 해제하세요)'
+        required: true
+        default: true
+        type: boolean
 
 
 jobs:
@@ -72,19 +71,26 @@ jobs:
           ENV_BASE64=$(echo -n "${{ secrets.ENV_FILE }}" | base64 -w 0)
           
           aws ssm send-command \
-            --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
-            --document-name "AWS-RunShellScript" \
-            --region "${{ secrets.AWS_REGION }}" \
-            --parameters commands='[
-              "export AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID }}",
-              "export AWS_REGION=${{ secrets.AWS_REGION }}",
-              "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
-              "cd /home/ubuntu",
-              "echo '"$DC_BASE64"' | base64 -d > docker-compose.deploy.yml",
-              "echo '"$ENV_BASE64"' | base64 -d > .env",
-              "chmod 600 docker-compose.deploy.yml",
-              "chmod 600 .env",
-              "docker compose -f docker-compose.deploy.yml pull backend",
-              "docker compose -f docker-compose.deploy.yml up -d backend",
-              "docker image prune -f"
-            ]'
+          --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
+          --document-name "AWS-RunShellScript" \
+          --region "${{ secrets.AWS_REGION }}" \
+          --parameters commands='[
+          "export AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID }}",
+          "export AWS_REGION=${{ secrets.AWS_REGION }}",
+          "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
+          
+          "cd /home/ubuntu",
+          
+          "echo '"$DC_BASE64"' | base64 -d > docker-compose.deploy.yml",
+          "echo '"$ENV_BASE64"' | base64 -d > .env",
+          
+          "chmod 600 docker-compose.deploy.yml",
+          "chmod 600 .env",
+          
+          "docker compose -f docker-compose.deploy.yml pull backend",
+          "docker compose -f docker-compose.deploy.yml up -d backend",
+          "docker image prune -f",
+          
+          "chmod +x health-check.sh",
+          "./health-check.sh"
+          ]'

--- a/.github/workflows/scripts/health-check.sh
+++ b/.github/workflows/scripts/health-check.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+echo "===== Health Check ====="
+
+# 서비스 이름 (systemd 기준)
+SERVICE_NAME="puppyrun-backend"
+
+# 헬스체크 대상 URL
+HEALTH_URL="http://127.0.0.1:8081/actuator/health"
+
+# 최대 재시도 횟수와 대기 시간
+MAX_RETRIES=10
+SLEEP_SEC=10
+
+for i in $(seq 1 $MAX_RETRIES); do
+  sleep $SLEEP_SEC
+  if curl -sSf "$HEALTH_URL" >/dev/null; then
+    echo "[v] Backend healthy (try $i/$MAX_RETRIES)"
+    exit 0
+  else
+    echo "Waiting for backend... (try $i/$MAX_RETRIES)"
+  fi
+done
+
+
+echo "[x] Backend health check failed"
+echo "===== Recent logs from $SERVICE_NAME ====="
+journalctl -u "$SERVICE_NAME" --no-pager -n 200
+exit 1
+

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/org/zerock/puppyrun/common/auth/security/PublicEndpoints.java
+++ b/src/main/java/org/zerock/puppyrun/common/auth/security/PublicEndpoints.java
@@ -13,6 +13,8 @@ public final class PublicEndpoints {
             "/api/verification/confirm",    // 본인 확인
             "/api/auth/refresh",            // 토큰 갱신
             "/api/oauth2/*/sign-in",        // 소셜 로그인
+            "/actuator/**",             // Health Check
             "/images/default/**"            // 기본 이미지
+
     );
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,20 @@ spring:
     username: ${RABBITMQ_USERNAME:guest}
     password: ${RABBITMQ_PASSWORD:guest}
 
+management:
+  server:
+    port: 8081
+
+  endpoint:
+    health:
+      show-details: never
+
+  endpoints:
+    web:
+      exposure:
+        include: health
+
+
 app:
   base-url: ${BASE_URL} # 로컬 호스트
 


### PR DESCRIPTION
# 📌 Pull Request: Actuator 헬스 체크 파이프라인 구축 및 CD 자동 배포 활성화 

# 📝 작업 요약 (Summary)

- Spring Boot Actuator 도입 및 독립 관리 포트(`8081`) 구성을 통한 애플리케이션 헬스 체크 파이프라인 구축
- `dev` 브랜치 `push` 시 EC2 자동 배포가 수행되도록 GitHub Actions CD 워크플로우 활성화
- 배포 직후 새 애플리케이션 컨테이너의 정상 기동 여부를 자동 검증하는 헬스 체크 재시도 스크립트(`health-check.sh`) 연동
- Spring Security 미인증 허용 목록(`PublicEndpoints`)에 `/actuator/**` 추가로 헬스 체크 접근성 확보

# 🛠️ 변경 사항 (Changes)

## 1. 헬스 체크 모듈 및 엔드포인트 구성 (Actuator & Security)
- **Actuator 의존성 및 관리 포트 분리**
  - `build.gradle`에 `spring-boot-starter-actuator` 의존성 추가.
  - `application.yml`에 `management.server.port: 8081` 및 `management.endpoints.web.exposure.include: health` 설정을 추가하여 메인 웹 서비스 포트(`8080`)와 헬스 체크 포트(`8081`)를 분리.
- **보안 설정 이행**
  - `PublicEndpoints.java`의 공용 허용 URI 목록에 `/actuator/**` 경로를 추가하여 JWT 토큰 없이 헬스 체크 검증이 가능하도록 승인.

## 2. CD 배포 워크플로우 및 자동 검증 구축 (CI/CD & Scripts)
- **자동 배포 트리거 활성화**
  - `.github/workflows/deploy.yml`: `dev` 브랜치 `push` 시 EC2 SSM 자동 배포가 실행되도록 트리거 주석 해제 및 파이프라인 구조 정비.
- **배포 헬스 체크 자동 검증 스크립트 작성**
  - `.github/workflows/scripts/health-check.sh` 스크립트를 신규 작성하여 배포 완료 직후 `http://127.0.0.1:8081/actuator/health`로 최대 10회(10초 간격) 헬스 체크를 수행.
  - 헬스 체크 성공 시 배포 성공(exit 0) 처리하며, 타임아웃 실패 시 최근 백엔드 서포트 로그 출력 후 배포 실패(exit 1) 처리.

# 📸 테스트 시나리오 (Test Scenarios)

## 1. Actuator 헬스 체크 API

* **Method**: `GET`
* **URL**: `http://127.0.0.1:8081/actuator/health`
* **Content-Type**: `application/json`
* **Header**: 없음 (Public Endpoint)

### ✅ 1-1 : 정상 헬스 체크 (200 OK)

애플리케이션 및 의존성 브로커/DB가 정상적으로 기동되었을 때의 헬스 응답입니다.

**Response (200 OK)**

```json
{
  "status": "UP"
}
```

### ❌ 1-2 : 애플리케이션 수신 장애 또는 미기동 상태 (503 Service Unavailable / Connection Refused)

애플리케이션이 완전히 초기화되지 않았거나 서버 내부 장애 발생 시의 실패 케이스입니다.


**Response (503 Service Unavailable)**

```json
{
  "status": "DOWN"
}
```
