### PR TITLE
chore: 절대 경로 기반 배포 구성 정비

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           set -euo pipefail
           printf -v quoted_image_tag '%q' "$DEPLOY_IMAGE_TAG"
-          command="/opt/puppyrun/scripts/deploy.sh $quoted_image_tag"
+          command="/home/ubuntu/puppyrun/scripts/deploy.sh $quoted_image_tag"
           aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \
             --document-name AWS-RunShellScript \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,14 +67,11 @@ jobs:
       - name: Trigger EC2 deployment
         env:
           INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
-          DEPLOY_ROOT: puppyrun
           DEPLOY_IMAGE_TAG: ${{ github.event_name == 'push' && github.sha || github.event.inputs.image_tag }}
         run: |
           set -euo pipefail
-          : "${DEPLOY_ROOT:?DEPLOY_ROOT is required.}"
-          printf -v quoted_root '%q' "$DEPLOY_ROOT"
           printf -v quoted_image_tag '%q' "$DEPLOY_IMAGE_TAG"
-          command="cd $quoted_root && ./scripts/deploy.sh $quoted_image_tag"
+          command="/opt/puppyrun/scripts/deploy.sh $quoted_image_tag"
           aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \
             --document-name AWS-RunShellScript \

--- a/.github/workflows/deployment/README.md
+++ b/.github/workflows/deployment/README.md
@@ -18,8 +18,8 @@ docker ps --filter name=puppyrun-rabbitmq
 ## 최초 1회 설정
 
 ```bash
-git clone --branch dev https://github.com/2026-SubProject-PuppyRun/BackEnd.git
-cd BackEnd
+git clone --branch dev https://github.com/2026-SubProject-PuppyRun/BackEnd.git /opt/puppyrun-source
+cd /opt/puppyrun-source
 sudo bash .github/workflows/deployment/bootstrap-ec2.sh
 ```
 
@@ -38,9 +38,9 @@ bootstrap은 EC2 운영 디렉터리와 공유 네트워크만 초기화한다. 
 ```
 
 ```bash
-sudoedit puppyrun/config/deploy.env  # AWS/ECR와 Compose 프로젝트 이름
-sudoedit puppyrun/config/app.env     # Spring Boot와 RabbitMQ 설정
-sudoedit puppyrun/config/infra.env   # Grafana Cloud remote_write 인증값
+sudoedit /opt/puppyrun/config/deploy.env  # AWS/ECR와 Compose 프로젝트 이름
+sudoedit /opt/puppyrun/config/app.env     # Spring Boot와 RabbitMQ 설정
+sudoedit /opt/puppyrun/config/infra.env   # Grafana Cloud remote_write 인증값
 ```
 
 Firebase 서비스 계정 JSON도 EC2에만 저장한다.
@@ -48,7 +48,7 @@ Firebase 서비스 계정 JSON도 EC2에만 저장한다.
 ```bash
 sudo install -o root -g ubuntu -m 640 \
   ./firebase-service-account.json \
-  puppyrun/config/firebase-service-account.json
+  /opt/puppyrun/config/firebase-service-account.json
 ```
 
 `app.env`에는 다음을 유지한다.
@@ -62,8 +62,8 @@ FCM_ACCOUNT_PATH=file:/run/secrets/firebase-service-account.json
 처음에는 infra를 한 번 올린 후 GitHub Actions 배포를 실행한다.
 
 ```bash
-sudo puppyrun/scripts/infra.sh up
-sudo puppyrun/scripts/infra.sh status
+sudo /opt/puppyrun/scripts/infra.sh up
+sudo /opt/puppyrun/scripts/infra.sh status
 ```
 
 이후 GitHub Actions는 ECR push 후 backend 배포만 실행한다. 수동 배포와 rollback도 backend에만 영향을 준다.
@@ -71,8 +71,8 @@ sudo puppyrun/scripts/infra.sh status
 실패하면 ECR에서 다시 받지 않고 로컬 `current` 이미지로 즉시 복구한다. `previous`는 수동 rollback용으로 보관한다.
 
 ```bash
