### PR TITLE
feat: 반려동물 일별/마지막 산책 활동 조회 및 산책 목록 페이징 기능 구현

### DIFF
--- a/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
@@ -7,11 +7,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 
 @RestControllerAdvice

--- a/src/main/java/org/zerock/puppyrun/statistics/DTO/PetActivityTracking.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/DTO/PetActivityTracking.java
@@ -3,7 +3,7 @@ package org.zerock.puppyrun.statistics.DTO;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public record TodayPetActivityTracking(
+public record PetActivityTracking(
         UUID petId,
         String petName,
         String PetProfileUrl,

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/ActivitySummaryController.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/ActivitySummaryController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.common.exception.InvalidValueException;
 import org.zerock.puppyrun.statistics.controller.Response.DailyActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyContributionResponse;
@@ -24,16 +25,22 @@ public class ActivitySummaryController {
     private final TrackingActivityService trackingActivityService;
 
     /**
-     * 펫을 기준으로 활동량 통계를 조회합니다.
-     *
-     * @param targetDay 조회 날짜
+     * 펫을 기준으로 마지막 활동량 통계를 조회합니다.
      */
-    @GetMapping("/pet")
+    @GetMapping("/pet/last-tracking")
     public ResponseEntity<PetActivityResponse> getLastTracking(
             @AuthenticationPrincipal UserPrincipal principal,
-            @RequestParam("date") LocalDate targetDay
+            @RequestParam("startDate") LocalDate startDate,
+            @RequestParam("endDate") LocalDate endDate
     ) {
-        PetActivityResponse response = trackingActivityService.getPetActivity(principal, targetDay);
+        if (endDate.isBefore(startDate)) {
+            throw new InvalidValueException("종료일은 시작일보다 빠를 수 없습니다.");
+        }
+        if (!endDate.isBefore(startDate.plusMonths(3))) {
+            throw new InvalidValueException("3달 이상 조회는 불가능합니다.");
+        }
+
+        PetActivityResponse response = trackingActivityService.getPetLastActivity(principal, startDate, endDate);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/zerock/puppyrun/statistics/controller/Response/PetActivityResponse.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/controller/Response/PetActivityResponse.java
@@ -2,54 +2,70 @@ package org.zerock.puppyrun.statistics.controller.Response;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.UUID;
 import org.zerock.puppyrun.common.s3.support.S3Url;
-import org.zerock.puppyrun.statistics.DTO.TodayPetActivityTracking;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.statistics.DTO.PetActivityTracking;
 import org.zerock.puppyrun.tracking.util.PaceConverter;
 
 public record PetActivityResponse(
         List<PetActivity> activities
 ) {
-    record PetActivity(
-            UUID petId,                 // 강아지 고유 ID
-            String petName,             // 강아지 이름
-            @S3Url String PetProfileUrl, // 강아지 프로파일 이미지
 
-            UUID trackingId,            // 산책 고유 ID (상세 페이지 이동용)
-            LocalDateTime startedAt,    // 산책 시작 시간
-            LocalDateTime endedAt,      // 산책 종료 시간
-            Integer distanceM,          // 산책 거리 (m)
-            Integer durationSec,        // 산책 시간 (초)
-            String averagePace          // 산책 페이스
-
+    public record PetActivity(
+            UUID petId,
+            String petName,
+            @S3Url String petProfileUrl,
+            LatestActivity latestActivity
     ) {
-        public static PetActivity from(TodayPetActivityTracking activityTrackings) {
+
+        private static PetActivity from(Pet pet, PetActivityTracking activity) {
             return new PetActivity(
-                    activityTrackings.petId(),
-                    activityTrackings.petName(),
-                    activityTrackings.PetProfileUrl(),
-                    activityTrackings.trackingId(),
-                    activityTrackings.startedAt(),
-                    activityTrackings.endedAt(),
-                    activityTrackings.distance(),
-                    activityTrackings.duration(),
-                    PaceConverter.toString(activityTrackings.averagePace())
+                    pet.getId(),
+                    pet.getName(),
+                    pet.getProfileImageUrl(),
+                    LatestActivity.from(activity)
             );
         }
     }
 
-    public static PetActivityResponse of(List<TodayPetActivityTracking> activityTrackings) {
-        // 리스트가 비었거나 null 일경우
-        if (Objects.isNull(activityTrackings) || activityTrackings.isEmpty()) {
-            return new PetActivityResponse(List.of());
+    public record LatestActivity(
+            UUID trackingId,
+            LocalDateTime startedAt,
+            LocalDateTime endedAt,
+            Integer distanceM,
+            Integer durationSec,
+            String averagePace
+    ) {
+
+        private static LatestActivity from(PetActivityTracking activity) {
+            if (activity == null) {
+                return null;
+            }
+
+            return new LatestActivity(
+                    activity.trackingId(),
+                    activity.startedAt(),
+                    activity.endedAt(),
+                    activity.distance(),
+                    activity.duration(),
+                    PaceConverter.toString(activity.averagePace())
+            );
         }
-
-        List<PetActivity> activityList = activityTrackings.stream()
-                .map(PetActivity::from)
-                .toList();
-
-        return new PetActivityResponse(activityList);
     }
 
+    public static PetActivityResponse of(
+            List<Pet> petList,
+            Map<Pet, PetActivityTracking> latestActivities
+    ) {
+        List<PetActivity> activities = petList.stream()
+                .map(pet -> PetActivity.from(
+                        pet,
+                        latestActivities.get(pet)
+                ))
+                .toList();
+
+        return new PetActivityResponse(activities);
+    }
 }

--- a/src/main/java/org/zerock/puppyrun/statistics/service/TrackingActivityService.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/service/TrackingActivityService.java
@@ -1,7 +1,9 @@
 package org.zerock.puppyrun.statistics.service;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
@@ -10,10 +12,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
+import org.zerock.puppyrun.pet.entity.Pet;
 import org.zerock.puppyrun.pet.repository.PetRepository;
 import org.zerock.puppyrun.statistics.DTO.DailyPetTracking;
 import org.zerock.puppyrun.statistics.DTO.MonthlyActivity;
-import org.zerock.puppyrun.statistics.DTO.TodayPetActivityTracking;
+import org.zerock.puppyrun.statistics.DTO.PetActivityTracking;
 import org.zerock.puppyrun.statistics.controller.Response.DailyActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyContributionResponse;
@@ -40,15 +43,39 @@ public class TrackingActivityService {
         return DailyActivityResponse.of(targetDay, dailyPetTracking);
     }
 
-    public PetActivityResponse getPetActivity(UserPrincipal principal, LocalDate startDate) {
-        LocalDate endDate = startDate.plusDays(1);
+    /**
+     * 펫을 기준으로 마지막 활동량 조회
+     *
+     * @param principal
+     * @return
+     */
+    public PetActivityResponse getPetLastActivity(UserPrincipal principal, LocalDate startDate, LocalDate endDate) {
+
+        List<Pet> petList = petRepository.findAllByMemberId(principal.id());
+        if (petList.isEmpty()) {
+            throw new ResourceNotFoundException("펫이 존재하지 않습니다.");
+        }
 
         // 해당 날짜를 기준으로 강아지 산책 리스트 조회
-        List<TodayPetActivityTracking> activityTrackings =
-                trackingRepository.getPetActivities(principal.id(), startDate, endDate);
+        Map<Pet, PetActivityTracking> latestActivities = new HashMap<>();
 
-        return PetActivityResponse.of(activityTrackings);
+        for (Pet pet : petList) {
+            List<PetActivityTracking> activities =
+                    trackingRepository.getPetActivitiesAsc(
+                            principal.id(),
+                            pet.getId(),
+                            startDate,
+                            endDate
+                    );
 
+            if (!activities.isEmpty()) {
+                latestActivities.put(pet, activities.getLast());
+            } else {
+                latestActivities.put(pet, null);
+            }
+        }
+
+        return PetActivityResponse.of(petList, latestActivities);
     }
 
     public WeeklyActivityResponse getWeeklyTracking(UserPrincipal principal, LocalDate targetDay) {

--- a/src/main/java/org/zerock/puppyrun/tracking/DTO/MainTrackingSummary.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/DTO/MainTrackingSummary.java
@@ -5,12 +5,14 @@ import java.util.UUID;
 import org.zerock.puppyrun.tracking.entity.RoutePoint;
 
 public record MainTrackingSummary(
-        UUID trackingId,
-        String featuredImage,
-        List<RoutePoint> path
+        List<TrackingSummary> trackingSummaries,
+        boolean hasNext
 ) {
-
-    public MainTrackingSummary {
-        path = List.copyOf(path);
+    public record TrackingSummary(
+            UUID trackingId,
+            String featuredImage,
+            List<RoutePoint> path
+    ) {
     }
+
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/TrackingController.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/TrackingController.java
@@ -4,6 +4,9 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -51,8 +55,21 @@ public class TrackingController {
     // 산책 기록 조회
     @GetMapping("")
     public ResponseEntity<MainTrackingResponse> getTrackingList(
-            @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        MainTrackingResponse response = trackingQueryService.getTrackingListResponse(userPrincipal.id());
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+
+    ) {
+        Pageable pageable = PageRequest.of(
+                page,
+                Math.min(Math.max(size, 1), 100),
+                Sort.by(
+                        Sort.Order.desc("createdAt"),
+                        Sort.Order.desc("id")
+                )
+        );
+
+        MainTrackingResponse response = trackingQueryService.getTrackingListResponse(userPrincipal.id(), pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/response/MainTrackingResponse.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/response/MainTrackingResponse.java
@@ -7,18 +7,20 @@ import org.zerock.puppyrun.tracking.DTO.MainTrackingSummary;
 import org.zerock.puppyrun.tracking.entity.RoutePoint;
 
 public record MainTrackingResponse(
-        List<TrackingDetail> trackingList
+        List<TrackingDetail> trackingList,
+        boolean hasNext,
+        int pageSize
 ) {
 
     /**
      * 산책 목록 조회 결과를 API 응답으로 변환합니다.
      */
-    public static MainTrackingResponse from(List<MainTrackingSummary> summaries) {
-        List<TrackingDetail> details = summaries.stream()
+    public static MainTrackingResponse from(MainTrackingSummary summaries) {
+        List<TrackingDetail> details = summaries.trackingSummaries().stream()
                 .map(TrackingDetail::from)
                 .toList();
 
-        return new MainTrackingResponse(details);
+        return new MainTrackingResponse(details, summaries.hasNext(), details.size());
     }
 
     public record TrackingDetail(
@@ -27,7 +29,7 @@ public record MainTrackingResponse(
             List<TrackingPoint> path     // 산책 경로
     ) {
 
-        private static TrackingDetail from(MainTrackingSummary summary) {
+        private static TrackingDetail from(MainTrackingSummary.TrackingSummary summary) {
             return new TrackingDetail(
                     summary.trackingId(),
                     summary.featuredImage(),

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
@@ -19,7 +19,7 @@ public interface TrackingRepoCustom {
     /**
      * 회원의 산책 목록을 대표 이미지, 경로와 함께 조회합니다.
      */
-    List<MainTrackingSummary> findMainTrackingSummaries(UUID memberId);
+    MainTrackingSummary findMainTrackingSummaries(UUID memberId, Pageable pageable);
 
     /**
      * 산책 상세 기본 정보와 경로 및 일기를 조회합니다.

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
-import org.zerock.puppyrun.statistics.DTO.TodayPetActivityTracking;
+import org.zerock.puppyrun.statistics.DTO.PetActivityTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyMemberStat;
 import org.zerock.puppyrun.tracking.DTO.DailyTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
@@ -51,10 +51,32 @@ public interface TrackingRepoCustom {
      */
     List<DailyTrackingSummary> getTrackingSummaryDateAsc(UUID memberId, LocalDate startDate, LocalDate endDate);
 
+    /**
+     * 특정 회원의 반려동물이 지정된 기간에 수행한 산책 기록을 조회합니다.
+     *
+     * <p>조회 기간은 {@code startDate} 00:00 이상부터 {@code endDate} 다음 날 00:00 미만까지이며,
+     * 산책 시작 시각 기준 오름차순으로 반환합니다.</p>
+     *
+     * @return 해당 반려동물의 기간 내 산책 기록 목록. 기록이 없으면 빈 목록
+     */
+    List<PetActivityTracking> getPetActivitiesAsc(UUID memberId, UUID petId, LocalDate startDate, LocalDate endDate);
 
-    List<TodayPetActivityTracking> getPetActivities(UUID memberId, LocalDate startDate, LocalDate endDate);
-
+    /**
+     * 특정 회원의 지정 날짜 산책 기록을 조회합니다.
+     *
+     * <p>조회 범위는 {@code targetDate} 00:00 이상부터 다음 날 00:00 미만까지입니다.</p>
+     *
+     * @return 해당 날짜의 산책 기록 목록. 기록이 없으면 빈 목록
+     */
     List<DailyTracking> getDailyActivities(UUID memberId, LocalDate targetDate);
 
+    /**
+     * 여러 회원의 지정 기간 산책 통계를 회원별로 집계합니다.
+     *
+     * <p>회원별 산책 횟수, 총 거리 및 총 시간을 반환합니다.
+     * 조회 기간은 {@code startDate} 00:00 이상부터 {@code endDate} 다음 날 00:00 미만까지입니다.</p>
+     *
+     * @return 기간 내 산책 기록이 있는 회원별 집계 목록
+     */
     List<DailyMemberStat> findMemberIdsByDate(List<UUID> memberIds, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-import org.zerock.puppyrun.statistics.DTO.TodayPetActivityTracking;
+import org.zerock.puppyrun.statistics.DTO.PetActivityTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyMemberStat;
 import org.zerock.puppyrun.tracking.DTO.DailyTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
@@ -262,10 +262,15 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
     }
 
     @Override
-    public List<TodayPetActivityTracking> getPetActivities(UUID memberId, LocalDate startDate, LocalDate endDate) {
+    public List<PetActivityTracking> getPetActivitiesAsc(
+            UUID memberId,
+            UUID petId,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
         return queryFactory
                 .select(Projections.constructor(
-                        TodayPetActivityTracking.class,
+                        PetActivityTracking.class,
                         pet.id,
                         pet.name,
                         pet.profileImageUrl,
@@ -281,14 +286,19 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
                 .join(petTracking.pet, pet)
                 .join(petTracking.tracking, tracking)
                 .where(
+                        pet.id.eq(petId),
                         pet.member.id.eq(memberId),
                         tracking.member.id.eq(memberId),
                         tracking.startedAt.goe(startDate.atStartOfDay()),
                         tracking.startedAt.lt(endDate.atStartOfDay())
                 )
-                .orderBy(petTracking.pet.id.asc(), tracking.startedAt.asc(), tracking.id.asc())
+                .orderBy(
+                        tracking.startedAt.asc(),
+                        tracking.id.asc()
+                )
                 .fetch();
     }
+
 
     @Override
     public List<DailyTracking> getDailyActivities(UUID memberId, LocalDate targetDate) {

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
@@ -21,6 +21,7 @@ import org.zerock.puppyrun.tracking.DTO.DailyTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
 import org.zerock.puppyrun.tracking.DTO.MainTrackingSummary;
 import org.zerock.puppyrun.tracking.DTO.TrackingDetailSummary;
+import org.zerock.puppyrun.tracking.entity.RoutePoint;
 import org.zerock.puppyrun.tracking.entity.Tracking;
 import org.zerock.puppyrun.tracking.entity.TrackingRoute;
 
@@ -39,12 +40,12 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<MainTrackingSummary> findMainTrackingSummaries(UUID memberId) {
-        return queryFactory
+    public MainTrackingSummary findMainTrackingSummaries(UUID memberId, Pageable pageable) {
+        List<Tuple> result = queryFactory
                 .select(
                         tracking.id,
                         trackingImage.imageUrl,
-                        trackingRoute
+                        trackingRoute.rawPath
                 )
                 .from(tracking)
                 .leftJoin(trackingImage).on(
@@ -57,17 +58,27 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
                         tracking.startedAt.desc(),
                         tracking.id.asc()
                 )
-                .fetch()
-                .stream()
-                .map(row -> {
-                    TrackingRoute route = row.get(trackingRoute);
-                    return new MainTrackingSummary(
-                            row.get(tracking.id),
-                            row.get(trackingImage.imageUrl),
-                            route != null ? route.getOriginalPath() : List.of()
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1L)
+                .fetch();
+
+        boolean hasNext = result.size() > pageable.getPageSize();
+        if (hasNext) {
+            result.remove(pageable.getPageSize()); // 안전하게 마지막 항목 제거
+        }
+
+        List<MainTrackingSummary.TrackingSummary> summaries = result.stream()
+                .map(r -> {
+                    List<RoutePoint> path = r.get(trackingRoute.rawPath); // originalPath 직접 추출
+                    return new MainTrackingSummary.TrackingSummary(
+                            r.get(tracking.id),
+                            r.get(trackingImage.imageUrl),
+                            path != null ? path : List.of()
                     );
                 })
                 .toList();
+
+        return new MainTrackingSummary(summaries, hasNext);
     }
 
     @Override

--- a/src/main/java/org/zerock/puppyrun/tracking/service/TrackingQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/service/TrackingQueryService.java
@@ -3,6 +3,8 @@ package org.zerock.puppyrun.tracking.service;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
@@ -22,8 +24,8 @@ public class TrackingQueryService {
     /**
      * 산책 리스트 조회
      */
-    public MainTrackingResponse getTrackingListResponse(UUID memberId) {
-        List<MainTrackingSummary> summaries = trackingRepository.findMainTrackingSummaries(memberId);
+    public MainTrackingResponse getTrackingListResponse(UUID memberId, Pageable pageable) {
+        MainTrackingSummary summaries = trackingRepository.findMainTrackingSummaries(memberId, pageable);
         return MainTrackingResponse.from(summaries);
     }
 

--- a/src/test/java/org/zerock/puppyrun/statistics/service/TrackingActivityServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/statistics/service/TrackingActivityServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.member.entity.UserRole;
+import org.zerock.puppyrun.pet.entity.Pet;
 import org.zerock.puppyrun.pet.repository.PetRepository;
 import org.zerock.puppyrun.statistics.DTO.DailyPetTracking;
 import org.zerock.puppyrun.statistics.DTO.MonthlyActivity;
@@ -112,9 +113,15 @@ class TrackingActivityServiceTest {
         LocalDate endDate = LocalDate.of(2026, 3, 31);
         UUID petWithoutTrackingId = UUID.randomUUID();
         UUID petWithTrackingId = UUID.randomUUID();
+        Pet petWithoutTracking = org.mockito.Mockito.mock(Pet.class);
+        given(petWithoutTracking.getId()).willReturn(petWithoutTrackingId);
+        given(petWithoutTracking.getName()).willReturn("콩이");
+        Pet petWithTracking = org.mockito.Mockito.mock(Pet.class);
+        given(petWithTracking.getId()).willReturn(petWithTrackingId);
+        given(petWithTracking.getName()).willReturn("보리");
         UUID latestTrackingId = UUID.randomUUID();
-        given(petRepository.findPetIdsByMemberId(memberId))
-                .willReturn(List.of(petWithoutTrackingId, petWithTrackingId));
+        given(petRepository.findAllByMemberId(memberId))
+                .willReturn(List.of(petWithoutTracking, petWithTracking));
         given(trackingRepository.getPetActivitiesAsc(
                 memberId,
                 petWithoutTrackingId,
@@ -135,10 +142,11 @@ class TrackingActivityServiceTest {
         PetActivityResponse response = trackingActivityService.getPetLastActivity(principal, startDate, endDate);
 
         // then
-        assertThat(response)
-                .extracting("activities")
-                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.LIST)
+        assertThat(response.activities()).hasSize(2);
+        assertThat(response.activities())
+                .filteredOn(activity -> activity.petId().equals(petWithTrackingId))
                 .singleElement()
+                .extracting("latestActivity")
                 .extracting("trackingId")
                 .isEqualTo(latestTrackingId);
     }

--- a/src/test/java/org/zerock/puppyrun/statistics/service/TrackingActivityServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/statistics/service/TrackingActivityServiceTest.java
@@ -21,10 +21,12 @@ import org.zerock.puppyrun.member.entity.UserRole;
 import org.zerock.puppyrun.pet.repository.PetRepository;
 import org.zerock.puppyrun.statistics.DTO.DailyPetTracking;
 import org.zerock.puppyrun.statistics.DTO.MonthlyActivity;
+import org.zerock.puppyrun.statistics.DTO.PetActivityTracking;
 import org.zerock.puppyrun.statistics.DTO.WeeklyActivityChart;
 import org.zerock.puppyrun.statistics.controller.Response.DailyActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.MonthlyContributionResponse;
+import org.zerock.puppyrun.statistics.controller.Response.PetActivityResponse;
 import org.zerock.puppyrun.statistics.controller.Response.WeeklyActivityResponse;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
 import org.zerock.puppyrun.tracking.DTO.DailyTracking;
@@ -100,6 +102,45 @@ class TrackingActivityServiceTest {
         assertThat(response.summary().totalDurationSec()).isZero();
         assertThat(response.summary().walkCount()).isZero();
         assertThat(response.tracking()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기간 내 산책 기록이 있는 반려견의 마지막 산책만 반환한다")
+    void getPetLastActivitySkipsPetsWithoutTrackingInPeriod() {
+        // given
+        LocalDate startDate = LocalDate.of(2026, 3, 1);
+        LocalDate endDate = LocalDate.of(2026, 3, 31);
+        UUID petWithoutTrackingId = UUID.randomUUID();
+        UUID petWithTrackingId = UUID.randomUUID();
+        UUID latestTrackingId = UUID.randomUUID();
+        given(petRepository.findPetIdsByMemberId(memberId))
+                .willReturn(List.of(petWithoutTrackingId, petWithTrackingId));
+        given(trackingRepository.getPetActivitiesAsc(
+                memberId,
+                petWithoutTrackingId,
+                startDate,
+                endDate
+        )).willReturn(List.of());
+        given(trackingRepository.getPetActivitiesAsc(
+                memberId,
+                petWithTrackingId,
+                startDate,
+                endDate
+        )).willReturn(List.of(
+                petActivityTracking(petWithTrackingId, UUID.randomUUID(), startDate.atTime(9, 0)),
+                petActivityTracking(petWithTrackingId, latestTrackingId, endDate.atTime(18, 0))
+        ));
+
+        // when
+        PetActivityResponse response = trackingActivityService.getPetLastActivity(principal, startDate, endDate);
+
+        // then
+        assertThat(response)
+                .extracting("activities")
+                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.LIST)
+                .singleElement()
+                .extracting("trackingId")
+                .isEqualTo(latestTrackingId);
     }
 
     @Test
@@ -263,6 +304,20 @@ class TrackingActivityServiceTest {
                 diary,
                 List.of(new DailyPetTracking.TrackingImageSummary(0, "image1.jpg")),
                 List.of(pet)
+        );
+    }
+
+    private PetActivityTracking petActivityTracking(UUID petId, UUID trackingId, java.time.LocalDateTime startedAt) {
+        return new PetActivityTracking(
+                petId,
+                "보리",
+                "pets/bori.jpg",
+                trackingId,
+                390.0,
+                startedAt,
+                startedAt.plusMinutes(30),
+                2_000,
+                1_800
         );
     }
 

--- a/src/test/java/org/zerock/puppyrun/tracking/repository/MainTrackingQueryRepositoryTest.java
+++ b/src/test/java/org/zerock/puppyrun/tracking/repository/MainTrackingQueryRepositoryTest.java
@@ -62,18 +62,20 @@ class MainTrackingQueryRepositoryTest extends TestContainerConfig {
         statistics.clear();
 
         // when
-        List<MainTrackingSummary> summaries = trackingRepository.findMainTrackingSummaries(member.getId());
+        org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(0, 10);
+        MainTrackingSummary summaryResult = trackingRepository.findMainTrackingSummaries(member.getId(), pageable);
+        List<MainTrackingSummary.TrackingSummary> summaries = summaryResult.trackingSummaries();
 
         // then
         assertThat(statistics.getPrepareStatementCount()).isEqualTo(1L);
         assertThat(summaries).hasSize(2);
 
-        MainTrackingSummary latestSummary = summaries.getFirst();
+        MainTrackingSummary.TrackingSummary latestSummary = summaries.getFirst();
         assertThat(latestSummary.trackingId()).isEqualTo(latestTracking.getId());
         assertThat(latestSummary.featuredImage()).isEqualTo("tracking/featured.jpg");
         assertThat(latestSummary.path()).containsExactlyElementsOf(latestPath);
 
-        MainTrackingSummary olderSummary = summaries.getLast();
+        MainTrackingSummary.TrackingSummary olderSummary = summaries.getLast();
         assertThat(olderSummary.trackingId()).isEqualTo(olderTracking.getId());
         assertThat(olderSummary.featuredImage()).isNull();
         assertThat(olderSummary.path())


### PR DESCRIPTION
# 📌 Pull Request: 반려동물 일별/마지막 산책 활동 조회 및 산책 목록 페이징 기능 구현

# 📝 작업 요약 (Summary)

로그인한 회원의 반려동물별 마지막 산책 활동을 조회하는 API (`GET /api/activity-tracking/statistics/pet/last-tracking`)를 구현하고, 메인 산책 목록 조회 API (
`GET /api/tracking`)에 `Pageable` 기반의 안전한 슬라이스 페이징(`hasNext`, `pageSize`)과 이중 정렬 기능을 적용했습니다.

또한, 컨트롤러 요청 파라미터 타입 불일치(`@RequestParam` 타입 오류) 시 기존 500 Internal Server Error로 응답되던 문제를 예외 처리기 패키지 수정(
`GlobalExceptionHandler`)을 통해 400 Bad Request(`INVALID_REQUEST`)로 정확히 반환하도록 개선했습니다.

---

# 🛠️ 변경 사항 (Changes)

## 1. 펫별 마지막 산책 활동 조회 API 구현

- `GET /api/activity-tracking/statistics/pet/last-tracking` 엔드포인트를 추가했습니다.
- 로그인된 회원의 모든 반려동물 목록을 가져온 뒤, 각 반려동물별 지정 기간 내 가장 마지막 산책 기록(`getPetActivitiesAsc`)을 추출하여 반환합니다.
- 지정 기간 동안 산책 기록이 없는 반려동물도 목록에 포함되며, 이 경우 `latest_activity` 필드는 `null`로 응답합니다.
- DTO 역할 구분을 위해 기존 `TodayPetActivityTracking`을 `PetActivityTracking`으로 리네임했습니다.

## 2. 메인 산책 목록 슬라이스 페이징 조회 기능

- `GET /api/v1/tracking`에 `page` (기본값: `0`), `size` (기본값: `10`) 쿼리 파라미터를 적용했습니다.
- `Math.min(Math.max(size, 1), 100)`을 통해 요청된 페이지 크기를 최소 1개에서 최대 100개 사이로 제한하여 과도한 조회 요청으로부터 서버 자원을 보호합니다.
- 생성일시 내림차순(`createdAt desc`) 및 식별자 내림차순(`id desc`)으로 이중 정렬 기준을 구성했습니다.
- `MainTrackingSummary` 및 `MainTrackingResponse` DTO 구조를 개편하여 `trackingList`, `hasNext`(다음 페이지 존재 여부), `pageSize`(현재 페이지
  응답 항목 수)를 포함했습니다.
- QueryDSL 쿼리에 `.offset()`과 `.limit(pageSize + 1)` 조회를 적용하고, `trackingRoute.rawPath`에서 직접 경로를 추출하여 NPE 방지 및 쿼리를 최적화했습니다.

## 3. 전역 예외 처리기 패키지 수정

- `GlobalExceptionHandler`에서 `MethodArgumentTypeMismatchException`의 import 경로를 Spring Messaging 패키지에서 Spring Web 패키지(
  `org.springframework.web.method.annotation.MethodArgumentTypeMismatchException`)로 수정했습니다.
- 잘못된 날짜 포맷(`2026-08-3` 등)이나 타입 불일치 파라미터 전달 시 400 Bad Request (`INVALID_REQUEST`)로 클라이언트 오류가 정상 응답됩니다.

---

# 📸 테스트 시나리오 (Test Scenarios)

## 1. 펫별 마지막 산책 조회 API

* **Method**: `GET`
* **URL**: `/api/activity-tracking/statistics/pet/last-tracking?startDate=2026-08-01&endDate=2026-08-14`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### Query Parameters

| 이름          | 타입                       | 필수 | 제약조건           | 설명     |
|-------------|--------------------------|---:|----------------|--------|
| `startDate` | LocalDate (`YYYY-MM-DD`) |  O | `endDate` 이하   | 조회 시작일 |
| `endDate`   | LocalDate (`YYYY-MM-DD`) |  O | `startDate` 이상 | 조회 종료일 |

### ✅ 1-1: 산책 기록 유무와 관계없이 모든 펫의 마지막 산책 조회

**Request Body**

```
없음
```

**Response (200 OK)**

```json
{
  "activities": [
    {
      "pet_id": "355f7c9c-4e7e-4d5f-8c23-f5f5e02faf46",
      "pet_name": "멍멍이",
      "pet_profile_url": "https://puppyrun.s3.ap-northeast-2.amazonaws.com/pets/profile.jpg",
      "latest_activity": {
        "tracking_id": "5c928a83-3ae6-49fd-b342-ed54b90c5d49",
        "started_at": "2026-08-12T09:00:00",
        "ended_at": "2026-08-12T09:32:10",
        "distance_m": 1820,
        "duration_sec": 1930,
        "average_pace": "5'18"
      }
    },
    {
      "pet_id": "019b1fbb-9e76-7000-a4ea-1257e470e24e",
      "pet_name": "두부",
      "pet_profile_url": null,
      "latest_activity": null
    }
  ]
}
```

### ❌ 1-2: 잘못된 날짜 포맷 입력 (타입 불일치)

**Request Body**

```
없음
```

**Response (400 Bad Request)**

```json
{
  "code": "INVALID_REQUEST",
  "description": "입력값이 올바르지 않습니다.",
  "message": "파라미터 형식이 올바르지 않습니다.",
  "timestamp": "2026-08-12T23:30:00",
  "path": "/api/activity-tracking/statistics/pet/last-tracking"
}
```

---

## 2. 메인 산책 목록 슬라이스 페이징 조회 API

* **Method**: `GET`
* **URL**: `/api/tracking?page=0&size=10`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### Query Parameters

| 이름     | 타입      | 필수 | 기본값 | 제약조건         | 설명                  |
|--------|---------|---:|-----|--------------|---------------------|
| `page` | Integer |  X | 0   | 0 이상         | 조회할 페이지 번호 (0부터 시작) |
| `size` | Integer |  X | 10  | 최소 1, 최대 100 | 한 페이지당 조회할 항목 수     |

### ✅ 2-1: 산책 목록 슬라이스 페이징 조회 성공

**Request Body**

```
없음
```

**Response (200 OK)**

```json
{
  "tracking_list": [
    {
      "id": "4e88a3ec-6be5-4d94-bbd4-77937c43f82e",
      "featured_image": "https://puppyrun.s3.ap-northeast-2.amazonaws.com/tracking/featured.jpg",
      "path": [
        {
          "lat": 37.5665,
          "lng": 126.9780,
          "time": 0
        },
        {
          "lat": 37.5670,
          "lng": 126.9790,
          "time": 600
        }
      ]
    }
  ],
  "has_next": true,
  "page_size": 1
}
```

