### PR TITLE
refactor: 로그 관측성 및 날씨 누락 진단 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'

--- a/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
@@ -26,8 +26,14 @@ public class GlobalExceptionHandler {
             BusinessException e,
             HttpServletRequest request) {
 
-        log.warn("Business Exception: {}", e.getMessage());
-        log.warn("Cause: ", e);
+        log.warn(
+                "exceptionType={}, errorCode={}, status={}, uri={}, message={}",
+                e.getClass().getSimpleName(),
+                e.getErrorCode().getCode(),
+                e.getErrorCode().getHttpStatus().value(),
+                request.getRequestURI(),
+                e.getMessage()
+        );
 
         ErrorResponse errorResponse = ErrorResponse.of(
                 e.getErrorCode().getCode(),
@@ -48,8 +54,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
             MethodArgumentNotValidException e,
             HttpServletRequest request) {
-        log.warn("MethodArgumentNotValidException: {}", e.getMessage());
-
         // 첫 번째 validation 오류 메시지 추출
         String errorMessage = e.getBindingResult()
                 .getFieldErrors()
@@ -80,8 +84,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleConstraintViolationException(
             ConstraintViolationException e,
             HttpServletRequest request) {
-        log.warn("ConstraintViolationException: {}", e.getMessage());
-
         String errorMessage = e.getConstraintViolations()
                 .stream()
                 .findFirst()
@@ -146,8 +148,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
             HttpMessageNotReadableException e,
             HttpServletRequest request) {
-
-        log.warn("JSON Parsing Error: {}", e.getMessage());
 
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
 

--- a/src/main/java/org/zerock/puppyrun/common/logging/ExecutionTimeAspect.java
+++ b/src/main/java/org/zerock/puppyrun/common/logging/ExecutionTimeAspect.java
@@ -1,0 +1,29 @@
+package org.zerock.puppyrun.common.logging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class ExecutionTimeAspect {
+
+    @Around("@annotation(org.zerock.puppyrun.common.logging.LogExecutionTime)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startedAt = System.nanoTime();
+        Object result = joinPoint.proceed();
+        long durationMs = (System.nanoTime() - startedAt) / 1_000_000;
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        log.info(
+                "Method completed. class={}, method={}, durationMs={}",
+                signature.getDeclaringType().getSimpleName(),
+                signature.getName(),
+                durationMs
+        );
+        return result;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/logging/LogExecutionTime.java
+++ b/src/main/java/org/zerock/puppyrun/common/logging/LogExecutionTime.java
@@ -1,0 +1,11 @@
+package org.zerock.puppyrun.common.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogExecutionTime {
+}

--- a/src/main/java/org/zerock/puppyrun/common/logging/TraceIdFilter.java
+++ b/src/main/java/org/zerock/puppyrun/common/logging/TraceIdFilter.java
@@ -1,0 +1,38 @@
+package org.zerock.puppyrun.common.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class TraceIdFilter extends OncePerRequestFilter {
+
+    public static final String TRACE_ID = "traceId";
+    public static final String TRACE_ID_HEADER = "X-Trace-Id";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String traceId = UUID.randomUUID().toString();
+        MDC.put(TRACE_ID, traceId);
+        response.setHeader(TRACE_ID_HEADER, traceId);
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(TRACE_ID);
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/NotificationProcessor.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/NotificationProcessor.java
@@ -40,10 +40,8 @@ public class NotificationProcessor {
             // 마지막으로 본 시간 이후의 1000명을 조회
             memberSettings = notificationRepository.findNextMembers(lastCreatedAt, limitOnly, type);
             if (memberSettings.isEmpty()) {
-                log.info("알림 가능한 멤버가 없습니다.");
                 break; // 더 이상 데이터가 없으면 탈출
             }
-
             // 메세지를 다르게 만드는 분기
             List<PushTask> pushTasks = sender.setPushTasks(memberSettings);
 

--- a/src/main/java/org/zerock/puppyrun/notification/service/WalkingPreferenceService.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/WalkingPreferenceService.java
@@ -12,11 +12,11 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.common.logging.LogExecutionTime;
 import org.zerock.puppyrun.notification.entity.WalkingPreference;
 import org.zerock.puppyrun.notification.repository.WalkingPreferenceRepository;
 import org.zerock.puppyrun.tracking.entity.Tracking;
@@ -27,7 +27,6 @@ import org.zerock.puppyrun.tracking.repository.TrackingRepository;
  */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 @Transactional
 public class WalkingPreferenceService {
 
@@ -41,6 +40,7 @@ public class WalkingPreferenceService {
     /**
      * 최근 30일 내 산책 회원을 청크 단위로 조회해 평일·주말 선호 시간을 갱신합니다.
      */
+    @LogExecutionTime
     public void updateAllMemberPreferences() {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime startDateTime = now.minusDays(ANALYSIS_WINDOW_DAYS);
@@ -53,7 +53,6 @@ public class WalkingPreferenceService {
             if (memberIds.isEmpty()) {
                 break;
             }
-
             List<Tracking> trackings = trackingRepository
                     .findAllByMemberIdsAndDateRange(memberIds, startDateTime);
             Map<UUID, List<Tracking>> trackingMap = trackings.stream()
@@ -78,8 +77,6 @@ public class WalkingPreferenceService {
             walkingPreferenceRepository.saveAll(updates);
             pageNumber++;
         } while (memberIds.size() == CHUNK_SIZE);
-
-        log.info("회원 산책 선호도 분석을 완료했습니다.");
     }
 
     private void updatePreference(

--- a/src/main/java/org/zerock/puppyrun/weather/messaging/APIRetry/WeatherAPIRetryConsumer.java
+++ b/src/main/java/org/zerock/puppyrun/weather/messaging/APIRetry/WeatherAPIRetryConsumer.java
@@ -32,11 +32,11 @@ public class WeatherAPIRetryConsumer {
                 || message.gridPoint() == null
                 || message.forecastType() == null
                 || message.requestTime() == null) {
-            log.error("[API 재시도 메시지 오류] 필수 값이 누락되어 재시도를 종료합니다.");
+            log.error("[weather API 재시도 큐] 필수 값이 누락되어 재시도를 종료합니다.");
             return;
         }
 
-        log.info("[API 재시도 큐 수신] 10분 지연 후 소비 시작 | nx={}, ny={}, 예보종류={}",
+        log.info("[weather API 재시도 큐] 10분 지연 후 소비 시작 | nx={}, ny={}, 예보종류={}",
                 message.gridPoint().nx(), message.gridPoint().ny(), message.forecastType());
 
         WeatherForecast forecast = WeatherForecast.toForecast(message.forecastType(), message.requestTime());

--- a/src/main/java/org/zerock/puppyrun/weather/messaging/APIRetry/WeatherAPIRetryPublisher.java
+++ b/src/main/java/org/zerock/puppyrun/weather/messaging/APIRetry/WeatherAPIRetryPublisher.java
@@ -36,8 +36,11 @@ public class WeatherAPIRetryPublisher {
             WeatherAPIRetryMessage message = WeatherAPIRetryMessage.from(failedResult);
 
             rabbitTemplate.convertAndSend(exchange, routingKey, message);
-            log.info("API 실패 응답 RabbitMQ 10분 지연 큐 발송 완료: nx={}, ny={}",
-                    failedResult.gridPoint().nx(), failedResult.gridPoint().ny());
+            log.warn("[weather API 재시도 큐] RabbitMQ 10분 지연 큐 발송 완료: type={} nx={}, ny={}",
+                    failedResult.forecast().getType(),
+                    failedResult.gridPoint().nx(),
+                    failedResult.gridPoint().ny()
+            );
         }
     }
 }

--- a/src/main/java/org/zerock/puppyrun/weather/messaging/DBRetry/WeatherDBRetryConsumer.java
+++ b/src/main/java/org/zerock/puppyrun/weather/messaging/DBRetry/WeatherDBRetryConsumer.java
@@ -24,17 +24,18 @@ public class WeatherDBRetryConsumer {
     @RabbitListener(queues = "weather.retry.db.queue")
     public void process(WeatherDBRetryMessage message) {
         if (message == null || message.commands().isEmpty()) {
-            log.info("[DB 재시도 큐 수신] 수신된 메시지에 저장할 데이터가 없습니다.");
+            log.info("[weather DB 재시도 큐] 수신된 메시지에 저장할 데이터가 없습니다.");
             return;
         }
 
-        log.info("[DB 재시도 큐 수신] 10초 지연 후 소비 시작 | 총 {}건", message.commands().size());
+        log.info("[weather DB 재시도 큐] 10초 지연 후 소비 시작 | 총 {}건", message.commands().size());
 
         try {
             weatherCommandService.save(message.commands());
-            log.info("[DB 재시도 성공] 총 {}건 DB 일괄 저장 완료", message.commands().size());
+            log.info("[weather DB 재시도 큐] 총 {}건 DB 일괄 저장 완료", message.commands().size());
         } catch (Exception e) {
-            log.error("[DB 최종 실패] 총 {}건 DB 저장 최종 실패: 원인={}", message.commands().size(), e.getMessage(), e);
+            log.error("[weather DB 재시도 큐] 최종 실패 총 {}건 DB 저장 최종 실패: 원인={}", message.commands().size(), e.getMessage(),
+                    e);
         }
     }
 }

--- a/src/main/java/org/zerock/puppyrun/weather/messaging/DBRetry/WeatherDBRetryPublisher.java
+++ b/src/main/java/org/zerock/puppyrun/weather/messaging/DBRetry/WeatherDBRetryPublisher.java
@@ -35,6 +35,6 @@ public class WeatherDBRetryPublisher {
         WeatherDBRetryMessage message = new WeatherDBRetryMessage(commands);
 
         rabbitTemplate.convertAndSend(exchange, routingKey, message);
-        log.info("[DB 지연 큐 발송] 10초 지연 큐로 메시지 발송 완료 (총 {}건)", commands.size());
+        log.info("[weather DB 재시도 큐] 10초 지연 큐로 메시지 발송 완료 (총 {}건)", commands.size());
     }
 }

--- a/src/main/java/org/zerock/puppyrun/weather/scheduler/WeatherScheduler.java
+++ b/src/main/java/org/zerock/puppyrun/weather/scheduler/WeatherScheduler.java
@@ -34,7 +34,7 @@ public class WeatherScheduler {
     )
     public void scheduledUltraShortForecastUpdate() {
         LocalDateTime requestTime = LocalDateTime.now(WEATHER_ZONE);
-        log.info("정기 초단기예보 수집 실행 (시각={})", requestTime);
+        log.info("[weather 스케줄러] 정기 초단기예보 수집 실행 (시각={})", requestTime);
 
         weatherForecastCollector.collectAll(new UltraShort(requestTime))
                 .collectList()
@@ -53,7 +53,7 @@ public class WeatherScheduler {
     )
     public void scheduledShortTermForecastUpdate() {
         LocalDateTime requestTime = LocalDateTime.now(WEATHER_ZONE);
-        log.info("정기 단기예보 수집 실행 (시각={})", requestTime);
+        log.info("[weather 스케줄러] 정기 단기예보 수집 실행 (시각={})", requestTime);
 
         weatherForecastCollector.collectAll(new ShortTerm(requestTime))
                 .collectList()

--- a/src/main/java/org/zerock/puppyrun/weather/scheduler/WeatherStartupInitializer.java
+++ b/src/main/java/org/zerock/puppyrun/weather/scheduler/WeatherStartupInitializer.java
@@ -40,12 +40,12 @@ public class WeatherStartupInitializer {
     @EventListener(ApplicationReadyEvent.class)
     public void initializeShortTermWeatherOnStartup() {
         if (!initializeOnStartup) {
-            log.info("서버 시작 시 날씨 초기 수집이 비활성화되어 있습니다.");
+            log.info("[weather 초기화] 서버 시작 시 날씨 초기 수집이 비활성화되어 있습니다.");
             return;
         }
 
         LocalDateTime requestTime = LocalDateTime.now(WEATHER_ZONE);
-        log.info("서버 가동 시작 1회 초기 수집 실행 (시각={})", requestTime);
+        log.info("[weather 초기화] 서버 가동 시작 1회 초기 수집 실행 (시각={})", requestTime);
 
         WeatherForecast forecast = new ShortTerm(requestTime);
 

--- a/src/main/java/org/zerock/puppyrun/weather/scheduler/WeatherStartupInitializer.java
+++ b/src/main/java/org/zerock/puppyrun/weather/scheduler/WeatherStartupInitializer.java
@@ -46,7 +46,6 @@ public class WeatherStartupInitializer {
 
         LocalDateTime requestTime = LocalDateTime.now(WEATHER_ZONE);
         log.info("[weather 초기화] 서버 가동 시작 1회 초기 수집 실행 (시각={})", requestTime);
-
         WeatherForecast forecast = new ShortTerm(requestTime);
 
         // DB 조회 후 존재 격자 목록 반환

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherApiClient.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherApiClient.java
@@ -45,8 +45,6 @@ public class WeatherApiClient {
                 .build(true)
                 .toUri();
 
-        log.info("기상청 API 요청 URI: {}", uri);
-
         return webClient.get()
                 .uri(uri)
                 .retrieve()

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherCacheProcess.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherCacheProcess.java
@@ -44,7 +44,7 @@ public class WeatherCacheProcess {
         cache.put(gridPoint, weather);
 
         log.info(
-                "성공 날씨 캐시 저장 완료. cache={}, nx={}, ny={}",
+                "[weather 캐시] 성공 날씨 캐시 저장 완료. cache={}, nx={}, ny={}",
                 cacheType.getCacheName(),
                 gridPoint.nx(),
                 gridPoint.ny()
@@ -67,7 +67,7 @@ public class WeatherCacheProcess {
         cache.put(key, result);
 
         log.info(
-                "실패 날씨 캐시 저장 완료. cache={}, type={}, nx={}, ny={}",
+                "[weather 캐시] 실패 날씨 캐시 저장 완료. cache={}, type={}, nx={}, ny={}",
                 CacheType.FAILED_WEATHER.getCacheName(),
                 result.forecast().getType(),
                 result.gridPoint().nx(),
@@ -117,7 +117,7 @@ public class WeatherCacheProcess {
         Cache cache = getRequiredCache(CacheType.FAILED_WEATHER);
 
         cache.clear();
-        log.info("실패 날씨 캐시 초기화 완료");
+        log.info("[weather 캐시] 실패 날씨 캐시 초기화 완료");
     }
 
     private Cache getRequiredCache(CacheType cacheType) {

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherCommandService.java
@@ -35,6 +35,7 @@ public class WeatherCommandService {
         if (commands == null || commands.isEmpty()) {
             return;
         }
+
         List<WeatherForecastEntity> entities = commands.stream()
                 .map(this::toEntity)
                 .toList();
@@ -42,7 +43,8 @@ public class WeatherCommandService {
         weatherForecastRepository.saveAllAndFlush(entities);
 
         log.info(
-                "전체 날씨 DB 저장 완료: 요청={}, 저장={}",
+                "전체 날씨 DB 저장 완료: type={} 요청={}, 저장={}",
+                commands.getFirst().forecastType(),
                 commands.size(),
                 entities.size()
         );

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherForecastCollector.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherForecastCollector.java
@@ -61,8 +61,8 @@ public class WeatherForecastCollector {
         }
 
         log.info(
-                "기상청 날씨 예보 수집 시작: 예보종류={}, 총 {}개 격자 좌표",
-                forecast.getClass().getSimpleName(),
+                "[weather 수집] 기상청 날씨 예보 수집 시작: type={}, 총 {}개 격자 좌표",
+                forecast.getType(),
                 gridPoints.size()
         );
 
@@ -73,8 +73,8 @@ public class WeatherForecastCollector {
                 )
                 .doOnComplete(() ->
                         log.info(
-                                "기상청 날씨 예보 수집 완료: 예보종류={}",
-                                forecast.getClass().getSimpleName()
+                                "[weather 수집] 기상청 날씨 예보 수집 완료: type={}",
+                                forecast.getType()
                         )
                 );
     }
@@ -108,6 +108,10 @@ public class WeatherForecastCollector {
             WeatherForecast forecast,
             GridPoint gridPoint
     ) {
+        log.info("[weather API 요청] type={}, nx={}, ny={}",
+                forecast.getType(), gridPoint.nx(), gridPoint.ny()
+        );
+
         return weatherApiClient.fetchWeather(forecast.getPara(gridPoint))
                 .timeout(API_REQUEST_TIMEOUT)
                 .map(response -> {
@@ -136,7 +140,7 @@ public class WeatherForecastCollector {
             Throwable error
     ) {
         if (error instanceof WeatherApiResponseException apiEx) {
-            log.warn(
+            log.error(
                     "기상청 API 응답 오류: nx={}, ny={}, code={}, message={}",
                     gridPoint.nx(),
                     gridPoint.ny(),
@@ -145,10 +149,10 @@ public class WeatherForecastCollector {
             );
         } else {
             log.error(
-                    "기상청 API 호출 또는 응답 변환 실패: nx={}, ny={}, 예보종류={}, error={}",
+                    "기상청 API 호출 또는 응답 변환 실패: type={}, nx={}, ny={}, reason={}",
+                    forecast.getType(),
                     gridPoint.nx(),
                     gridPoint.ny(),
-                    forecast.getClass().getSimpleName(),
                     Objects.toString(
                             error.getMessage(),
                             error.getClass().getSimpleName()

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherQueryService.java
@@ -138,7 +138,7 @@ public class WeatherQueryService {
 
         // 조회한 시간중 없는 시간대가 있으면 예외 처리
         if (result.stream().anyMatch(Objects::isNull)) {
-            log.warn(
+            log.error(
                     "모든 데이터 출처 조회 후에도 날씨 정보가 누락되었습니다. nx={}, ny={}, start={}, end={}, availableTimes={}",
                     gridPoint.nx(),
                     gridPoint.ny(),

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherQueryService.java
@@ -128,29 +128,31 @@ public class WeatherQueryService {
             );
         }
 
-        // 4. 시간 순서대로 최종 응답 생성
-        List<WeatherDTO.WeatherList> result =
-                createForecastList(
-                        forecasts,
-                        startTime,
-                        limit
-                );
+        List<LocalDateTime> failDateTime = new ArrayList<>();
+
+        for (int hour = 0; hour < limit; hour++) {
+            LocalDateTime requiredTime = startTime.plusHours(hour);
+
+            if (!forecasts.containsKey(requiredTime)) {
+                failDateTime.add(requiredTime);
+            }
+        }
 
         // 조회한 시간중 없는 시간대가 있으면 예외 처리
-        if (result.stream().anyMatch(Objects::isNull)) {
+        if (!failDateTime.isEmpty()) {
             log.error(
-                    "모든 데이터 출처 조회 후에도 날씨 정보가 누락되었습니다. nx={}, ny={}, start={}, end={}, availableTimes={}",
+                    "모든 데이터 출처 조회 후에도 날씨 정보가 누락되었습니다. nx={}, ny={}, start={}, end={}, failDateTime={}",
                     gridPoint.nx(),
                     gridPoint.ny(),
                     startTime,
                     endTime,
-                    forecasts.keySet()
+                    failDateTime
             );
 
             throw new WeatherNotFoundException("요청한 시간대의 날씨 정보가 일부 누락되었습니다.");
         }
-
-        return new WeatherDTO(result);
+        // 4. 시간 순서대로 최종 응답 생성
+        return new WeatherDTO(createForecastList(forecasts, startTime, limit));
     }
 
     public List<WeatherForecastEntity> findAllByBaseDateTimeAndType(LocalDateTime baseDateTime, ForecastType type) {

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherUpdateResultHandler.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherUpdateResultHandler.java
@@ -43,10 +43,10 @@ public class WeatherUpdateResultHandler {
     public void processRetry(WeatherUpdateResult result) {
         if (result == null || !result.success()) {
             if (result == null) {
-                log.error("[API 최종 실패] 재시도 결과가 없습니다.");
+                log.error("[weather API 재시도 큐] 재시도 결과가 없습니다.");
             } else {
                 log.error(
-                        "[API 최종 실패] type={}, nx={}, ny={} | 재발행하지 않고 실패 캐시 기록을 유지합니다.",
+                        "[weather API 재시도 큐] 최종 실패 type={}, nx={}, ny={} | 재발행하지 않고 실패 캐시 기록을 유지합니다.",
                         result.forecast().getType(),
                         result.gridPoint().nx(),
                         result.gridPoint().ny()
@@ -62,7 +62,7 @@ public class WeatherUpdateResultHandler {
         }
 
         log.info(
-                "[API 재시도 성공] type={}, nx={}, ny={} | 후속 저장 완료",
+                "[weather API 재시도 큐] 재시도 성공 type={}, nx={}, ny={} | 후속 저장 완료",
                 result.forecast().getType(),
                 result.gridPoint().nx(),
                 result.gridPoint().ny()
@@ -78,7 +78,8 @@ public class WeatherUpdateResultHandler {
                 .toList();
 
         log.info(
-                "[1차 수집 분류 완료] 총 {}건 (성공 {}건, API 실패 {}건)",
+                "[weather 1차 수집 분류 완료] type={}, 총 {}건 (성공 {}건, API 실패 {}건)",
+                results.getFirst().forecast().getType(),
                 results.size(),
                 successes.size(),
                 failures.size()
@@ -119,7 +120,7 @@ public class WeatherUpdateResultHandler {
             weatherCommandService.save(commands);
         } catch (Exception saveException) {
             log.warn(
-                    "[DB 저장 실패] 총 {}건 저장 실패: {} | 10초 지연 큐 발송",
+                    "[weather DB 재시도 큐] 저장 실패 총 {}건 저장 실패: {} | 10초 지연 큐 발송",
                     commands.size(),
                     saveException.getMessage(),
                     saveException
@@ -129,7 +130,7 @@ public class WeatherUpdateResultHandler {
                 dbRetryPublisher.publish(commands);
             } catch (Exception publishException) {
                 log.error(
-                        "[DB 재시도 발행 실패] 총 {}건을 지연 큐에 발행하지 못했습니다: {}",
+                        "[weather DB 재시도 큐] 재시도 발행 실패 총 {}건을 지연 큐에 발행하지 못했습니다: {}",
                         commands.size(),
                         publishException.getMessage(),
                         publishException
@@ -147,7 +148,7 @@ public class WeatherUpdateResultHandler {
             apiRetryPublisher.publish(failures);
         } catch (Exception exception) {
             log.error(
-                    "[API 재시도 발행 실패] 총 {}건을 지연 큐에 발행하지 못했습니다: {}",
+                    "[weather API 재시도 큐] 재시도 발행 실패 총 {}건을 지연 큐에 발행하지 못했습니다: {}",
                     failures.size(),
                     exception.getMessage(),
                     exception

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,7 +7,7 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <!-- 가독성을 위해 색상 패턴 적용 -->
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %magenta([%thread]) %cyan(%logger{36}) - %msg%n
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %magenta([%thread]) %cyan(%logger{36}) [traceId=%X{traceId:-}] - %msg%n
             </pattern>
         </encoder>
     </appender>
@@ -24,7 +24,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [traceId=%X{traceId:-}] - %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -39,6 +39,7 @@
                     > **Time:** `%d{yyyy-MM-dd HH:mm:ss}`
                     > **Logger:** `%logger{36}`
                     > **Level:** `%-5level`
+                    > **Trace ID:** `%X{traceId:-}`
 
                     **📌 Error Message:**
                     ```text
@@ -64,6 +65,16 @@
     </springProfile>
 
     <springProfile name="prod">
+        <logger name="org.zerock.puppyrun.common.exception.GlobalExceptionHandler" level="WARN" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+            <appender-ref ref="ASYNC_DISCORD"/>
+        </logger>
+        <logger name="org.zerock.puppyrun.common.logging.ExecutionTimeAspect" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </logger>
+
         <root level="ERROR">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>


### PR DESCRIPTION
# 📌 Pull Request: 로그 관측성 및 날씨 누락 진단 개선

# 📝 작업 요약 (Summary)

- 운영 로그에서 예상 가능한 비즈니스 예외와 예상 밖 오류를 구분하고, 사용자 문의 시 요청 흐름을 찾을 수 있도록 `traceId`를 도입했습니다.
- 서비스 로직에 측정 코드를 넣지 않고, 선택한 메서드에 재사용 가능한 AOP 실행 시간 로그를 적용했습니다.
- 날씨 예보 조회 실패 시 실제로 누락된 시간대만 로그로 확인할 수 있도록 개선했습니다.

# 🛠️ 변경 사항 (Changes)

## 1. 예외 및 요청 추적 로그

- **GlobalExceptionHandler 개선**
    - `BusinessException`을 스택트레이스 없이 단일 `WARN`으로 기록합니다.
    - 로그에 예외 클래스, 에러 코드, HTTP 상태, 요청 URI, 메시지를 포함합니다.
    - 입력 검증 실패(`@Valid`, 파라미터 형식 오류, 잘못된 JSON)는 별도 로그를 남기지 않습니다.
- **TraceIdFilter 추가**
    - HTTP 요청마다 UUID 기반 `traceId`를 생성합니다.
    - 응답 헤더 `X-Trace-Id`로 반환하고, 요청 처리 중 MDC에 보관합니다.
    - 기존 콘솔·파일·Discord 오류 로그에 `traceId`를 표시합니다.

## 2. 실행 시간 관측 AOP

- `spring-boot-starter-aop` 의존성을 추가했습니다.
- `@LogExecutionTime` 어노테이션과 `ExecutionTimeAspect`를 추가했습니다.
    - 어노테이션이 붙은 동기 메서드가 정상 종료되면 클래스·메서드·소요 시간을 `INFO`로 기록합니다.
    - 예외 발생 시 별도 성공 로그를 남기지 않아 기존 예외 로그와 중복되지 않습니다.
- 산책 선호도 분석 메서드에 적용했습니다.

## 3. 날씨 예보 누락 시간 로그

- 최종 응답을 만들기 전에 요청 범위의 누락 시간대를 계산합니다.
- 누락 시 `failDateTime`에 누락된 시간만 기록하고 `WeatherNotFoundException`을 발생시킵니다.
- 누락이 없을 때만 시간 순서의 최종 예보 응답을 생성합니다.