-sudo puppyrun/scripts/deploy.sh <github-sha>
-sudo puppyrun/scripts/rollback.sh
+sudo /opt/puppyrun/scripts/deploy.sh <github-sha>
+sudo /opt/puppyrun/scripts/rollback.sh
 ```
 
 ## 설정 변경
@@ -80,10 +80,12 @@ sudo puppyrun/scripts/rollback.sh
 - `app.env` 또는 `infra.env`를 수정한 뒤에는 아래 한 명령으로 두 Compose에 반영한다. backend 이미지는 바뀌지 않는다.
 
   ```bash
-  sudo puppyrun/scripts/apply-config.sh
+  sudo /opt/puppyrun/scripts/apply-config.sh
   ```
 
   backend health check가 실패하면 마지막으로 성공한 `app.env`로 자동 복원한다.
 - backend 배포·rollback: RabbitMQ 데이터 volume과 Alloy 컨테이너는 유지된다.
 
-배포 로그는 `puppyrun/logs/latest-deploy.log`에서 확인한다. infra 로그는 `sudo puppyrun/scripts/infra.sh logs`로 확인한다.
+배포 로그는 `/opt/puppyrun/logs/latest-deploy.log`에서 확인한다. infra 로그는 `sudo /opt/puppyrun/scripts/infra.sh logs`로 확인한다.
+
+배포 루트는 `/opt/puppyrun`으로 고정되어 있으며, GitHub Actions Secret으로 경로를 전달하지 않는다.

--- a/.github/workflows/deployment/README.md
+++ b/.github/workflows/deployment/README.md
@@ -18,8 +18,8 @@ docker ps --filter name=puppyrun-rabbitmq
 ## 최초 1회 설정
 
 ```bash
-git clone --branch dev https://github.com/2026-SubProject-PuppyRun/BackEnd.git /opt/puppyrun-source
-cd /opt/puppyrun-source
+git clone --branch dev https://github.com/2026-SubProject-PuppyRun/BackEnd.git /home/ubuntu/BackEnd
+cd /home/ubuntu/BackEnd
 sudo bash .github/workflows/deployment/bootstrap-ec2.sh
 ```
 
@@ -38,9 +38,9 @@ bootstrap은 EC2 운영 디렉터리와 공유 네트워크만 초기화한다. 
 ```
 
 ```bash
-sudoedit /opt/puppyrun/config/deploy.env  # AWS/ECR와 Compose 프로젝트 이름
-sudoedit /opt/puppyrun/config/app.env     # Spring Boot와 RabbitMQ 설정
-sudoedit /opt/puppyrun/config/infra.env   # Grafana Cloud remote_write 인증값
+sudoedit /home/ubuntu/puppyrun/config/deploy.env  # AWS/ECR와 Compose 프로젝트 이름
+sudoedit /home/ubuntu/puppyrun/config/app.env     # Spring Boot와 RabbitMQ 설정
+sudoedit /home/ubuntu/puppyrun/config/infra.env   # Grafana Cloud remote_write 인증값
 ```
 
 Firebase 서비스 계정 JSON도 EC2에만 저장한다.
@@ -48,7 +48,7 @@ Firebase 서비스 계정 JSON도 EC2에만 저장한다.
 ```bash
 sudo install -o root -g ubuntu -m 640 \
   ./firebase-service-account.json \
-  /opt/puppyrun/config/firebase-service-account.json
+  /home/ubuntu/puppyrun/config/firebase-service-account.json
 ```
 
 `app.env`에는 다음을 유지한다.
@@ -62,8 +62,8 @@ FCM_ACCOUNT_PATH=file:/run/secrets/firebase-service-account.json
 처음에는 infra를 한 번 올린 후 GitHub Actions 배포를 실행한다.
 
 ```bash
-sudo /opt/puppyrun/scripts/infra.sh up
-sudo /opt/puppyrun/scripts/infra.sh status
+sudo /home/ubuntu/puppyrun/scripts/infra.sh up
+sudo /home/ubuntu/puppyrun/scripts/infra.sh status
 ```
 
 이후 GitHub Actions는 ECR push 후 backend 배포만 실행한다. 수동 배포와 rollback도 backend에만 영향을 준다.
@@ -71,8 +71,8 @@ sudo /opt/puppyrun/scripts/infra.sh status
 실패하면 ECR에서 다시 받지 않고 로컬 `current` 이미지로 즉시 복구한다. `previous`는 수동 rollback용으로 보관한다.
 
 ```bash
-sudo /opt/puppyrun/scripts/deploy.sh <github-sha>
-sudo /opt/puppyrun/scripts/rollback.sh
+sudo /home/ubuntu/puppyrun/scripts/deploy.sh <github-sha>
+sudo /home/ubuntu/puppyrun/scripts/rollback.sh
 ```
 
 ## 설정 변경
