### PR TITLE
feat: 반려동물 일별 산책 조회 및 통계 응답 계약 정비

### DIFF
--- a/.github/workflows/deployment/compose/docker-compose.backend.yml
+++ b/.github/workflows/deployment/compose/docker-compose.backend.yml
@@ -12,6 +12,7 @@ services:
       - ../config/firebase-service-account.json:/run/secrets/firebase-service-account.json:ro
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILE}
+      TZ: Asia/Seoul
     env_file:
       - ../config/app.env
     networks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8080
 EXPOSE 8081
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]

--- a/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
@@ -7,7 +7,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -97,6 +99,43 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(errorResponse);
+    }
+
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestParameter(
+            MissingServletRequestParameterException e,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(
+                        errorCode.getCode(),
+                        errorCode.getDescription(),
+                        "'" + e.getParameterName() + "' 파라미터는 필수입니다.",
+                        request.getRequestURI()
+                ));
+    }
+
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(
+            MethodArgumentTypeMismatchException e,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+
+        String detailMessage = String.format("'%s' 파라미터의 값('%s') 형식이 올바르지 않습니다.",
+                e.getName(), e.getValue());
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(
+                        errorCode.getCode(),
+                        errorCode.getDescription(),
+                        detailMessage,
+                        request.getRequestURI()
+                ));
     }
 
 

