### PR TITLE
fix: SSM이 받는 배포 본문과 EC2 배포 스크립트 모두 POSIX sh 문법만 사용하도록 수정

### DIFF
--- a/.github/workflows/deployment/deploy.sh
+++ b/.github/workflows/deployment/deploy.sh
@@ -1,11 +1,11 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-set -euo pipefail
+set -eu
 
 # 역할: EC2 new 후보 디렉터리에서 실행되어 새 이미지를 기동한다.
 # 흐름: 후보 구성 검증 → digest 고정 → backend 교체 → health check → current/previous 승격.
 # 실패: current 릴리스의 이미지·.env·Compose로 즉시 복구하고 링크는 변경하지 않는다.
-SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 ROOT_DIRECTORY="${ROOT_DIRECTORY:-/home/ubuntu/puppyrun}"
 NEW_DIRECTORY="$ROOT_DIRECTORY/new"
 CURRENT_DIRECTORY="$ROOT_DIRECTORY/current"
@@ -49,7 +49,6 @@ restore_current_release() {
     return 1
   fi
 
-  local current_release current_image
   current_release="$CURRENT_DIRECTORY"
   current_image=$(sed -n 's/^BACKEND_IMAGE=//p' "$current_release/metadata.env")
   if [ -z "$current_image" ] || [ ! -f "$current_release/.env" ] || [ ! -f "$current_release/docker-compose.deploy.yml" ] || [ ! -f "$current_release/health-check.sh" ]; then
@@ -63,7 +62,7 @@ restore_current_release() {
     --env-file "$current_release/.env" \
     -f "$current_release/docker-compose.deploy.yml" \
     up -d --force-recreate "$SERVICE_NAME"
-  bash "$current_release/health-check.sh"
+  sh "$current_release/health-check.sh"
 }
 
 activate_candidate() {
@@ -116,7 +115,7 @@ if ! BACKEND_IMAGE="$BACKEND_IMAGE" docker compose \
 fi
 
 # liveness와 readiness가 모두 통과해야만 후보를 성공 릴리스로 승격한다.
-if ! bash "$HEALTH_CHECK_SCRIPT"; then
+if ! sh "$HEALTH_CHECK_SCRIPT"; then
   printf 'STATUS=failed-health-check\n' >> "$METADATA_FILE"
   restore_current_release || true
   exit 1

--- a/.github/workflows/deployment/health-check.sh
+++ b/.github/workflows/deployment/health-check.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-set -euo pipefail
+set -eu
 
 # 역할: deploy.sh와 rollback.sh가 backend 교체 뒤 호출하는 로컬 readiness 검증이다.
 # 관리 포트는 Docker Compose에서 EC2 loopback에만 바인딩되어 외부에 노출되지 않는다.

--- a/.github/workflows/deployment/rollback.sh
+++ b/.github/workflows/deployment/rollback.sh
@@ -1,11 +1,10 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-set -euo pipefail
+set -eu
 
 # 역할: Grafana Cloud 알림이 Lambda/SSM을 통해 호출하는 런타임 롤백이다.
 # 흐름: previous의 digest·.env·Compose로 기동 → health check → current/previous 링크 교환.
 # 실패: previous 후보가 건강하지 않으면 기존 current를 다시 기동하고 링크는 유지한다.
-SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 ROOT_DIRECTORY="${ROOT_DIRECTORY:-/home/ubuntu/puppyrun}"
 CURRENT_DIRECTORY="$ROOT_DIRECTORY/current"
 PREVIOUS_DIRECTORY="$ROOT_DIRECTORY/previous"
@@ -45,14 +44,14 @@ BACKEND_IMAGE="$PREVIOUS_IMAGE" docker compose \
   up -d --force-recreate backend
 
 # 롤백 후보가 실패하면 현재 릴리스를 재기동한다. 포인터 교환은 이 이후에만 일어난다.
-if ! bash "$PREVIOUS_RELEASE/health-check.sh"; then
+if ! sh "$PREVIOUS_RELEASE/health-check.sh"; then
   CURRENT_IMAGE=$(sed -n 's/^BACKEND_IMAGE=//p' "$CURRENT_RELEASE/metadata.env")
   BACKEND_IMAGE="$CURRENT_IMAGE" docker compose \
     -p puppyrun \
     --env-file "$CURRENT_RELEASE/.env" \
     -f "$CURRENT_RELEASE/docker-compose.deploy.yml" \
     up -d --force-recreate backend || true
-  bash "$CURRENT_RELEASE/health-check.sh" || true
+  sh "$CURRENT_RELEASE/health-check.sh" || true
   exit 1
 fi
 

--- a/.github/workflows/github-actions/send-ssm-command.sh
+++ b/.github/workflows/github-actions/send-ssm-command.sh
@@ -47,7 +47,6 @@ fi
 
 
 SSM_COMMANDS=$(cat <<EOF
-bash -s <<'REMOTE_DEPLOY_SCRIPT'
 set -eu
 
 test ! -e "$NEW_DIRECTORY"
@@ -55,17 +54,12 @@ test ! -e "$NEW_DIRECTORY"
 mkdir -p "$NEW_DIRECTORY"
 
 # 다운로드·pull·기동 중 어느 단계에서 실패해도 다음 배포를 막지 않도록 후보 폴더만 정리한다.
-# 성공하면 deploy.sh가 new를 current로 이동하므로 이 정리 함수는 아무것도 삭제하지 않는다.
-cleanup_new() {
-  if [ -e "$NEW_DIRECTORY" ]; then
-    rm -rf -- "$NEW_DIRECTORY"
-  fi
-}
-trap cleanup_new 0 1 2 15
+# 성공하면 deploy.sh가 new를 current로 이동하므로 trap은 아무것도 삭제하지 않는다.
+trap 'if [ -e "$NEW_DIRECTORY" ]; then rm -rf -- "$NEW_DIRECTORY"; fi' 0 1 2 15
 
 echo "===== Receive release files from SSM ====="
 
-base64 --decode <<'RELEASE_ARCHIVE' | tar -xzf - -C "$NEW_DIRECTORY"
+base64 -d <<'RELEASE_ARCHIVE' | tar -xzf - -C "$NEW_DIRECTORY"
 $RELEASE_ARCHIVE_BASE64
 RELEASE_ARCHIVE
 
@@ -101,18 +95,18 @@ docker pull \
 
 echo "===== Deploy ====="
 
-AWS_REGION="$AWS_REGION" \
-AWS_ACCOUNT_ID="$AWS_ACCOUNT_ID" \
-RELEASE_TAG="$RELEASE_TAG" \
-SKIP_IMAGE_PULL=true \
-bash "$NEW_DIRECTORY/deploy.sh" "$DEPLOY_IMAGE_TAG" || {
+if AWS_REGION="$AWS_REGION" \
+  AWS_ACCOUNT_ID="$AWS_ACCOUNT_ID" \
+  RELEASE_TAG="$RELEASE_TAG" \
+  SKIP_IMAGE_PULL=true \
+  sh "$NEW_DIRECTORY/deploy.sh" "$DEPLOY_IMAGE_TAG"; then
+  :
+else
   deploy_status=\$?
   # deploy.sh가 current 복구를 마친 뒤 실패한 후보 파일만 정리한다.
   rm -rf -- "$NEW_DIRECTORY"
   exit "\$deploy_status"
-}
-
-REMOTE_DEPLOY_SCRIPT
+fi
 EOF
 )
 


### PR DESCRIPTION
- cleanup_new() 같은 함수 문법 제거
- Bash 전용 set -o pipefail, BASH_SOURCE, local, { ... } 제거
- deploy.sh, rollback.sh, health-check.sh를 #!/usr/bin/env sh로 변경
- SSM 실행 본문도 함수 없이 trap과 if ... then만 사용
- 문제였던 환경변수 + if 문법도 유효한 POSIX 형태로 수정