@@ -80,12 +80,12 @@ sudo /opt/puppyrun/scripts/rollback.sh
 - `app.env` 또는 `infra.env`를 수정한 뒤에는 아래 한 명령으로 두 Compose에 반영한다. backend 이미지는 바뀌지 않는다.
 
   ```bash
-  sudo /opt/puppyrun/scripts/apply-config.sh
+  sudo /home/ubuntu/puppyrun/scripts/apply-config.sh
   ```
 
   backend health check가 실패하면 마지막으로 성공한 `app.env`로 자동 복원한다.
 - backend 배포·rollback: RabbitMQ 데이터 volume과 Alloy 컨테이너는 유지된다.
 
-배포 로그는 `/opt/puppyrun/logs/latest-deploy.log`에서 확인한다. infra 로그는 `sudo /opt/puppyrun/scripts/infra.sh logs`로 확인한다.
+배포 로그는 `/home/ubuntu/puppyrun/logs/latest-deploy.log`에서 확인한다. infra 로그는 `sudo /home/ubuntu/puppyrun/scripts/infra.sh logs`로 확인한다.
 
-배포 루트는 `/opt/puppyrun`으로 고정되어 있으며, GitHub Actions Secret으로 경로를 전달하지 않는다.
+배포 루트는 `/home/ubuntu/puppyrun`으로 고정되어 있으며, GitHub Actions Secret으로 경로를 전달하지 않는다.

--- a/.github/workflows/deployment/bootstrap-ec2.sh
+++ b/.github/workflows/deployment/bootstrap-ec2.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 SOURCE_DIRECTORY=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 SCRIPTS_SOURCE="$SOURCE_DIRECTORY/scripts"
 COMPOSE_SOURCE="$SOURCE_DIRECTORY/compose"
-ROOT="${DEPLOY_ROOT:-puppyrun}"
+ROOT="/opt/puppyrun"
 
 install -d -o root -g ubuntu -m 750 \
   "$ROOT/scripts" "$ROOT/compose" "$ROOT/config" "$ROOT/state" "$ROOT/logs" "$ROOT/locks"

--- a/.github/workflows/deployment/bootstrap-ec2.sh
+++ b/.github/workflows/deployment/bootstrap-ec2.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 # EC2 운영 디렉터리와 공유 네트워크만 초기화한다.
 [[ "${EUID}" -eq 0 ]] || { echo "Run with sudo."; exit 1; }
-SOURCE_DIRECTORY=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+SOURCE_DIRECTORY="/home/ubuntu/BackEnd/.github/workflows/deployment"
 SCRIPTS_SOURCE="$SOURCE_DIRECTORY/scripts"
 COMPOSE_SOURCE="$SOURCE_DIRECTORY/compose"
-ROOT="/opt/puppyrun"
+ROOT="/home/ubuntu/puppyrun"
 
 install -d -o root -g ubuntu -m 750 \
   "$ROOT/scripts" "$ROOT/compose" "$ROOT/config" "$ROOT/state" "$ROOT/logs" "$ROOT/locks"

--- a/.github/workflows/deployment/compose/docker-compose.backend.yml
+++ b/.github/workflows/deployment/compose/docker-compose.backend.yml
@@ -9,12 +9,14 @@ services:
       - "127.0.0.1:8081:8081"
     volumes:
       - backend_data:/var/lib/backend
-      - ../config/firebase-service-account.json:/run/secrets/firebase-service-account.json:ro
+      - /opt/puppyrun/config/firebase-service-account.json:/run/secrets/firebase-service-account.json:ro
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILE}
       TZ: Asia/Seoul
+      # deploy.sh가 배포한 불변 이미지 태그를 전달한다.
+      APP_VERSION: ${APP_VERSION:-unknown}
     env_file:
-      - ../config/app.env
+      - /opt/puppyrun/config/app.env
     networks:
       - app
       - observability

--- a/.github/workflows/deployment/compose/docker-compose.backend.yml
+++ b/.github/workflows/deployment/compose/docker-compose.backend.yml
@@ -9,14 +9,14 @@ services:
       - "127.0.0.1:8081:8081"
     volumes:
       - backend_data:/var/lib/backend