--- a/src/main/java/org/zerock/puppyrun/common/s3/support/S3Url.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/support/S3Url.java
@@ -7,6 +7,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+
+/**
+ * <p>이미지 호스트 매핑 어노테이션</p>
+ * String, Collection.String 가능
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.RECORD_COMPONENT})
 @JacksonAnnotationsInside

--- a/src/main/java/org/zerock/puppyrun/member/controller/response/AccountResponse.java
+++ b/src/main/java/org/zerock/puppyrun/member/controller/response/AccountResponse.java
@@ -1,11 +1,13 @@
 package org.zerock.puppyrun.member.controller.response;
 
 import lombok.Builder;
+import org.zerock.puppyrun.common.s3.support.S3Url;
 
 @Builder
 public record AccountResponse(
         String nickName,
         String email,
+        @S3Url
         String profileImage,
         String UserRole
 ) {

--- a/src/main/java/org/zerock/puppyrun/pet/controller/request/RegisterPetRequest.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/request/RegisterPetRequest.java
@@ -12,7 +12,6 @@ public record RegisterPetRequest(
         @Size(max = 50, message = "이름은 50자를 초과할 수 없습니다.")
         String name,
 
-        @NotNull(message = "출생일은 필수입니다.")
         LocalDate birthYear,
 
         @NotBlank(message = "견종 코드는 필수입니다.")

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetDetailResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetDetailResponse.java
@@ -3,6 +3,7 @@ package org.zerock.puppyrun.pet.controller.response;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.Builder;
+import org.zerock.puppyrun.common.s3.support.S3Url;
 import org.zerock.puppyrun.pet.entity.Pet;
 import org.zerock.puppyrun.pet.entity.PetBadge;
 
@@ -17,6 +18,8 @@ public record PetDetailResponse(
         Double weight,
         String color,
         String breedCode,
+        
+        @S3Url
         String profileImageUrl,
         Boolean isNeutered,
         String gender,

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetListResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetListResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
+import org.zerock.puppyrun.common.s3.support.S3Url;
 import org.zerock.puppyrun.pet.entity.Pet;
 
 public record PetListResponse(
@@ -28,9 +29,12 @@ public record PetListResponse(
             LocalDate birthYear,
             Double weight,
             String color,
+
+            @S3Url
             String profileImageUrl,
             String breedCode,
             String gender,
+            String mbti,
             boolean isNeutered
     ) {
         public static PetSummary from(Pet pet) {
@@ -43,6 +47,7 @@ public record PetListResponse(
                     .profileImageUrl(pet.getProfileImageUrl())
                     .breedCode(pet.getBreed().getCode())
                     .gender(pet.getGender())
+                    .mbti(pet.getMbti())
                     .isNeutered(pet.getIsNeutered())
                     .build();
         }

--- a/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
+++ b/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
@@ -36,7 +36,7 @@ public class Pet extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String name;
 
-    @Column(name = "birth_year", nullable = false)
+    @Column(name = "birth_year")
     private LocalDate birthYear; // 출생년도
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/zerock/puppyrun/statistics/DTO/DailyPetTracking.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/DTO/DailyPetTracking.java
@@ -12,8 +12,8 @@ public record DailyPetTracking(
         UUID trackingId,            // 산책 고유 ID (상세 페이지 이동용)
         LocalDateTime startedAt,    // 산책 시작 시간
         LocalDateTime endedAt,      // 산책 종료 시간
-        Integer distance,           // 산책 거리 (km)
-        Integer durationMin,        // 산책 시간 (분)
+        Integer distance,           // 산책 거리 (m)
+        Integer duration,           // 산책 시간 (초)
         Double averagePace,         // 산책 페이스
 
         DiaryDetail diary,          // 일기 작성 여부 (UI 뱃지용)
@@ -36,8 +36,8 @@ public record DailyPetTracking(
                 tracking.trackingId(),
                 tracking.startedAt(),
                 tracking.endedAt(),
-                (int) Math.round(tracking.distance() / 1000.0), // m -> km 단위 변환 후 반올림
-                tracking.duration() / 60,                       // 초 -> 분 단위 변환
+                tracking.distance(),
+                tracking.duration(),
                 tracking.averagePace(),
                 DiaryDetail.from(tracking.diaryId()),
                 tracking.trackingImages() != null ? tracking.trackingImages() : Collections.emptyList(),

--- a/src/main/java/org/zerock/puppyrun/statistics/DTO/DailyPetTracking.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/DTO/DailyPetTracking.java
@@ -15,23 +15,12 @@ public record DailyPetTracking(
         Integer distance,           // 산책 거리 (m)
         Integer duration,           // 산책 시간 (초)
         Double averagePace,         // 산책 페이스
-
         DiaryDetail diary,          // 일기 작성 여부 (UI 뱃지용)
-        List<String> trackingImages, // 산책 중 찍은 사진 리스트 (썸네일용)
+        List<TrackingImageSummary> trackingImages, // 산책 중 찍은 사진 리스트 (썸네일용)
         List<ParticipatingPet> participatingPets // 참여한 펫 목록
 ) {
 
-    /**
-     * DailyTracking과 pets를 조합하여 DailyPetTracking 객체를 생성합니다.
-     */
     public static DailyPetTracking of(DailyTracking tracking, List<Pet> pets) {
-        // 인자로 받은 pets 리스트를 ParticipatingPet 리스트로 변환
-        List<ParticipatingPet> participatingPetsList = (pets == null)
-                ? Collections.emptyList()
-                : pets.stream()
-                        .map(ParticipatingPet::from)
-                        .toList();
-
         return new DailyPetTracking(
                 tracking.trackingId(),
                 tracking.startedAt(),
@@ -40,42 +29,56 @@ public record DailyPetTracking(
                 tracking.duration(),
                 tracking.averagePace(),
                 DiaryDetail.from(tracking.diaryId()),
-                tracking.trackingImages() != null ? tracking.trackingImages() : Collections.emptyList(),
-                participatingPetsList
+                TrackingImageSummary.from(tracking.trackingImages()),
+                ParticipatingPet.from(pets)
         );
     }
 
     @Builder
     public record DiaryDetail(
-            boolean hasDiary,           // 일기 작성 여부 (UI 뱃지용)
-            UUID diaryId               // 작성된 일기가 있다면 일기 ID (없으면 null)
+            boolean hasDiary,
+            UUID diaryId
     ) {
         public static DiaryDetail from(UUID diaryId) {
-            return DiaryDetail.builder()
-                    .hasDiary(diaryId != null)
-                    .diaryId(diaryId)
-                    .build();
+            return new DiaryDetail(
+                    diaryId != null,
+                    diaryId
+            );
         }
     }
 
-    /**
-     * 산책에 참여한 펫 정보
-     */
+    @Builder
+    public record TrackingImageSummary(
+            Integer order,
+            String image
+    ) {
+        public static List<TrackingImageSummary> from(
+                List<DailyTracking.TrackingImageSummary> images
+        ) {
+            return (images == null) ? Collections.emptyList()
+                    : images.stream()
+                            .map(i -> new TrackingImageSummary(i.order(), i.image()))
+                            .toList();
+        }
+    }
+
     @Builder
     public record ParticipatingPet(
-            UUID petId,                 // 펫 고유 ID
-            String name,                // 펫 이름
-            String profileImageUrl,     // 펫 프로필 이미지
-            String themeColor           // 펫 고유 색상 (UI 테두리 등에 활용)
+            UUID petId,
+            String name,
+            String profileImageUrl,
+            String themeColor
     ) {
-        // Pet 엔티티를 받아 DTO로 변환하도록 수정
-        public static ParticipatingPet from(Pet pet) {
-            return ParticipatingPet.builder()
-                    .petId(pet.getId())
-                    .name(pet.getName())
-                    .profileImageUrl(pet.getProfileImageUrl())
-                    .themeColor(pet.getColor())
-                    .build();
+        public static List<ParticipatingPet> from(List<Pet> pets) {
+            return (pets == null) ? Collections.emptyList()
+                    : pets.stream()
+                            .map(pet -> new ParticipatingPet(
+                                    pet.getId(),
+                                    pet.getName(),
+                                    pet.getProfileImageUrl(),
+                                    pet.getColor()
+                            ))
+                            .toList();
         }
     }
 }

--- a/src/main/java/org/zerock/puppyrun/statistics/DTO/TodayPetActivityTracking.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/DTO/TodayPetActivityTracking.java
@@ -1,0 +1,18 @@
+package org.zerock.puppyrun.statistics.DTO;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TodayPetActivityTracking(
+        UUID petId,
+        String petName,
+        String PetProfileUrl,
+
+        UUID trackingId,
+        Double averagePace,
+        LocalDateTime startedAt,
+        LocalDateTime endedAt,
+        Integer distance,
+        Integer duration
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/ActivitySummaryController.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/ActivitySummaryController.java
@@ -13,6 +13,7 @@ import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.statistics.controller.Response.DailyActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyContributionResponse;
+import org.zerock.puppyrun.statistics.controller.Response.PetActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.WeeklyActivityResponse;
 import org.zerock.puppyrun.statistics.service.TrackingActivityService;
 
@@ -21,6 +22,21 @@ import org.zerock.puppyrun.statistics.service.TrackingActivityService;
 @RequestMapping("/api/activity-tracking/statistics")
 public class ActivitySummaryController {
     private final TrackingActivityService trackingActivityService;
+
+    /**
+     * 펫을 기준으로 활동량 통계를 조회합니다.
+     *
+     * @param targetDay 조회 날짜
+     */
+    @GetMapping("/pet")
+    public ResponseEntity<PetActivityResponse> getLastTracking(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam("date") LocalDate targetDay
+    ) {
+        PetActivityResponse response = trackingActivityService.getPetActivity(principal, targetDay);
+        return ResponseEntity.ok(response);
+    }
+
 
     @GetMapping("/daily")
     public ResponseEntity<DailyActivityResponse> getDailyTracking(

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/Response/DailyActivityResponse.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/Response/DailyActivityResponse.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import lombok.Builder;
 import org.zerock.puppyrun.common.s3.support.S3Url;
 import org.zerock.puppyrun.statistics.DTO.DailyPetTracking;
+import org.zerock.puppyrun.tracking.DTO.DailyTracking;
 import org.zerock.puppyrun.tracking.util.PaceConverter;
 
 @Builder
@@ -68,9 +69,7 @@ public record DailyActivityResponse(
             Integer durationSec,        // 산책 시간 (초)
             String averagePace,         // 산책 페이스
             DiaryDetail diary,          // 일기 작성 여부 (UI 뱃지용)
-
-            @S3Url
-            List<String> trackingImages, // 산책 중 찍은 사진 리스트 (썸네일용)
+            List<TrackingImage> trackingImages, // 산책 중 찍은 사진 리스트 (썸네일용)
             List<ParticipatingPet> participatingPets // 참여한 펫 목록
     ) {
         public static TrackingDetails from(DailyPetTracking dpt) {
@@ -82,11 +81,22 @@ public record DailyActivityResponse(
                     .durationSec(dpt.duration())
                     .averagePace(PaceConverter.toString(dpt.averagePace()))
                     .diary(DiaryDetail.from(dpt.diary()))
-                    .trackingImages(dpt.trackingImages())
+                    .trackingImages(dpt.trackingImages().stream()
+                            .map(TrackingImage::from)
+                            .toList())
                     .participatingPets(dpt.participatingPets().stream()
                             .map(ParticipatingPet::from)
                             .toList())
                     .build();
+        }
+    }
+
+    public record TrackingImage(
+            Integer order,
+            @S3Url String image
+    ) {
+        private static TrackingImage from(DailyPetTracking.TrackingImageSummary image) {
+            return new TrackingImage(image.order(), image.image());
         }
     }
 

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/Response/DailyActivityResponse.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/Response/DailyActivityResponse.java
@@ -36,21 +36,21 @@ public record DailyActivityResponse(
      */
     @Builder
     public record DailySummary(
-            Double totalDistanceKm,     // 하루 총 산책 거리 (km)
-            Integer totalDurationMin,   // 하루 총 산책 시간 (분)
+            Integer totalDistanceM,     // 하루 총 산책 거리 (m)
+            Integer totalDurationSec,   // 하루 총 산책 시간 (초)
             Integer walkCount           // 하루 총 산책 횟수
     ) {
         public static DailySummary of(List<DailyPetTracking> dailyPetTrackings) {
-            double totalDistance = dailyPetTrackings.stream()
-                    .mapToDouble(DailyPetTracking::distance) // Integer를 Double로 캐스팅
+            int totalDistance = dailyPetTrackings.stream()
+                    .mapToInt(DailyPetTracking::distance)
                     .sum();
             int totalDuration = dailyPetTrackings.stream()
-                    .mapToInt(DailyPetTracking::durationMin)
+                    .mapToInt(DailyPetTracking::duration)
                     .sum();
 
             return DailySummary.builder()
-                    .totalDistanceKm(totalDistance)
-                    .totalDurationMin(totalDuration)
+                    .totalDistanceM(totalDistance)
+                    .totalDurationSec(totalDuration)
                     .walkCount(dailyPetTrackings.size())
                     .build();
         }
@@ -64,8 +64,8 @@ public record DailyActivityResponse(
             UUID trackingId,            // 산책 고유 ID (상세 페이지 이동용)
             LocalDateTime startedAt,    // 산책 시작 시간
             LocalDateTime endedAt,      // 산책 종료 시간
-            Double distanceKm,          // 산책 거리 (km)
-            Integer durationMin,        // 산책 시간 (분)
+            Integer distanceM,          // 산책 거리 (m)
+            Integer durationSec,        // 산책 시간 (초)
             String averagePace,         // 산책 페이스
             DiaryDetail diary,          // 일기 작성 여부 (UI 뱃지용)
 
@@ -78,8 +78,8 @@ public record DailyActivityResponse(
                     .trackingId(dpt.trackingId())
                     .startedAt(dpt.startedAt())
                     .endedAt(dpt.endedAt())
-                    .distanceKm((double) dpt.distance()) // Integer -> Double 변환
-                    .durationMin(dpt.durationMin())
+                    .distanceM(dpt.distance())
+                    .durationSec(dpt.duration())
                     .averagePace(PaceConverter.toString(dpt.averagePace()))
                     .diary(DiaryDetail.from(dpt.diary()))
                     .trackingImages(dpt.trackingImages())

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/Response/DailyActivityResponse.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/Response/DailyActivityResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
+import org.zerock.puppyrun.common.s3.support.S3Url;
 import org.zerock.puppyrun.statistics.DTO.DailyPetTracking;
 import org.zerock.puppyrun.tracking.util.PaceConverter;
 
@@ -67,6 +68,8 @@ public record DailyActivityResponse(
             Integer durationMin,        // 산책 시간 (분)
             String averagePace,         // 산책 페이스
             DiaryDetail diary,          // 일기 작성 여부 (UI 뱃지용)
+
+            @S3Url
             List<String> trackingImages, // 산책 중 찍은 사진 리스트 (썸네일용)
             List<ParticipatingPet> participatingPets // 참여한 펫 목록
     ) {
@@ -107,6 +110,7 @@ public record DailyActivityResponse(
     public record ParticipatingPet(
             UUID petId,                 // 펫 고유 ID
             String name,                // 펫 이름
+            @S3Url
             String profileImageUrl,     // 펫 프로필 이미지
             String themeColor           // 펫 고유 색상 (UI 테두리 등에 활용)
     ) {

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/Response/MonthlyActivityResponse.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/Response/MonthlyActivityResponse.java
@@ -13,8 +13,6 @@ public record MonthlyActivityResponse(
         List<MonthlySummary> monthlySummary, // 월 전체 산책 요약
         List<ContributionChart> contributionChart // 지난 15주의 산책 요약
 ) {
-    private static final double METERS_TO_KM = 1000.0;
-    private static final int SECONDS_TO_MINUTES = 60;
 
     @Builder
     public record Period(
@@ -32,15 +30,15 @@ public record MonthlyActivityResponse(
     @Builder
     public record MonthlySummary(
             String label, // 월 표시
-            Double totalDistanceKm,
-            Integer totalDurationMin,
+            Integer totalDistanceM,
+            Integer totalDurationSec,
             Integer totalCount
     ) {
         private static MonthlySummary from(MonthlyActivity activity) {
             return MonthlySummary.builder()
                     .label(activity.month().name())
-                    .totalDistanceKm(Math.round(activity.totalDistance() / METERS_TO_KM * 10) / 10.0)
-                    .totalDurationMin(activity.totalDuration() / SECONDS_TO_MINUTES)
+                    .totalDistanceM(activity.totalDistance())
+                    .totalDurationSec(activity.totalDuration())
                     .totalCount(activity.trackingCount())
                     .build();
         }
@@ -56,15 +54,15 @@ public record MonthlyActivityResponse(
     @Builder
     public record ContributionChart(
             LocalDate label,
-            Double distanceKm,
-            Integer durationMin,
+            Integer distanceM,
+            Integer durationSec,
             Integer trackingCount
     ) {
         private static ContributionChart from(DailyTrackingSummary ac) {
             return ContributionChart.builder()
                     .label(ac.date())
-                    .distanceKm(Math.round(ac.distance() / METERS_TO_KM * 10) / 10.0)
-                    .durationMin(ac.duration() / SECONDS_TO_MINUTES)
+                    .distanceM(ac.distance())
+                    .durationSec(ac.duration())
                     .trackingCount(ac.trackingCount())
                     .build();
         }

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/Response/MonthlyContributionResponse.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/Response/MonthlyContributionResponse.java
@@ -13,9 +13,6 @@ public record MonthlyContributionResponse(
 
 ) {
 
-    private static final double METERS_TO_KM = 1000.0;
-    private static final int SECONDS_TO_MINUTES = 60;
-
     @Builder
     public record Period(
             String type,
@@ -33,15 +30,15 @@ public record MonthlyContributionResponse(
     @Builder
     public record ActivityChart(
             LocalDate label,
-            Double distanceKm,
-            Integer durationMin,
+            Integer distanceM,
+            Integer durationSec,
             Integer trackingCount
     ) {
         private static ActivityChart from(MonthlyActivity.ActivityChart ac) {
             return ActivityChart.builder()
                     .label(ac.date())
-                    .distanceKm(Math.round(ac.totalDistance() / METERS_TO_KM * 10) / 10.0)
-                    .durationMin(ac.totalDuration() / SECONDS_TO_MINUTES)
+                    .distanceM(ac.totalDistance())
+                    .durationSec(ac.totalDuration())
                     .trackingCount(ac.trackingCount())
                     .build();
         }

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/Response/PetActivityResponse.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/Response/PetActivityResponse.java
@@ -1,0 +1,55 @@
+package org.zerock.puppyrun.statistics.controller.Response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.zerock.puppyrun.common.s3.support.S3Url;
+import org.zerock.puppyrun.statistics.DTO.TodayPetActivityTracking;
+import org.zerock.puppyrun.tracking.util.PaceConverter;
+
+public record PetActivityResponse(
+        List<PetActivity> activities
+) {
+    record PetActivity(
+            UUID petId,                 // 강아지 고유 ID
+            String petName,             // 강아지 이름
+            @S3Url String PetProfileUrl, // 강아지 프로파일 이미지
+
+            UUID trackingId,            // 산책 고유 ID (상세 페이지 이동용)
+            LocalDateTime startedAt,    // 산책 시작 시간
+            LocalDateTime endedAt,      // 산책 종료 시간
+            Integer distanceM,          // 산책 거리 (m)
+            Integer durationSec,        // 산책 시간 (초)
+            String averagePace          // 산책 페이스
+
+    ) {
+        public static PetActivity from(TodayPetActivityTracking activityTrackings) {
+            return new PetActivity(
+                    activityTrackings.petId(),
+                    activityTrackings.petName(),
+                    activityTrackings.PetProfileUrl(),
+                    activityTrackings.trackingId(),
+                    activityTrackings.startedAt(),
+                    activityTrackings.endedAt(),
+                    activityTrackings.distance(),
+                    activityTrackings.duration(),
+                    PaceConverter.toString(activityTrackings.averagePace())
+            );
+        }
+    }
+
+    public static PetActivityResponse of(List<TodayPetActivityTracking> activityTrackings) {
+        // 리스트가 비었거나 null 일경우
+        if (Objects.isNull(activityTrackings) || activityTrackings.isEmpty()) {
+            return new PetActivityResponse(List.of());
+        }
+
+        List<PetActivity> activityList = activityTrackings.stream()
+                .map(PetActivity::from)
+                .toList();
+
+        return new PetActivityResponse(activityList);
+    }
+
+}

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/Response/RadarMetric.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/Response/RadarMetric.java
@@ -9,34 +9,29 @@ import java.util.function.ToDoubleFunction;
 @Getter
 @RequiredArgsConstructor
 public enum RadarMetric {
-    DISTANCE("총 이동 거리 (km)", 30.0, RadarMetric::calculateDistance),
-    DURATION("총 산책 시간 (분)", 360.0, RadarMetric::calculateDuration),
+    DISTANCE("총 이동 거리 (m)", 30_000.0, RadarMetric::calculateDistance),
+    DURATION("총 산책 시간 (초)", 21_600.0, RadarMetric::calculateDuration),
     SPEED("평균 이동 속도 (km/h)", 10.0, RadarMetric::calculateSpeed),
     FREQUENCY("산책 빈도 (회)", 7.0, RadarMetric::calculateFrequency),
-    REST_TIME("휴식 시간 (분)", 120.0, RadarMetric::calculateRestTime);
+    REST_TIME("휴식 시간 (초)", 7_200.0, RadarMetric::calculateRestTime);
 
     private final String label;
     private final Double maxScore; // 차트 렌더링용 만점 기준
 
     private final ToDoubleFunction<TotalPetTracking> calculator;
 
-    private static final double METERS_TO_KM = 1000.0;
-    private static final double SECONDS_TO_MINUTES = 60.0;
-
     private static double calculateDistance(TotalPetTracking tracking) {
         if (tracking == null || tracking.totalDistance() == null) {
             return 0.0;
         }
-        double distKm = tracking.totalDistance() / METERS_TO_KM;
-        return Math.round(distKm * 10) / 10.0;
+        return tracking.totalDistance().doubleValue();
     }
 
     private static double calculateDuration(TotalPetTracking tracking) {
         if (tracking == null || tracking.totalDuration() == null) {
             return 0.0;
         }
-        double durationMin = tracking.totalDuration() / SECONDS_TO_MINUTES;
-        return Math.round(durationMin * 10.0) / 10.0;
+        return tracking.totalDuration().doubleValue();
     }
 
     private static double calculateSpeed(TotalPetTracking tracking) {
@@ -57,7 +52,6 @@ public enum RadarMetric {
         if (tracking == null || tracking.restDuration() == null) {
             return 0.0;
         }
-        double restMin = tracking.restDuration() / SECONDS_TO_MINUTES;
-        return Math.round(restMin * 100.0) / 100.0;
+        return tracking.restDuration().doubleValue();
     }
 }

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/Response/WeeklyActivityResponse.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/Response/WeeklyActivityResponse.java
@@ -17,8 +17,6 @@ public record WeeklyActivityResponse(
         FamilyReport familyReport,
         List<DogRadar> dogRadars // 강아지별 방사형 데이터 리스트로 변경
 ) {
-    private static final double METERS_TO_KM = 1000.0;
-    private static final int SECONDS_TO_MINUTES = 60;
 
     @Builder
     public record Period(
@@ -37,18 +35,18 @@ public record WeeklyActivityResponse(
 
     @Builder
     public record Summary(
-            Double totalDistanceKm,
-            Integer totalDurationMin,
+            Integer totalDistanceM,
+            Integer totalDurationSec,
             Integer totalCount
     ) {
         public static Summary of(List<ActivityChart> activityCharts) {
-            double totalDistanceKm = activityCharts.stream().mapToDouble(ActivityChart::distanceKm).sum();
-            int totalDurationMin = activityCharts.stream().mapToInt(ActivityChart::durationMin).sum();
-            int totalCount = activityCharts.stream().mapToInt(ac -> ac.durationMin() > 0 ? 1 : 0).sum();
+            int totalDistanceM = activityCharts.stream().mapToInt(ActivityChart::distanceM).sum();
+            int totalDurationSec = activityCharts.stream().mapToInt(ActivityChart::durationSec).sum();
+            int totalCount = activityCharts.stream().mapToInt(ac -> ac.durationSec() > 0 ? 1 : 0).sum();
 
             return Summary.builder()
-                    .totalDistanceKm(Math.round(totalDistanceKm * 10) / 10.0)
-                    .totalDurationMin(totalDurationMin)
+                    .totalDistanceM(totalDistanceM)
+                    .totalDurationSec(totalDurationSec)
                     .totalCount(totalCount)
                     .build();
         }
@@ -67,7 +65,7 @@ public record WeeklyActivityResponse(
         @Builder
         public record RadarDataPoint(
                 String metricCode,    // "DISTANCE"
-                String label,         // "총 이동 거리 (km)"
+                String label,         // "총 이동 거리 (m)"
                 Double thisWeekValue, // 이번 주 값
                 Double lastWeekValue, // 저번 주 값
                 Double maxScore       // 만점 기준 (차트 렌더링용)
@@ -108,8 +106,8 @@ public record WeeklyActivityResponse(
     public record ActivityChart(
             LocalDate date,
             String label,
-            Double distanceKm,
-            Integer durationMin
+            Integer distanceM,
+            Integer durationSec
     ) {
         public static List<ActivityChart> listOf(List<WeeklyActivityChart.ActivityChart> charts, LocalDate targetDate) {
             LocalDate thisWeekStart = targetDate.minusDays(6);
@@ -123,8 +121,8 @@ public record WeeklyActivityResponse(
             return ActivityChart.builder()
                     .date(ac.date())
                     .label(ac.label())
-                    .distanceKm(Math.round(((ac.distance() == null ? 0 : ac.distance()) / METERS_TO_KM) * 10) / 10.0)
-                    .durationMin((ac.duration() == null ? 0 : ac.duration()) / SECONDS_TO_MINUTES)
+                    .distanceM(ac.distance() == null ? 0 : ac.distance())
+                    .durationSec(ac.duration() == null ? 0 : ac.duration())
                     .build();
         }
     }
@@ -157,14 +155,13 @@ public record WeeklyActivityResponse(
             @S3Url
             String profileImageUrl,
             String themeColor,
-            Double distanceKm,
-            Integer durationMin,
+            Integer distanceM,
+            Integer durationSec,
             Double sharePercentage,
             Integer totalCount,
             String badge
     ) {
         public static DogStat of(TotalPetTracking ps, double allDogsTotalDistance) {
-            double distanceKm = ps.totalDistance() / METERS_TO_KM;
             double sharePercentage = allDogsTotalDistance > 0
                     ? (ps.totalDistance() / allDogsTotalDistance) * 100
                     : 0.0;
@@ -174,8 +171,8 @@ public record WeeklyActivityResponse(
                     .name(ps.name())
                     .profileImageUrl(ps.profileImageUrl())
                     .themeColor(ps.themeColor())
-                    .distanceKm(Math.round(distanceKm * 10) / 10.0)
-                    .durationMin(ps.totalDuration() / 60)
+                    .distanceM(ps.totalDistance())
+                    .durationSec(ps.totalDuration())
                     .sharePercentage(Math.round(sharePercentage * 10) / 10.0)
                     .totalCount(ps.totalCount().intValue())
                     .badge(ps.badge() != null ? ps.badge().getCode() : null)

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/Response/WeeklyActivityResponse.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/Response/WeeklyActivityResponse.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
+import org.zerock.puppyrun.common.s3.support.S3Url;
 import org.zerock.puppyrun.statistics.DTO.WeeklyActivityChart;
 import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
 
@@ -58,6 +59,7 @@ public record WeeklyActivityResponse(
     public record DogRadar(
             UUID dogId,
             String dogName,
+            @S3Url
             String profileImageUrl,
             String themeColor,
             List<RadarDataPoint> dataPoints
@@ -152,6 +154,7 @@ public record WeeklyActivityResponse(
     public record DogStat(
             UUID dogId,
             String name,
+            @S3Url
             String profileImageUrl,
             String themeColor,
             Double distanceKm,

--- a/src/main/java/org/zerock/puppyrun/statistics/service/TrackingActivityService.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/service/TrackingActivityService.java
@@ -13,9 +13,11 @@ import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.pet.repository.PetRepository;
 import org.zerock.puppyrun.statistics.DTO.DailyPetTracking;
 import org.zerock.puppyrun.statistics.DTO.MonthlyActivity;
+import org.zerock.puppyrun.statistics.DTO.TodayPetActivityTracking;
 import org.zerock.puppyrun.statistics.controller.Response.DailyActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyContributionResponse;
+import org.zerock.puppyrun.statistics.controller.Response.PetActivityResponse;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
 import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
 import org.zerock.puppyrun.statistics.DTO.WeeklyActivityChart;
@@ -36,6 +38,17 @@ public class TrackingActivityService {
     public DailyActivityResponse getDailyTracking(UserPrincipal principal, LocalDate targetDay) {
         List<DailyPetTracking> dailyPetTracking = trackingStatistics.getDayActivity(principal.id(), targetDay);
         return DailyActivityResponse.of(targetDay, dailyPetTracking);
+    }
+
+    public PetActivityResponse getPetActivity(UserPrincipal principal, LocalDate startDate) {
+        LocalDate endDate = startDate.plusDays(1);
+
+        // 해당 날짜를 기준으로 강아지 산책 리스트 조회
+        List<TodayPetActivityTracking> activityTrackings =
+                trackingRepository.getPetActivities(principal.id(), startDate, endDate);
+
+        return PetActivityResponse.of(activityTrackings);
+
     }
 
     public WeeklyActivityResponse getWeeklyTracking(UserPrincipal principal, LocalDate targetDay) {

--- a/src/main/java/org/zerock/puppyrun/tracking/DTO/DailyTracking.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/DTO/DailyTracking.java
@@ -13,7 +13,12 @@ public record DailyTracking(
         Double averagePace,         // 산책 페이스
 
         UUID diaryId,          // 일기 작성 여부 (UI 뱃지용)
-        List<String> trackingImages // 산책 중 찍은 사진 리스트 (썸네일용)
+        List<TrackingImageSummary> trackingImages // 산책 중 찍은 사진 리스트 (썸네일용)
 ) {
 
+    public record TrackingImageSummary(
+            Integer order,
+            String image
+    ) {
+    }
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/response/TrackingDetailResponse.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/response/TrackingDetailResponse.java
@@ -17,6 +17,7 @@ public record TrackingDetailResponse(
         Integer duration,            // 산책 진행 시간
         String visibility,           // 공개 여부
         Integer distance,            // 이동 거리
+        @S3Url
         List<TrackingImages> trackingImages, // 이미지 리스트
         String averagePace,              // 평균 속도
         List<RoutePoint> path,     // 이동 경로 리스트

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
+import org.zerock.puppyrun.statistics.DTO.TodayPetActivityTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyMemberStat;
 import org.zerock.puppyrun.tracking.DTO.DailyTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
@@ -50,6 +51,8 @@ public interface TrackingRepoCustom {
      */
     List<DailyTrackingSummary> getTrackingSummaryDateAsc(UUID memberId, LocalDate startDate, LocalDate endDate);
 
+
+    List<TodayPetActivityTracking> getPetActivities(UUID memberId, LocalDate startDate, LocalDate endDate);
 
     List<DailyTracking> getDailyActivities(UUID memberId, LocalDate targetDate);
 

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.statistics.DTO.TodayPetActivityTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyMemberStat;
 import org.zerock.puppyrun.tracking.DTO.DailyTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
@@ -260,6 +261,34 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
                 .toList();
     }
 
+    @Override
+    public List<TodayPetActivityTracking> getPetActivities(UUID memberId, LocalDate startDate, LocalDate endDate) {
+        return queryFactory
+                .select(Projections.constructor(
+                        TodayPetActivityTracking.class,
+                        pet.id,
+                        pet.name,
+                        pet.profileImageUrl,
+
+                        tracking.id,
+                        tracking.averagePace,
+                        tracking.startedAt,
+                        tracking.endedAt,
+                        tracking.distance,
+                        tracking.duration
+                ))
+                .from(petTracking)
+                .join(petTracking.pet, pet)
+                .join(petTracking.tracking, tracking)
+                .where(
+                        pet.member.id.eq(memberId),
+                        tracking.member.id.eq(memberId),
+                        tracking.startedAt.goe(startDate.atStartOfDay()),
+                        tracking.startedAt.lt(endDate.atStartOfDay())
+                )
+                .orderBy(petTracking.pet.id.asc(), tracking.startedAt.asc(), tracking.id.asc())
+                .fetch();
+    }
 
     @Override
     public List<DailyTracking> getDailyActivities(UUID memberId, LocalDate targetDate) {
@@ -288,7 +317,12 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
                     t.getDuration(),
                     t.getAveragePace(),
                     diaryId,
-                    t.getImages()
+                    t.getTrackingImages().stream()
+                            .map(image -> new DailyTracking.TrackingImageSummary(
+                                    image.getImageOrder(),
+                                    image.getImageUrl()
+                            ))
+                            .toList()
             );
         }).toList();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,13 +6,21 @@ spring:
     name: PuppyRun
 
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    # DB 세션도 KST(UTC+09:00)로 고정한다. TIMESTAMP 컬럼의 조회 조건과 반환값이
+    # 컨테이너/JVM 시간대와 달라져 날짜 경계가 밀리는 것을 방지한다.
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&characterEncoding=UTF-8&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jackson:
     property-naming-strategy: SNAKE_CASE
+
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
 
 
   cloud:

--- a/src/test/java/org/zerock/puppyrun/statistics/service/TrackingActivityServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/statistics/service/TrackingActivityServiceTest.java
@@ -1,6 +1,7 @@
 package org.zerock.puppyrun.statistics.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDate;
@@ -26,6 +27,7 @@ import org.zerock.puppyrun.statistics.controller.Response.MonthlyActivityRespons
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyContributionResponse;
 import org.zerock.puppyrun.statistics.controller.Response.WeeklyActivityResponse;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
+import org.zerock.puppyrun.tracking.DTO.DailyTracking;
 import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
 import org.zerock.puppyrun.tracking.repository.TrackingRepository;
 
@@ -78,6 +80,10 @@ class TrackingActivityServiceTest {
                 .singleElement()
                 .extracting(DailyActivityResponse.TrackingDetails::trackingId)
                 .isEqualTo(trackingId);
+        assertThat(response.tracking().getFirst().trackingImages())
+                .extracting(DailyActivityResponse.TrackingImage::order,
+                        DailyActivityResponse.TrackingImage::image)
+                .containsExactly(tuple(0, "image1.jpg"));
     }
 
     @Test
@@ -255,7 +261,7 @@ class TrackingActivityServiceTest {
                 3_600,
                 12000.0,
                 diary,
-                List.of("image1.jpg"),
+                List.of(new DailyPetTracking.TrackingImageSummary(0, "image1.jpg")),
                 List.of(pet)
         );
     }

--- a/src/test/java/org/zerock/puppyrun/statistics/service/TrackingActivityServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/statistics/service/TrackingActivityServiceTest.java
@@ -71,8 +71,8 @@ class TrackingActivityServiceTest {
 
         // then
         assertThat(response.date()).isEqualTo(targetDay);
-        assertThat(response.summary().totalDistanceKm()).isEqualTo(3.0);
-        assertThat(response.summary().totalDurationMin()).isEqualTo(60);
+        assertThat(response.summary().totalDistanceM()).isEqualTo(3_000);
+        assertThat(response.summary().totalDurationSec()).isEqualTo(3_600);
         assertThat(response.summary().walkCount()).isEqualTo(1);
         assertThat(response.tracking())
                 .singleElement()
@@ -90,8 +90,8 @@ class TrackingActivityServiceTest {
         DailyActivityResponse response = trackingActivityService.getDailyTracking(principal, targetDay);
 
         // then
-        assertThat(response.summary().totalDistanceKm()).isZero();
-        assertThat(response.summary().totalDurationMin()).isZero();
+        assertThat(response.summary().totalDistanceM()).isZero();
+        assertThat(response.summary().totalDurationSec()).isZero();
         assertThat(response.summary().walkCount()).isZero();
         assertThat(response.tracking()).isEmpty();
     }
@@ -133,12 +133,12 @@ class TrackingActivityServiceTest {
         assertThat(response.period().type()).isEqualTo("weekly");
         assertThat(response.period().startDate()).isEqualTo(weekStart);
         assertThat(response.period().endDate()).isEqualTo(targetDay);
-        assertThat(response.summary().totalDistanceKm()).isEqualTo(3.5);
-        assertThat(response.summary().totalDurationMin()).isEqualTo(75);
+        assertThat(response.summary().totalDistanceM()).isEqualTo(3_500);
+        assertThat(response.summary().totalDurationSec()).isEqualTo(4_500);
         assertThat(response.summary().totalCount()).isEqualTo(2);
         assertThat(response.activityChart())
-                .extracting(WeeklyActivityResponse.ActivityChart::distanceKm)
-                .containsExactly(1.2, 0.0, 2.3);
+                .extracting(WeeklyActivityResponse.ActivityChart::distanceM)
+                .containsExactly(1_200, 0, 2_300);
         assertThat(response.familyReport().totalDogs()).isEqualTo(2);
         assertThat(response.familyReport().dogStats())
                 .extracting(WeeklyActivityResponse.DogStat::sharePercentage)
@@ -147,8 +147,8 @@ class TrackingActivityServiceTest {
         WeeklyActivityResponse.DogRadar firstDogRadar = response.dogRadars().getFirst();
         assertThat(firstDogRadar.dogId()).isEqualTo(firstPetId);
         assertThat(firstDogRadar.dataPoints().getFirst().metricCode()).isEqualTo("DISTANCE");
-        assertThat(firstDogRadar.dataPoints().getFirst().thisWeekValue()).isEqualTo(3.0);
-        assertThat(firstDogRadar.dataPoints().getFirst().lastWeekValue()).isEqualTo(2.0);
+        assertThat(firstDogRadar.dataPoints().getFirst().thisWeekValue()).isEqualTo(3_000.0);
+        assertThat(firstDogRadar.dataPoints().getFirst().lastWeekValue()).isEqualTo(2_000.0);
     }
 
     @Test
@@ -215,23 +215,23 @@ class TrackingActivityServiceTest {
         assertThat(overview.period().year()).isEqualTo("2026");
         assertThat(overview.monthlySummary()).hasSize(2);
         assertThat(overview.monthlySummary().getFirst().label()).isEqualTo("JANUARY");
-        assertThat(overview.monthlySummary().getFirst().totalDistanceKm()).isEqualTo(1.3);
-        assertThat(overview.monthlySummary().getFirst().totalDurationMin()).isEqualTo(30);
+        assertThat(overview.monthlySummary().getFirst().totalDistanceM()).isEqualTo(1_250);
+        assertThat(overview.monthlySummary().getFirst().totalDurationSec()).isEqualTo(1_800);
         assertThat(overview.monthlySummary().getFirst().totalCount()).isEqualTo(2);
         assertThat(overview.monthlySummary().get(1).label()).isEqualTo("MARCH");
-        assertThat(overview.monthlySummary().get(1).totalDistanceKm()).isEqualTo(2.8);
-        assertThat(overview.monthlySummary().get(1).totalDurationMin()).isEqualTo(60);
+        assertThat(overview.monthlySummary().get(1).totalDistanceM()).isEqualTo(2_750);
+        assertThat(overview.monthlySummary().get(1).totalDurationSec()).isEqualTo(3_600);
         assertThat(overview.monthlySummary().get(1).totalCount()).isEqualTo(3);
         assertThat(overview.contributionChart())
-                .extracting(MonthlyActivityResponse.ContributionChart::distanceKm)
-                .containsExactly(1.2, 1.6);
+                .extracting(MonthlyActivityResponse.ContributionChart::distanceM)
+                .containsExactly(1_200, 1_550);
 
         assertThat(daily.period().type()).isEqualTo("contributions");
         assertThat(daily.period().month()).isEqualTo("MARCH");
         assertThat(daily.activityChart()).hasSize(2);
         assertThat(daily.activityChart().getFirst().label()).isEqualTo(firstDay);
-        assertThat(daily.activityChart().getFirst().distanceKm()).isEqualTo(1.2);
-        assertThat(daily.activityChart().getFirst().durationMin()).isEqualTo(30);
+        assertThat(daily.activityChart().getFirst().distanceM()).isEqualTo(1_200);
+        assertThat(daily.activityChart().getFirst().durationSec()).isEqualTo(1_800);
         assertThat(daily.activityChart().getFirst().trackingCount()).isEqualTo(1);
     }
 
@@ -251,8 +251,8 @@ class TrackingActivityServiceTest {
                 trackingId,
                 targetDay.atTime(10, 0),
                 targetDay.atTime(11, 0),
-                3,
-                60,
+                3_000,
+                3_600,
                 12000.0,
                 diary,
                 List.of("image1.jpg"),


### PR DESCRIPTION
# 📌 Pull Request: 반려동물 일별 산책 조회 및 통계 응답 계약 정비

# 📝 작업 요약 (Summary)

반려동물별 당일 산책 기록을 조회할 수 있도록 통계 API를 추가하고, 통계 응답의 거리·시간 단위를 저장 단위인 m·초로 통일했습니다. 또한 이미지 응답에는 S3 전체 URL을 제공하고, 서버·DB의 시간대를
Asia/Seoul로 고정해 날짜 경계 조회가 환경에 따라 달라지지 않도록 했습니다.

- 대상 커밋: `253bf63` ~ `d44298b` (최근 4개 커밋)
- DB 스키마 변경: 없음
- API 계약 변경: 기존 통계 응답의 `distanceKm`/`durationMin` 계열 필드가 `distanceM`/`durationSec` 계열로 변경됩니다.

# 🛠️ 변경 사항 (Changes)

## 1. 반려동물 일별 산책 활동 조회 API

- `GET /api/activity-tracking/statistics/pet`을 추가했습니다.
- 인증된 회원을 기준으로 반려동물과 연결된 산책 기록을 조회합니다.
    - 반려동물 소유자와 산책 소유자가 모두 요청 회원인 데이터를 대상으로 합니다.
    - 조회일 00:00 이상, 다음 날 00:00 미만의 산책만 반환합니다.
    - 반려동물 ID 오름차순, 산책 시작 시각 오름차순으로 정렬합니다.
    - 반려동물 또는 해당 일자의 산책 기록이 없으면 `activities: []`를 반환합니다.
- 응답에 반려동물 정보, 산책 식별자, 시작·종료 시각, 거리(m), 시간(초), 평균 페이스를 포함했습니다.

## 2. 통계 및 산책 이미지 응답 계약 정비

- 일간·주간·월간·기여도·레이더 통계의 거리/시간 단위를 km/분에서 m/초로 통일했습니다.
- 일별 산책 이미지 응답을 문자열 목록에서 `order`, `image`를 갖는 객체 목록으로 변경했습니다.
- 이미지 경로가 저장된 응답 필드에 `@S3Url`을 적용해 S3 키 대신 전체 URL을 직렬화합니다.
    - 회원 프로필, 반려동물 프로필, 일별/주별 통계, 산책 상세의 이미지 필드가 대상입니다.

## 3. 시간대 설정 일관화

- Docker JVM의 기본 시간대를 `Asia/Seoul`로 고정했습니다.
- MySQL 연결 세션과 Hibernate JDBC 시간대를 `Asia/Seoul`로 설정했습니다.
- 날짜 기반 산책 조회에서 서버·DB 시간대 불일치로 날짜 경계가 밀리는 문제를 방지합니다.

# 📸 테스트 시나리오 (Test Scenarios)

## 1. 반려동물 일별 산책 활동 조회

* **Method**: `GET`
* **URL**: `/api/activity-tracking/statistics/pet?date=2026-08-12`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### Query Parameters

| 이름     | 타입                       | 필수 | 제약조건 | 설명       |
|--------|--------------------------|---:|------|----------|
| `date` | LocalDate (`YYYY-MM-DD`) |  O | 없음   | 조회 대상 날짜 |

### ✅ 1-1: 회원의 반려동물별 당일 산책을 조회한다

**Request Body**

없음

**Response (200 OK)**

```json
{
  "activities": [
    {
      "pet_id": "02ee0a37-d7ff-4544-b23f-65f229b6a99e",
      "pet_name": "보리",
      "pet_profile_url": "https://puppyrun.s3.ap-northeast-2.amazonaws.com/pets/bori.jpg",
      "tracking_id": "4e88a3ec-6be5-4d94-bbd4-77937c43f82e",
      "started_at": "2026-08-12T09:00:00",
      "ended_at": "2026-08-12T09:30:00",
      "distance_m": 2000,
      "duration_sec": 1800,
      "average_pace": "6'30"
    }
  ]
}
```

### ✅ 1-2: 반려동물 또는 당일 산책이 없으면 빈 목록을 반환한다

**Request Body**

없음

**Response (200 OK)**

```json
{
  "activities": []
}
```
