### PR TITLE
refactor: deploy와 health-check 스크립트 역할 분리 및 원본 로그 출력 전환

### DIFF
--- a/.github/workflows/deployment/deploy.sh
+++ b/.github/workflows/deployment/deploy.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 SERVICE_NAME="backend"
+CONTAINER_NAME="puppyrun-backend"
 RELEASES_DIRECTORY="/home/ubuntu/puppyrun/releases"
 CURRENT_LINK="/home/ubuntu/puppyrun/current"
 PREVIOUS_LINK="/home/ubuntu/puppyrun/previous"
@@ -14,17 +15,21 @@ CONTAINER_VERSIONS_FILE="$SCRIPT_DIR/container-versions.env"
 
 : "${RELEASE_TAG:?RELEASE_TAG is required}"
 : "${DEPLOY_IMAGE_TAG:?DEPLOY_IMAGE_TAG is required}"
+: "${AWS_REGION:?AWS_REGION is required}"
+: "${AWS_ACCOUNT_ID:?AWS_ACCOUNT_ID is required}"
+
 
 prepare_release() {
   if [ ! -f "$RELEASE_ENV_FILE" ]; then
-    echo "[x] Release environment file not found: $RELEASE_ENV_FILE"
+    echo "Release environment file not found: $RELEASE_ENV_FILE"
     return 1
   fi
 
-  chmod 600 "$RELEASE_ENV_FILE" || return 1
-  printf '%s\n' "$RELEASE_TAG" > "$RELEASE_TAG_FILE" || return 1
-  printf '%s\n' "$DEPLOY_IMAGE_TAG" > "$IMAGE_TAG_FILE" || return 1
+  chmod 600 "$RELEASE_ENV_FILE"
+  printf '%s\n' "$RELEASE_TAG" > "$RELEASE_TAG_FILE"
+  printf '%s\n' "$DEPLOY_IMAGE_TAG" > "$IMAGE_TAG_FILE"
 }
