### PR TITLE
fix: EC2 Docker 컨테이너 간 MySQL 연결 포트를 내부 포트로 수정

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
     ports:
-      - "${DB_PORT}:3306"
+      - "${DB_PORT}:3307"
 
     volumes:
       - mysql_data:/var/lib/mysql

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -12,7 +12,7 @@ services:
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
     ports:
-      - "${DB_PORT}:3306"
+      - "${DB_PORT}:3307"
 
     volumes:
       - mysql_data:/var/lib/mysql


### PR DESCRIPTION
EC2 Docker 컨테이너 간 MySQL 연결 포트를 내부 포트로 수정