-      - /opt/puppyrun/config/firebase-service-account.json:/run/secrets/firebase-service-account.json:ro
+      - /home/ubuntu/puppyrun/config/firebase-service-account.json:/run/secrets/firebase-service-account.json:ro
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILE}
       TZ: Asia/Seoul
       # deploy.sh가 배포한 불변 이미지 태그를 전달한다.
       APP_VERSION: ${APP_VERSION:-unknown}
     env_file:
-      - /opt/puppyrun/config/app.env
+      - /home/ubuntu/puppyrun/config/app.env
     networks:
       - app
       - observability

--- a/.github/workflows/deployment/compose/docker-compose.infra.yml
+++ b/.github/workflows/deployment/compose/docker-compose.infra.yml
@@ -23,7 +23,7 @@ services:
       GRAFANA_CLOUD_PROMETHEUS_USERNAME: ${GRAFANA_CLOUD_PROMETHEUS_USERNAME}
       GRAFANA_CLOUD_API_KEY: ${GRAFANA_CLOUD_API_KEY}
     volumes:
-      - ./config.alloy:/etc/alloy/config.alloy:ro
+      - /opt/puppyrun/compose/config.alloy:/etc/alloy/config.alloy:ro
       # EC2 CPU, memory, disk metric 수집용 host filesystem mount다.
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro

--- a/.github/workflows/deployment/compose/docker-compose.infra.yml
+++ b/.github/workflows/deployment/compose/docker-compose.infra.yml
@@ -23,7 +23,7 @@ services:
       GRAFANA_CLOUD_PROMETHEUS_USERNAME: ${GRAFANA_CLOUD_PROMETHEUS_USERNAME}
       GRAFANA_CLOUD_API_KEY: ${GRAFANA_CLOUD_API_KEY}
     volumes:
-      - /opt/puppyrun/compose/config.alloy:/etc/alloy/config.alloy:ro
+      - /home/ubuntu/puppyrun/compose/config.alloy:/etc/alloy/config.alloy:ro
       # EC2 CPU, memory, disk metric 수집용 host filesystem mount다.
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro

--- a/.github/workflows/deployment/scripts/apply-config.sh
+++ b/.github/workflows/deployment/scripts/apply-config.sh
@@ -18,9 +18,11 @@ source "$CONFIG/deploy.env"
 : "${BACKEND_COMPOSE_PROJECT_NAME:=puppyrun}"
 : "${HEALTH_URL:=http://127.0.0.1:8081/actuator/health/readiness}"
 CURRENT_IMAGE=$(<"$STATE/current-image")
+CURRENT_VERSION="unknown"
+[[ -f "$STATE/current-version" ]] && CURRENT_VERSION=$(<"$STATE/current-version")
 
 restart_backend() {
-  BACKEND_IMAGE="$CURRENT_IMAGE" docker compose --project-name "$BACKEND_COMPOSE_PROJECT_NAME" \
+  BACKEND_IMAGE="$CURRENT_IMAGE" APP_VERSION="$CURRENT_VERSION" docker compose --project-name "$BACKEND_COMPOSE_PROJECT_NAME" \
     --env-file "$APP_ENV" -f "$BACKEND_COMPOSE" up -d --force-recreate backend
   "$ROOT/scripts/health-check.sh" "$HEALTH_URL"
 }
@@ -33,7 +35,7 @@ restore_last_success() {
   restart_backend
 }
 
-docker compose --project-name "$BACKEND_COMPOSE_PROJECT_NAME" \
+BACKEND_IMAGE="$CURRENT_IMAGE" APP_VERSION="$CURRENT_VERSION" docker compose --project-name "$BACKEND_COMPOSE_PROJECT_NAME" \
   --env-file "$APP_ENV" -f "$BACKEND_COMPOSE" config -q
 
 if ! "$ROOT/scripts/infra.sh" up || ! restart_backend; then

--- a/.github/workflows/deployment/scripts/apply-config.sh
+++ b/.github/workflows/deployment/scripts/apply-config.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 # 이미지 변경 없이 app.env/infra.env 변경을 적용한다.
 # Compose 파일은 분리돼 있지만, 운영자는 이 명령 하나로 공통 설정을 반영할 수 있다.
