### PR TITLE
fix: ecr 로그인 증명을 먼저 시작하게 변경

### DIFF
--- a/.github/workflows/github-actions/send-ssm-command.sh
+++ b/.github/workflows/github-actions/send-ssm-command.sh
@@ -36,7 +36,13 @@ install -m 600 $ROOT_DIRECTORY/config/.env $CANDIDATE_DIRECTORY/.env
 ln -sfn $CANDIDATE_DIRECTORY $ROOT_DIRECTORY/new.next
 mv -Tf $ROOT_DIRECTORY/new.next $ROOT_DIRECTORY/new
 # 이미지 pull이 성공한 경우에만 후보 deploy.sh가 서버 교체와 health check를 수행한다.
-aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+echo "===== Verify EC2 IAM identity ====="
+aws sts get-caller-identity --query 'Arn' --output text
+echo "===== Login to ECR ====="
+if ! aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com; then
+  echo "ECR login failed. Check the EC2 instance profile permissions and AWS region/account settings."
+  exit 1
+fi
 docker pull $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/puppyrun-backend:$DEPLOY_IMAGE_TAG
 AWS_REGION=$AWS_REGION AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID RELEASE_TAG=$RELEASE_TAG SKIP_IMAGE_PULL=true bash $CANDIDATE_DIRECTORY/deploy.sh $DEPLOY_IMAGE_TAG
 EOF

--- a/.github/workflows/github-actions/wait-for-ssm-command.sh
+++ b/.github/workflows/github-actions/wait-for-ssm-command.sh
@@ -9,6 +9,15 @@ set -euo pipefail
 
 MAX_WAITER_CYCLES="${MAX_WAITER_CYCLES:-6}"
 
+show_ssm_output() {
+  # ECR 인증·pull·deploy 실패를 기다린 직후 바로 출력해 GitHub Actions 로그에서 원인을 확인한다.
+  aws ssm get-command-invocation \
+    --command-id "$COMMAND_ID" \
+    --instance-id "$INSTANCE_ID" \
+    --query '{Status:Status,ResponseCode:ResponseCode,StandardOutput:StandardOutputContent,StandardError:StandardErrorContent}' \
+    --output json || true
+}
+
 # AWS waiter가 일시적으로 Pending/InProgress를 반환할 수 있으므로 제한 횟수만큼 재확인한다.
 for attempt in $(seq 1 "$MAX_WAITER_CYCLES"); do
   if aws ssm wait command-executed \
@@ -34,10 +43,12 @@ for attempt in $(seq 1 "$MAX_WAITER_CYCLES"); do
       ;;
     *)
       echo "EC2 pull or deploy command failed with status: $STATUS"
+      show_ssm_output
       exit 1
       ;;
   esac
 done
 
 echo "EC2 pull or deploy command did not finish within ${MAX_WAITER_CYCLES} waiter cycles."
+show_ssm_output
 exit 1


### PR DESCRIPTION
- .github/workflows/github-actions/send-ssm-command.sh:38 
  - EC2 SSM 실행 역할의 ARN을 aws sts get-caller-identity로 출력 
  - ECR 로그인 실패 시 명확한 오류와 함께 즉시 종료 
  - set -o pipefail 상태라 aws ecr get-login-password | docker login 중 어느 쪽 실패도 감지됩니다.

- .github/workflows/github-actions/wait-for-ssm-command.sh:12 
  - SSM이 실패하거나 시간 초과되면 EC2의 StandardOutput/StandardError를 즉시 GitHub Actions 로그에 출력합니다. 
  - 이제 ECR 권한 부족, 리전 불일치, Docker 로그인 오류를 별도 단계까지 기다리지 않고 확인할 수 있습니다.

- .github/workflows/deployment/README.md:18 
  - EC2 인스턴스 프로파일에 필요한 ECR 권한을 기록했습니다.