+
 
 deploy_release() {
   local release_directory="$1"
@@ -34,24 +39,40 @@ deploy_release() {
 
   echo "===== ECR Login ====="
 
+  # ECR 로그인 실패 시 AWS/Docker가 출력하는 원본 에러를 그대로 전달
   aws ecr get-login-password \
-    --region "$AWS_REGION" \
-    | docker login \
-        --username AWS \
-        --password-stdin \
-        "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com" \
-    || return 1
-
+    --region "$AWS_REGION" |
+    docker login \
+      --username AWS \
+      --password-stdin \
+      "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
 
   echo "===== Deploy image: $image_tag ====="
-  IMAGE_TAG="$image_tag" docker compose -p puppyrun --env-file "$env_file" -f "$compose_file" pull "$SERVICE_NAME" || return 1
-  IMAGE_TAG="$image_tag" docker compose -p puppyrun --env-file "$env_file" -f "$compose_file" up -d --force-recreate "$SERVICE_NAME" || return 1
+
+  # Docker Compose Pull 실패 시 원본 stderr를 그대로 출력
+  IMAGE_TAG="$image_tag" \
+    docker compose \
+      -p puppyrun \
+      --env-file "$env_file" \
+      -f "$compose_file" \
+      pull "$SERVICE_NAME"
+
+  # Docker Compose Up 실패 시 원본 stderr를 그대로 출력
+  IMAGE_TAG="$image_tag" \
+    docker compose \
+      -p puppyrun \
+      --env-file "$env_file" \
+      -f "$compose_file" \
+      up -d --force-recreate "$SERVICE_NAME"
 }
 
+
 health_check_release() {
-  local release_directory="$1"
+  local release_directory="${1:-$SCRIPT_DIR}"
+
   bash "$release_directory/health-check.sh"
 }
+
 
 write_container_version() {
   local prefix="$1"
@@ -60,15 +81,31 @@ write_container_version() {
   local image_id
   local image_digest
 
-  configured_image=$(docker inspect --format '{{.Config.Image}}' "$container_name") || return 1
-  image_id=$(docker inspect --format '{{.Image}}' "$container_name") || return 1
-  image_digest=$(docker image inspect --format '{{index .RepoDigests 0}}' "$configured_image" 2>/dev/null || true)
+  configured_image=$(
+    docker inspect \
+      --format '{{.Config.Image}}' \
+      "$container_name"
+  ) || return 1
+
+  image_id=$(
+    docker inspect \
+      --format '{{.Image}}' \
+      "$container_name"
+  ) || return 1
+
+  # 원본 Docker 에러를 숨기지 않음
+  image_digest=$(
+    docker image inspect \
+      --format '{{index .RepoDigests 0}}' \
+      "$configured_image"
+  ) || true
 
   printf '%s_CONTAINER=%s\n' "$prefix" "$container_name"
   printf '%s_IMAGE=%s\n' "$prefix" "$configured_image"
   printf '%s_IMAGE_ID=%s\n' "$prefix" "$image_id"
   printf '%s_IMAGE_DIGEST=%s\n' "$prefix" "$image_digest"
 }
+
 
 write_container_versions() {
   local temporary_file="$CONTAINER_VERSIONS_FILE.tmp"
@@ -78,9 +115,11 @@ write_container_versions() {
     printf 'RELEASE_TAG=%s\n' "$RELEASE_TAG"
     printf 'DEPLOYED_AT_UTC=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     printf 'ENVIRONMENT_FILE=.env\n'
+
     write_container_version BACKEND puppyrun-backend
     write_container_version MYSQL puppyrun-mysql
     write_container_version RABBITMQ puppyrun-rabbitmq
+
   } > "$temporary_file" || {
     rm -f -- "$temporary_file"
     return 1
@@ -90,100 +129,187 @@ write_container_versions() {
   mv -f "$temporary_file" "$CONTAINER_VERSIONS_FILE"
 
   if [ -n "${AWS_S3_BUCKET:-}" ]; then
-    echo "[v] Syncing container versions to S3..."
-    aws s3 cp "$CONTAINER_VERSIONS_FILE" "s3://${AWS_S3_BUCKET}/puppyrun/releases/${RELEASE_TAG}/container-versions.env" || true
-    aws s3 cp "$CONTAINER_VERSIONS_FILE" "s3://${AWS_S3_BUCKET}/puppyrun/current/container-versions.env" || true
+    echo "===== Syncing Container Versions to S3 ====="
+
+    aws s3 cp \
+      "$CONTAINER_VERSIONS_FILE" \
+      "s3://${AWS_S3_BUCKET}/puppyrun/releases/${RELEASE_TAG}/container-versions.env" \
+      || true
+
+    aws s3 cp \
+      "$CONTAINER_VERSIONS_FILE" \
+      "s3://${AWS_S3_BUCKET}/puppyrun/current/container-versions.env" \
+      || true
   fi
 }
 
+
 rollback_current_release() {
   if [ ! -L "$CURRENT_LINK" ]; then
-    echo "[x] No current release is registered. Rollback is unavailable."
+    echo "No current release registered. Rollback unavailable."
     return 1
   fi
 
   local current_release
   current_release=$(readlink -f "$CURRENT_LINK")
+
   local current_image_tag
   current_image_tag=$(<"$current_release/image-tag")
 
   echo "===== Rollback to release: $(<"$current_release/release-tag") ====="
-  if deploy_release "$current_release" "$current_image_tag" && health_check_release "$current_release"; then
-    echo "[v] Rollback completed successfully."
-    return 0
+  echo "===== Rollback image: $current_image_tag ====="
+
+  # rollback 과정에서 발생하는 Docker/ECR/Compose 원본 에러를 그대로 출력
+  if deploy_release "$current_release" "$current_image_tag"; then
+
+    echo "===== Rollback Health Check ====="
+
+    if health_check_release "$current_release"; then
+      echo "Rollback completed successfully."
+      return 0
+    fi
+
+    echo "Rollback health check failed."
+    return 1
   fi
 
-  echo "[x] Rollback failed."
+  echo "Rollback Docker Compose deployment failed."
   return 1
 }
 
+
 activate_release() {
   if [ -L "$CURRENT_LINK" ]; then
-    ln -sfn "$(readlink "$CURRENT_LINK")" "$PREVIOUS_LINK.next" || return 1
-    mv -Tf "$PREVIOUS_LINK.next" "$PREVIOUS_LINK" || return 1
+    ln -sfn \
+      "$(readlink "$CURRENT_LINK")" \
+      "$PREVIOUS_LINK.next" \
+      || return 1
+
+    mv -Tf \
+      "$PREVIOUS_LINK.next" \
+      "$PREVIOUS_LINK" \
+      || return 1
   fi
 
-  ln -sfn "$SCRIPT_DIR" "$CURRENT_LINK.next" || return 1
-  mv -Tf "$CURRENT_LINK.next" "$CURRENT_LINK" || return 1
+  ln -sfn \
+    "$SCRIPT_DIR" \
+    "$CURRENT_LINK.next" \
+    || return 1
+
+  mv -Tf \
+    "$CURRENT_LINK.next" \
+    "$CURRENT_LINK" \
+    || return 1
 }
+
 
 cleanup_failed_release() {
   if [ "$(dirname "$SCRIPT_DIR")" != "$RELEASES_DIRECTORY" ]; then
-    echo "[x] Refusing to remove an unexpected release directory: $SCRIPT_DIR"
+    echo "Refusing to remove unexpected directory: $SCRIPT_DIR"
     return 1
   fi
 
   rm -rf -- "$SCRIPT_DIR"
 }
 
+
 fail_deployment() {
   local reason="$1"
-  echo "[x] $reason"
-  rollback_current_release || true
+
+  echo "=========================================="
+  echo "===== Deployment Failed: $reason ====="
+  echo "=========================================="
+
+  echo "===== Container Logs on Failure ($CONTAINER_NAME) ====="
+
+  # 컨테이너가 존재하지 않는 경우에도 전체 배포 실패 처리는 계속 진행
+  docker logs \
+    --tail 100 \
+    "$CONTAINER_NAME" \
+    || true
+
+  echo "===== Rollback ====="
+
+  # Rollback 과정에서 발생하는 원본 에러는 그대로 출력
+  if rollback_current_release; then
+    echo "===== Rollback Completed ====="
+  else
+    echo "===== Rollback Failed ====="
+  fi
+
+  echo "===== Cleanup Failed Release ====="
+
   cleanup_failed_release || true
+
   exit 1
 }
 
+
 echo "===== Deployment Start ====="
 
+
 if [ "$SCRIPT_DIR" != "$RELEASES_DIRECTORY/$RELEASE_TAG" ]; then
-  echo "[x] Release directory does not match release tag: $SCRIPT_DIR"
+  echo "Release directory does not match release tag: $SCRIPT_DIR"
   exit 1
 fi
 
+
 if [ "$DEPLOY_IMAGE_TAG" = "__CURRENT__" ]; then
+
   if [ ! -L "$CURRENT_LINK" ]; then
-    echo "[x] No previously successful image is registered. A build is required for the first deployment."
+    echo "No previously successful image registered."
     exit 1
   fi
 
-  DEPLOY_IMAGE_TAG=$(<"$(readlink -f "$CURRENT_LINK")/image-tag")
-  echo "[v] Re-deploying registered image: $DEPLOY_IMAGE_TAG"
+  DEPLOY_IMAGE_TAG=$(
+    <"$(readlink -f "$CURRENT_LINK")/image-tag"
+  )
+
+  echo "Re-deploying registered image: $DEPLOY_IMAGE_TAG"
 fi
+
+
+echo "===== Prepare Release ====="
 
 if ! prepare_release; then
   fail_deployment "Failed to prepare release files."
 fi
 
+
+echo "===== Deploy Release ====="
+
 if ! deploy_release "$SCRIPT_DIR" "$DEPLOY_IMAGE_TAG"; then
-  fail_deployment "New image could not be started."
+  fail_deployment "Docker Compose deployment failed."
 fi
 
+
+echo "===== Health Check ====="
+
 if ! health_check_release "$SCRIPT_DIR"; then
-  fail_deployment "New image failed health checks."
+  fail_deployment "Application health check failed."
 fi
+
+
+echo "===== Record Container Versions ====="
 
 if ! write_container_versions; then
   fail_deployment "Failed to record container version information."
 fi
 
+
+echo "===== Activate Release ====="
+
 if ! activate_release; then
-  fail_deployment "Failed to activate the new release."
+  fail_deployment "Failed to activate new release."
 fi
 
-echo "[v] Registered successful release: $RELEASE_TAG"
+
+echo "Registered successful release: $RELEASE_TAG"
+
 
 echo "===== Remove Old Images ====="
+
 docker image prune -f || true
+
 
 echo "===== Deployment Success ====="

--- a/.github/workflows/deployment/health-check.sh
+++ b/.github/workflows/deployment/health-check.sh
@@ -3,39 +3,26 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-ENV_FILE="$SCRIPT_DIR/.env"
-COMPOSE_FILE="$SCRIPT_DIR/docker-compose.deploy.yml"
 SERVICE_NAME="puppyrun-backend"
 LIVENESS_URL="http://127.0.0.1:8081/actuator/health/liveness"
 READINESS_URL="http://127.0.0.1:8081/actuator/health/readiness"
-MAX_RETRIES=10
-SLEEP_SEC=10
+MAX_RETRIES=12
+SLEEP_SEC=5
 
-echo "===== Deployment Validation ====="
-
-if [ ! -f "$ENV_FILE" ]; then
-  echo "[x] .env file not found: $ENV_FILE"
-  exit 1
-fi
-
-if [ ! -f "$COMPOSE_FILE" ]; then
-  echo "[x] docker-compose file not found: $COMPOSE_FILE"
-  exit 1
-fi
+echo "===== Application Health Check ====="
 
 for i in $(seq 1 "$MAX_RETRIES"); do
-  if curl -fsS "$LIVENESS_URL" >/dev/null && curl -fsS "$READINESS_URL" >/dev/null; then
-    echo "[v] Backend liveness and readiness checks passed (try $i/$MAX_RETRIES)"
+  if curl -fsS "$LIVENESS_URL" >/dev/null 2>&1 && curl -fsS "$READINESS_URL" >/dev/null 2>&1; then
+    echo "[v] Application health check passed (attempt $i/$MAX_RETRIES)"
     exit 0
   fi
 
-  echo "Waiting for backend liveness/readiness... (try $i/$MAX_RETRIES)"
+  echo "Waiting for backend application... (attempt $i/$MAX_RETRIES)"
   if [ "$i" -lt "$MAX_RETRIES" ]; then
     sleep "$SLEEP_SEC"
   fi
 done
 
-echo "[x] Backend health check failed"
-echo "===== Recent logs from docker container: $SERVICE_NAME ====="
-docker logs --tail 200 "$SERVICE_NAME" || true
+echo "===== Health Check Failed. Application Container Logs ($SERVICE_NAME) ====="
+docker logs --tail 400 "$SERVICE_NAME" || true
 exit 1


### PR DESCRIPTION
- .github/workflows/deployment/deploy.sh:
  - 도커/서버 기동 및 롤백 전용 스크립트로 정리
  - 인위적 메시지 가공 제거 및 디버깅용 원형 stderr/stdout 에러 노출
  - health_check_release 함수 내 기본값 매핑으로 인자 누락 에러 방지
- .github/workflows/deployment/health-check.sh:
  - 독립된 애플리케이션 헬스체크 스크립트로 분리 및 실패 시 도커 로그 200줄 원형 출력