-SCRIPT_DIRECTORY=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-ROOT=$(cd -- "$SCRIPT_DIRECTORY/.." && pwd)
+ROOT="/home/ubuntu/puppyrun"
 CONFIG="$ROOT/config"
 STATE="$ROOT/state"
 BACKEND_COMPOSE="$ROOT/compose/docker-compose.backend.yml"

--- a/.github/workflows/deployment/scripts/cleanup-images.sh
+++ b/.github/workflows/deployment/scripts/cleanup-images.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 
 # 역할: local current/previous가 아닌 Puppyrun backend 이미지만 정리한다.
 # Docker 전체 prune이나 volume 삭제는 수행하지 않는다.
-SCRIPT_DIRECTORY=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-ROOT=$(cd -- "$SCRIPT_DIRECTORY/.." && pwd)
+ROOT="/home/ubuntu/puppyrun"
 CONFIG="$ROOT/config"
 
 source "$CONFIG/deploy.env"

--- a/.github/workflows/deployment/scripts/deploy.sh
+++ b/.github/workflows/deployment/scripts/deploy.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIRECTORY=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-ROOT=$(cd -- "$SCRIPT_DIRECTORY/.." && pwd)
+ROOT="/home/ubuntu/puppyrun"
 CONFIG="$ROOT/config"
 STATE="$ROOT/state"
 LOGS="$ROOT/logs"

--- a/.github/workflows/deployment/scripts/deploy.sh
+++ b/.github/workflows/deployment/scripts/deploy.sh
@@ -39,6 +39,8 @@ flock -n 9 || { echo "Another deployment is already running."; exit 1; }
 ECR_URI="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY"
 CURRENT_IMAGE=""
 [[ -f "$STATE/current-image" ]] && CURRENT_IMAGE=$(<"$STATE/current-image")
+CURRENT_VERSION="unknown"
+[[ -f "$STATE/current-version" ]] && CURRENT_VERSION=$(<"$STATE/current-version")
 
 write_state() {
   local name="$1" value="$2" temporary
@@ -48,7 +50,8 @@ write_state() {
 }
 
 run_image() {
-  BACKEND_IMAGE="$1" docker compose --project-name "$BACKEND_COMPOSE_PROJECT_NAME" \
+  local image_reference="$1" app_version="${2:-unknown}"
+  BACKEND_IMAGE="$image_reference" APP_VERSION="$app_version" docker compose --project-name "$BACKEND_COMPOSE_PROJECT_NAME" \
     --env-file "$APP_ENV" -f "$COMPOSE" up -d --no-deps --force-recreate backend
 }
 
@@ -65,7 +68,7 @@ restore_current() {
     return 1
   }
   echo "Restoring local image: $CURRENT_TAG"
-  run_image "$CURRENT_TAG"
+  run_image "$CURRENT_TAG" "$CURRENT_VERSION"
   "$HEALTH_CHECK" "$HEALTH_URL"
 }
 
