### PR TITLE
chore: AWS S3 기반 릴리스 아티팩트 관리 및 배포 파이프라인 개편

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,38 +183,19 @@ jobs:
 
 
       # ----------------------------------------
-      # 10. 배포에 필요한 파일을 EC2로 복사
+      # 10. 릴리스 번들을 AWS S3로 업로드
       # ----------------------------------------
-      - name: Copy deployment bundle to EC2
+      - name: Upload deployment bundle to AWS S3
 
-        # SCP를 사용하여 Runner -> EC2로 파일 전송
-        uses: appleboy/scp-action@v1
-        with:
-
-          # EC2의 SSH 접속 주소
-          host: ${{ secrets.EC2_HOST }}
-
-          # EC2 SSH 사용자
-          username: ubuntu
-
-          # EC2 SSH Private Key
-          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-
-          # SSH 서버의 fingerprint 검증
-          fingerprint: ${{ secrets.EC2_SSH_FINGERPRINT }}
-
-          # Compose, 배포 스크립트, 릴리스별 .env를 모두 전송
-          source: .github/workflows/deployment/*,.github/workflows/deployment/.env
-
-          # GitHub Actions 실행 단위의 독립 릴리스 폴더
-          target: /home/ubuntu/puppyrun/releases/${{ env.RELEASE_TAG }}
-
-          # deployment 디렉터리 자체는 제외하고 내부 파일만 복사
-          strip_components: 3
+        # S3 버킷으로 배포 아티팩트를 압축하여 업로드
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          RELEASE_BUNDLE_DIRECTORY: .github/workflows/deployment
+        run: bash .github/workflows/github-actions/upload-release-to-s3.sh
 
 
       # ----------------------------------------
-      # 11. SSM 배포 명령 전송
+      # 11. SSM 배포 명령 전송 (S3에서 다운로드 후 실행)
       # ----------------------------------------
       - name: Send deployment command to SSM
 
@@ -226,6 +207,9 @@ jobs:
           # SSM 명령을 실행할 EC2 Instance ID
           INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
 
+          # S3 아티팩트를 업로드한 S3 버킷명
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+
           # EC2에서 이번 릴리스가 저장된 디렉터리
           DEPLOY_DIRECTORY: /home/ubuntu/puppyrun/releases/${{ env.RELEASE_TAG }}
 
@@ -235,7 +219,7 @@ jobs:
           # 빌드한 경우에는 SHA 태그, 빌드를 생략한 경우에는 마지막 성공 버전을 재배포
           DEPLOY_IMAGE_TAG: ${{ (github.event_name == 'push' || github.event.inputs.build_required == true) && github.sha || '__CURRENT__' }}
 
-        # SSM SendCommand를 실행하는 스크립트
+        # SSM SendCommand를 실행하는 스크립트 (S3 다운로드 및 배포 실행)
         run: bash .github/workflows/github-actions/send-ssm-command.sh
 
 

--- a/.github/workflows/deployment/deploy.sh
+++ b/.github/workflows/deployment/deploy.sh
@@ -77,6 +77,12 @@ write_container_versions() {
 
   chmod 600 "$temporary_file" || return 1
   mv -f "$temporary_file" "$CONTAINER_VERSIONS_FILE"
+
+  if [ -n "${AWS_S3_BUCKET:-}" ]; then
+    echo "[v] Syncing container versions to S3..."
+    aws s3 cp "$CONTAINER_VERSIONS_FILE" "s3://${AWS_S3_BUCKET}/puppyrun/releases/${RELEASE_TAG}/container-versions.env" || true
+    aws s3 cp "$CONTAINER_VERSIONS_FILE" "s3://${AWS_S3_BUCKET}/puppyrun/current/container-versions.env" || true
+  fi
 }
 
 rollback_current_release() {

--- a/.github/workflows/github-actions/send-ssm-command.sh
+++ b/.github/workflows/github-actions/send-ssm-command.sh
@@ -6,14 +6,26 @@ set -euo pipefail
 : "${DEPLOY_DIRECTORY:?DEPLOY_DIRECTORY is required}"
 : "${RELEASE_TAG:?RELEASE_TAG is required}"
 : "${DEPLOY_IMAGE_TAG:?DEPLOY_IMAGE_TAG is required}"
+: "${AWS_S3_BUCKET:?AWS_S3_BUCKET is required}"
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+SSM_COMMANDS=$(cat <<EOF
+mkdir -p $DEPLOY_DIRECTORY && \
+aws s3 cp s3://$AWS_S3_BUCKET/puppyrun/releases/$RELEASE_TAG.tar.gz $DEPLOY_DIRECTORY/release.tar.gz && \
+tar -xzf $DEPLOY_DIRECTORY/release.tar.gz -C $DEPLOY_DIRECTORY && \
+rm -f $DEPLOY_DIRECTORY/release.tar.gz && \
+cd $DEPLOY_DIRECTORY && \
+RELEASE_TAG=$RELEASE_TAG DEPLOY_IMAGE_TAG=$DEPLOY_IMAGE_TAG AWS_S3_BUCKET=$AWS_S3_BUCKET bash deploy.sh
+EOF
+)
 
 COMMAND_ID=$(aws ssm send-command \
   --instance-ids "$INSTANCE_ID" \
   --document-name "AWS-RunShellScript" \
-  --parameters commands="[\"cd $DEPLOY_DIRECTORY && RELEASE_TAG=$RELEASE_TAG DEPLOY_IMAGE_TAG=$DEPLOY_IMAGE_TAG bash deploy.sh\"]" \
+  --parameters commands="$(jq -n --arg cmd "$SSM_COMMANDS" '[$cmd]')" \
   --query 'Command.CommandId' \
   --output text)
 
 echo "SSM command ID: $COMMAND_ID"
 echo "command_id=$COMMAND_ID" >> "$GITHUB_OUTPUT"
+

--- a/.github/workflows/github-actions/upload-release-to-s3.sh
+++ b/.github/workflows/github-actions/upload-release-to-s3.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${AWS_S3_BUCKET:?AWS_S3_BUCKET is required}"
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+: "${RELEASE_BUNDLE_DIRECTORY:?RELEASE_BUNDLE_DIRECTORY is required}"
+
+ARCHIVE_PATH="/tmp/release-${RELEASE_TAG}.tar.gz"
+
+echo "===== Archiving deployment bundle ====="
+tar -czf "$ARCHIVE_PATH" -C "$RELEASE_BUNDLE_DIRECTORY" .
+
+echo "===== Uploading release bundle to S3 ====="
+aws s3 cp "$ARCHIVE_PATH" "s3://${AWS_S3_BUCKET}/puppyrun/releases/${RELEASE_TAG}.tar.gz"
+
+rm -f "$ARCHIVE_PATH"
+
+echo "[v] Successfully uploaded release bundle to S3: s3://${AWS_S3_BUCKET}/puppyrun/releases/${RELEASE_TAG}.tar.gz"


### PR DESCRIPTION
- .github/workflows/deploy.yml:
  - SCP 복사 스텝을 제거하고 릴리스 번들을 AWS S3로 업로드하는 스텝으로 교체
  - SSM 배포 전송 스텝에 AWS_S3_BUCKET 환경변수 전달 추가
- .github/workflows/github-actions/upload-release-to-s3.sh:
  - 릴리스 번들(tar.gz)을 압축하여 AWS S3 버킷으로 업로드하는 스크립트 추가
- .github/workflows/github-actions/send-ssm-command.sh:
  - EC2가 S3 버킷에서 지정된 릴리스 아티팩트를 다운로드하여 실행하도록 SSM 명령 구조 수정
- .github/workflows/deployment/deploy.sh:
  - 배포 성공 후 컨테이너 상태 버전(container-versions.env)을 S3 버킷에 동기화하도록 로직 추가