@@ -89,7 +92,7 @@ CANDIDATE_IMAGE=$(docker image inspect --format '{{index .RepoDigests 0}}' "$ECR
 docker image rm -f "$CANDIDATE_TAG" >/dev/null 2>&1 || true
 docker tag "$CANDIDATE_IMAGE" "$CANDIDATE_TAG"
 
-if ! run_image "$CANDIDATE_TAG" || ! "$HEALTH_CHECK" "$HEALTH_URL"; then
+if ! run_image "$CANDIDATE_TAG" "$IMAGE_TAG" || ! "$HEALTH_CHECK" "$HEALTH_URL"; then
   echo "Candidate failed; restoring current image."
   restore_current || true
   docker image rm -f "$CANDIDATE_TAG" >/dev/null 2>&1 || true
@@ -97,8 +100,12 @@ if ! run_image "$CANDIDATE_TAG" || ! "$HEALTH_CHECK" "$HEALTH_URL"; then
 fi
 
 promote_candidate
-[[ -n "$CURRENT_IMAGE" ]] && write_state previous-image "$CURRENT_IMAGE"
+if [[ -n "$CURRENT_IMAGE" ]]; then
+  write_state previous-image "$CURRENT_IMAGE"
+  write_state previous-version "$CURRENT_VERSION"
+fi
 write_state current-image "$CANDIDATE_IMAGE"
+write_state current-version "$IMAGE_TAG"
 # 이후 app.env만 변경했을 때 실패하면 이 시점의 정상 설정으로 복구할 수 있다.
 install -m 640 "$APP_ENV" "$CONFIG/app.env.last-success"
 "$CLEANUP_SCRIPT" || echo "Image cleanup failed; deployment remains successful."

--- a/.github/workflows/deployment/scripts/health-check.sh
+++ b/.github/workflows/deployment/scripts/health-check.sh
@@ -14,8 +14,7 @@ for attempt in $(seq 1 "$MAX_RETRIES"); do
 done
 
 # container_name을 사용하지 않으므로 Compose 서비스 기준으로 최근 로그를 남긴다.
-SCRIPT_DIRECTORY=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-ROOT="${ROOT:-$(cd -- "$SCRIPT_DIRECTORY/.." && pwd)}"
+ROOT="/home/ubuntu/puppyrun"
 COMPOSE_PROJECT_NAME="${BACKEND_COMPOSE_PROJECT_NAME:-puppyrun}"
 docker compose --project-name "$COMPOSE_PROJECT_NAME" \
   -f "$ROOT/compose/docker-compose.backend.yml" logs --tail 200 backend || true

--- a/.github/workflows/deployment/scripts/infra.sh
+++ b/.github/workflows/deployment/scripts/infra.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 # RabbitMQ와 Alloy만 독립적으로 관리한다. backend 이미지는 이 스크립트가 교체하지 않는다.
-SCRIPT_DIRECTORY=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-ROOT=$(cd -- "$SCRIPT_DIRECTORY/.." && pwd)
+ROOT="/home/ubuntu/puppyrun"
 CONFIG="$ROOT/config"
 COMPOSE="$ROOT/compose/docker-compose.infra.yml"
 ACTION="${1:-up}"

--- a/.github/workflows/deployment/scripts/rollback.sh
+++ b/.github/workflows/deployment/scripts/rollback.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIRECTORY=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-ROOT=$(cd -- "$SCRIPT_DIRECTORY/.." && pwd)
+ROOT="/home/ubuntu/puppyrun"
 CONFIG="$ROOT/config"
 STATE="$ROOT/state"
 COMPOSE="$ROOT/compose/docker-compose.backend.yml"

--- a/.github/workflows/deployment/scripts/rollback.sh
+++ b/.github/workflows/deployment/scripts/rollback.sh
@@ -16,6 +16,10 @@ source "$CONFIG/deploy.env"
 [[ -f "$STATE/current-image" && -f "$STATE/previous-image" ]] || { echo "Rollback state is unavailable."; exit 1; }
 CURRENT_IMAGE=$(<"$STATE/current-image")
 PREVIOUS_IMAGE=$(<"$STATE/previous-image")
+CURRENT_VERSION="unknown"
+PREVIOUS_VERSION="unknown"
+[[ -f "$STATE/current-version" ]] && CURRENT_VERSION=$(<"$STATE/current-version")
+[[ -f "$STATE/previous-version" ]] && PREVIOUS_VERSION=$(<"$STATE/previous-version")
 
 ensure_local_tag() {
   local local_tag="$1" image_reference="$2"
@@ -32,11 +36,11 @@ PREVIOUS_ID=$(docker image inspect --format '{{.Id}}' "$PREVIOUS_TAG")
 SWAP_CURRENT_TAG="$RUNTIME_REPOSITORY:swap-current"
 SWAP_PREVIOUS_TAG="$RUNTIME_REPOSITORY:swap-previous"
 
-BACKEND_IMAGE="$PREVIOUS_TAG" docker compose --project-name "$BACKEND_COMPOSE_PROJECT_NAME" \
+BACKEND_IMAGE="$PREVIOUS_TAG" APP_VERSION="$PREVIOUS_VERSION" docker compose --project-name "$BACKEND_COMPOSE_PROJECT_NAME" \
   --env-file "$CONFIG/app.env" -f "$COMPOSE" up -d --no-deps --force-recreate backend
 
 if ! "$ROOT/scripts/health-check.sh" "$HEALTH_URL"; then
-  BACKEND_IMAGE="$CURRENT_TAG" docker compose --project-name "$BACKEND_COMPOSE_PROJECT_NAME" \
+  BACKEND_IMAGE="$CURRENT_TAG" APP_VERSION="$CURRENT_VERSION" docker compose --project-name "$BACKEND_COMPOSE_PROJECT_NAME" \
     --env-file "$CONFIG/app.env" -f "$COMPOSE" up -d --no-deps --force-recreate backend || true
   exit 1
 fi
@@ -52,4 +56,6 @@ docker tag "$SWAP_CURRENT_TAG" "$PREVIOUS_TAG"
 docker image rm -f "$SWAP_CURRENT_TAG" "$SWAP_PREVIOUS_TAG" >/dev/null 2>&1 || true
 printf '%s\n' "$PREVIOUS_IMAGE" > "$STATE/current-image"
 printf '%s\n' "$CURRENT_IMAGE" > "$STATE/previous-image"
+printf '%s\n' "$PREVIOUS_VERSION" > "$STATE/current-version"
+printf '%s\n' "$CURRENT_VERSION" > "$STATE/previous-version"
 echo "Rollback succeeded: $PREVIOUS_IMAGE"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,7 @@ management:
     tags:
       application: ${spring.application.name}
       environment: ${SPRING_PROFILES_ACTIVE:default}
+      version: ${APP_VERSION:unknown}
 
   prometheus:
     metrics:


### PR DESCRIPTION
# 📌 Pull Request: 절대 경로 기반 EC2 배포 안정화

# 📝 작업 요약 (Summary)

SSM에서 실행되는 GitHub Actions 배포가 실행 위치에 영향을 받지 않도록, EC2 배포 루트를 `/opt/puppyrun`으로 고정했습니다. 배포·롤백·설정 재적용 시 실행 버전도 Prometheus 메트릭 라벨로 노출해 Grafana에서 실제 실행 릴리스를 식별할 수 있습니다.

- DB 스키마 변경: 없음
- API 계약 변경: 없음
- 운영 전제: EC2의 배포 정의와 운영 설정 경로는 `/opt/puppyrun`입니다.

# 🛠️ 변경 사항 (Changes)

## 1. 고정 절대 경로 배포

- GitHub Actions가 SSM으로 `/opt/puppyrun/scripts/deploy.sh {imageTag}`를 직접 실행하도록 변경했습니다.
- bootstrap, backend Compose, infra Compose의 운영 파일 경로를 `/opt/puppyrun` 기준으로 통일했습니다.
- Firebase 서비스 계정, `app.env`, Alloy 설정 파일의 마운트 경로가 현재 작업 디렉터리에 의존하지 않도록 했습니다.

## 2. 버전 라벨 및 배포 상태 관리

- Compose에서 `APP_VERSION`을 컨테이너에 전달하고, Micrometer 공통 태그 `version`으로 Prometheus 메트릭에 노출합니다.
- 배포 성공 시 `current-version`을 저장하고, 이전 버전은 `previous-version`으로 보관합니다.
- 후보 배포 실패 복구, 수동 롤백, 설정 재적용 때 실행 이미지에 맞는 버전을 유지합니다.

# 📸 테스트 시나리오 (Test Scenarios)

## 1. GitHub Actions 배포

* **실행 명령**: GitHub Actions `Deploy to EC2`
* **배포 명령**: `/opt/puppyrun/scripts/deploy.sh {imageTag}`

### ✅ 1-1: 불변 이미지 태그로 배포한다

1. GitHub Actions가 ECR에 `{imageTag}` 이미지를 push한다.
2. SSM이 `/opt/puppyrun/scripts/deploy.sh {imageTag}`를 실행한다.
3. EC2가 후보 이미지를 pull하고 readiness endpoint를 확인한다.
4. 성공하면 `current-image`와 `current-version`이 새 이미지 및 태그로 갱신된다.

### ✅ 1-2: 후보 이미지의 readiness 검사에 실패하면 기존 버전으로 복구한다

1. 후보 컨테이너의 readiness 검사 실패를 유도한다.
2. 기존 `current` 이미지와 `current-version`으로 backend가 복구되는지 확인한다.
3. `current-image`와 `current-version`이 기존 값으로 유지되는지 확인한다.

### ✅ 1-3: 롤백 시 이미지와 메트릭 버전이 함께 교체된다

1. `/opt/puppyrun/scripts/rollback.sh`를 실행한다.
2. `previous-image`가 실행되고 readiness 검사를 통과하는지 확인한다.
3. `/actuator/prometheus`의 `jvm_info`에 `version="{previousVersion}"` 라벨이 표시되는지 확인한다.
