### PR TITLE
feat: 게이미피케이션 레벨 조회 기능 추가

### DIFF
--- a/src/main/java/org/zerock/puppyrun/gamification/DTO/LevelInfo.java
+++ b/src/main/java/org/zerock/puppyrun/gamification/DTO/LevelInfo.java
@@ -1,0 +1,43 @@
+package org.zerock.puppyrun.gamification.DTO;
+
+import lombok.Builder;
+import org.zerock.puppyrun.gamification.util.GamificationLevelPolicy;
+
+@Builder
+public record LevelInfo(
+        int level,
+        int experience,
+        int currentLevelExperience,
+        int nextLevelExperience,
+        int remainingExperience,
+        Double progressPercent
+) {
+    public static LevelInfo of(int totalDistance, int totalDuration) {
+        int experience = GamificationLevelPolicy.calculateExperience(totalDistance, totalDuration);
+        int level = GamificationLevelPolicy.calculateLevel(experience);
+        int currentLevelExperience = GamificationLevelPolicy.requiredExperienceForLevel(level);
+        int nextLevelExperience = GamificationLevelPolicy.requiredExperienceForLevel(level + 1);
+        int remainingExperience = Math.max(nextLevelExperience - experience, 0);
+        double progressPercent = calculateProgressPercent(experience, currentLevelExperience, nextLevelExperience);
+
+        return LevelInfo.builder()
+                .level(level)
+                .experience(experience)
+                .currentLevelExperience(currentLevelExperience)
+                .nextLevelExperience(nextLevelExperience)
+                .remainingExperience(remainingExperience)
+                .progressPercent(progressPercent)
+                .build();
+    }
+
+    private static double calculateProgressPercent(int experience, int currentLevelExperience, int nextLevelExperience) {
+        int requiredExperience = nextLevelExperience - currentLevelExperience;
+
+        if (requiredExperience <= 0) {
+            return 100.0;
+        }
+
+        double progress = (experience - currentLevelExperience) * 100.0 / requiredExperience;
+        return Math.round(progress * 10) / 10.0;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/gamification/controller/GamificationController.java
+++ b/src/main/java/org/zerock/puppyrun/gamification/controller/GamificationController.java
@@ -1,0 +1,26 @@
+package org.zerock.puppyrun.gamification.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.gamification.controller.response.GamificationResponse;
+import org.zerock.puppyrun.gamification.service.GamificationQueryService;
+
+@RestController
+@RequestMapping("/api/gamification")
+@RequiredArgsConstructor
+public class GamificationController {
+    private final GamificationQueryService gamificationQueryService;
+
+    @GetMapping
+    public ResponseEntity<GamificationResponse> getGamification(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        GamificationResponse response = gamificationQueryService.getGamification(userPrincipal);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/gamification/controller/response/GamificationResponse.java
+++ b/src/main/java/org/zerock/puppyrun/gamification/controller/response/GamificationResponse.java
@@ -1,0 +1,74 @@
+package org.zerock.puppyrun.gamification.controller.response;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.zerock.puppyrun.gamification.DTO.LevelInfo;
+import org.zerock.puppyrun.pet.entity.PetBadge;
+import org.zerock.puppyrun.tracking.DTO.TotalMemberTracking;
+import org.zerock.puppyrun.tracking.DTO.TotalPetStat;
+
+@Builder
+public record GamificationResponse(
+        MemberLevel memberLevel,
+        List<PetLevel> petLevels
+) {
+    public static GamificationResponse of(TotalMemberTracking memberStat, List<TotalPetStat> petStats) {
+        List<PetLevel> petLevels = petStats.stream()
+                .map(PetLevel::from)
+                .toList();
+
+        return GamificationResponse.builder()
+                .memberLevel(MemberLevel.from(memberStat))
+                .petLevels(petLevels)
+                .build();
+    }
+
+    @Builder
+    public record MemberLevel(
+            UUID memberId,
+            Integer totalDistance,
+            Integer totalDuration,
+            Long totalCount,
+            LevelInfo levelInfo
+    ) {
+        public static MemberLevel from(TotalMemberTracking stat) {
+            return MemberLevel.builder()
+                    .memberId(stat.memberId())
+                    .totalDistance(stat.totalDistance())
+                    .totalDuration(stat.totalDuration())
+                    .totalCount(stat.totalCount())
+                    .levelInfo(LevelInfo.of(stat.totalDistance(), stat.totalDuration()))
+                    .build();
+        }
+    }
+
+    @Builder
+    public record PetLevel(
+            UUID petId,
+            String name,
+            String profileImageUrl,
+            String themeColor,
+            Integer totalDistance,
+            Integer totalDuration,
+            Long totalCount,
+            String badgeCode,
+            LevelInfo levelInfo
+    ) {
+        public static PetLevel from(TotalPetStat stat) {
+            PetBadge badge = PetBadge.getBadgeByDistance(stat.totalDistance());
+
+            return PetLevel.builder()
+                    .petId(stat.petId())
+                    .name(stat.name())
+                    .profileImageUrl(stat.profileImageUrl())
+                    .themeColor(stat.themeColor())
+                    .totalDistance(stat.totalDistance())
+                    .totalDuration(stat.totalDuration())
+                    .totalCount(stat.totalCount())
+                    .badgeCode(badge.getCode())
+                    .levelInfo(LevelInfo.of(stat.totalDistance(), stat.totalDuration()))
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/gamification/service/GamificationQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/gamification/service/GamificationQueryService.java
@@ -1,0 +1,31 @@
+package org.zerock.puppyrun.gamification.service;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.common.auth.security.UserPrincipal;
+import org.zerock.puppyrun.gamification.controller.response.GamificationResponse;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+import org.zerock.puppyrun.statistics.service.PetStatistics;
+import org.zerock.puppyrun.tracking.DTO.TotalMemberTracking;
+import org.zerock.puppyrun.tracking.DTO.TotalPetStat;
+import org.zerock.puppyrun.tracking.repository.TrackingRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GamificationQueryService {
+    private final TrackingRepository trackingRepository;
+    private final PetRepository petRepository;
+    private final PetStatistics petStatistics;
+
+    public GamificationResponse getGamification(UserPrincipal principal) {
+        TotalMemberTracking memberStat = trackingRepository.getTotalTrackingSummaryByMemberId(principal.id());
+        List<UUID> petIds = petRepository.findPetIdsByMemberId(principal.id());
+        List<TotalPetStat> petStats = petStatistics.getTotalPetTrackingSummary(petIds);
+
+        return GamificationResponse.of(memberStat, petStats);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/gamification/util/GamificationLevelPolicy.java
+++ b/src/main/java/org/zerock/puppyrun/gamification/util/GamificationLevelPolicy.java
@@ -1,0 +1,41 @@
+package org.zerock.puppyrun.gamification.util;
+
+public final class GamificationLevelPolicy {
+    private static final int BASE_REQUIRED_EXPERIENCE = 10_000;
+    private static final int DURATION_EXPERIENCE_PER_MINUTE = 10;
+    private static final int SECONDS_TO_MINUTES = 60;
+
+    private GamificationLevelPolicy() {
+    }
+
+    public static int calculateExperience(int totalDistance, int totalDuration) {
+        long distanceExperience = Math.max(totalDistance, 0);
+        long durationExperience = (Math.max(totalDuration, 0) / (long) SECONDS_TO_MINUTES)
+                * DURATION_EXPERIENCE_PER_MINUTE;
+        long experience = distanceExperience + durationExperience;
+
+        return experience > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) experience;
+    }
+
+    public static int calculateLevel(int experience) {
+        int safeExperience = Math.max(experience, 0);
+        int level = 1;
+
+        int nextRequiredExperience = requiredExperienceForLevel(level + 1);
+        while (nextRequiredExperience < Integer.MAX_VALUE && safeExperience >= nextRequiredExperience) {
+            level++;
+            nextRequiredExperience = requiredExperienceForLevel(level + 1);
+        }
+
+        return level;
+    }
+
+    public static int requiredExperienceForLevel(int level) {
+        if (level <= 1) {
+            return 0;
+        }
+
+        long requiredExperience = (long) BASE_REQUIRED_EXPERIENCE * (level - 1) * level / 2;
+        return requiredExperience > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) requiredExperience;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetDetailResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetDetailResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.UUID;
 import lombok.Builder;
 import org.zerock.puppyrun.common.s3.support.S3Url;
+import org.zerock.puppyrun.gamification.DTO.LevelInfo;
 import org.zerock.puppyrun.pet.entity.Pet;
 import org.zerock.puppyrun.pet.entity.PetBadge;
 
@@ -23,6 +24,7 @@ public record PetDetailResponse(
         String profileImageUrl,
         Boolean isNeutered,
         String gender,
+        LevelInfo levelInfo,
         BadgeInfo badgeInfo,
         String mbti
 ) {
@@ -31,6 +33,14 @@ public record PetDetailResponse(
      * Pet 엔티티를 PetDetailResponse DTO로 변환하는 정적 팩토리 메서드
      */
     public static PetDetailResponse of(Pet pet) {
+        return of(pet, pet.getWalkedDistance(), 0);
+    }
+
+    public static PetDetailResponse of(Pet pet, int walkedDistance) {
+        return of(pet, walkedDistance, 0);
+    }
+
+    public static PetDetailResponse of(Pet pet, int walkedDistance, int walkedDuration) {
         return PetDetailResponse.builder()
                 .PetId(pet.getId())
                 .name(pet.getName())
@@ -41,7 +51,8 @@ public record PetDetailResponse(
                 .breedCode(pet.getBreed().getCode())
                 .isNeutered(pet.getIsNeutered())
                 .gender(pet.getGender())
-                .badgeInfo(BadgeInfo.from(pet.getWalkedDistance()))
+                .levelInfo(LevelInfo.of(walkedDistance, walkedDuration))
+                .badgeInfo(BadgeInfo.from(walkedDistance))
                 .mbti(pet.getMbti())
                 .build();
     }

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetListResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetListResponse.java
@@ -3,10 +3,12 @@ package org.zerock.puppyrun.pet.controller.response;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.Builder;
 import org.zerock.puppyrun.common.s3.support.S3Url;
 import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.entity.PetBadge;
 
 public record PetListResponse(
         int totalPetCount,
@@ -15,8 +17,12 @@ public record PetListResponse(
 ) {
 
     public static PetListResponse of(List<Pet> pets) {
+        return of(pets, Map.of());
+    }
+
+    public static PetListResponse of(List<Pet> pets, Map<UUID, Integer> walkedDistances) {
         List<PetSummary> summaryList = pets.stream()
-                .map(PetSummary::from)
+                .map(pet -> PetSummary.from(pet, walkedDistances.getOrDefault(pet.getId(), pet.getWalkedDistance())))
                 .toList();
 
         return new PetListResponse(summaryList.size(), summaryList);
@@ -33,11 +39,18 @@ public record PetListResponse(
             @S3Url
             String profileImageUrl,
             String breedCode,
+            String badgeCode,
             String gender,
             String mbti,
             boolean isNeutered
     ) {
         public static PetSummary from(Pet pet) {
+            return from(pet, pet.getWalkedDistance());
+        }
+
+        public static PetSummary from(Pet pet, int walkedDistance) {
+            PetBadge badge = PetBadge.getBadgeByDistance(walkedDistance);
+
             return PetSummary.builder()
                     .PetId(pet.getId())
                     .name(pet.getName())
@@ -46,6 +59,7 @@ public record PetListResponse(
                     .color(pet.getColor())
                     .profileImageUrl(pet.getProfileImageUrl())
                     .breedCode(pet.getBreed().getCode())
+                    .badgeCode(badge.getCode())
                     .gender(pet.getGender())
                     .mbti(pet.getMbti())
                     .isNeutered(pet.getIsNeutered())

--- a/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
+++ b/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
@@ -99,6 +99,10 @@ public class Pet extends BaseEntity {
         this.weight = weight;
     }
 
+    public void refreshWalkedDistance(int walkedDistance) {
+        this.walkedDistance = walkedDistance;
+    }
+
     public void setDefaultProfile() {
         this.profileImageUrl = null;
     }

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetQueryService.java
@@ -19,6 +19,7 @@ import org.zerock.puppyrun.pet.entity.Pet;
 import org.zerock.puppyrun.pet.entity.PetWeightLog;
 import org.zerock.puppyrun.pet.repository.PetRepository;
 import org.zerock.puppyrun.statistics.service.PetStatistics;
+import org.zerock.puppyrun.tracking.DTO.TotalPetStat;
 
 @Service
 @Slf4j
@@ -37,7 +38,9 @@ public class PetQueryService {
      */
     public PetDetailResponse getPet(UserPrincipal userPrincipal, UUID petId) {
         Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
-        return PetDetailResponse.of(pet);
+        int walkedDistance = petStatistics.getTotalWalkedDistance(pet);
+        int walkedDuration = petStatistics.getTotalWalkedDuration(pet);
+        return PetDetailResponse.of(pet, walkedDistance, walkedDuration);
     }
 
     /**
@@ -48,7 +51,13 @@ public class PetQueryService {
      */
     public PetListResponse getPetList(UserPrincipal userPrincipal) {
         List<Pet> petList = petRepository.findAllByMemberId(userPrincipal.id());
-        return PetListResponse.of(petList);
+        List<UUID> petIds = petList.stream()
+                .map(Pet::getId)
+                .toList();
+        Map<UUID, Integer> walkedDistances = petStatistics.getTotalPetTrackingSummary(petIds).stream()
+                .collect(Collectors.toMap(TotalPetStat::petId, TotalPetStat::totalDistance));
+
+        return PetListResponse.of(petList, walkedDistances);
     }
 
     /**

--- a/src/main/java/org/zerock/puppyrun/statistics/service/PetStatistics.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/service/PetStatistics.java
@@ -12,6 +12,7 @@ import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.pet.entity.Pet;
 import org.zerock.puppyrun.pet.entity.PetWeightLog;
 import org.zerock.puppyrun.pet.repository.PetWeightLogRepository;
+import org.zerock.puppyrun.tracking.DTO.TotalPetStat;
 import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
 import org.zerock.puppyrun.tracking.repository.PetTrackingRepository;
 
@@ -110,5 +111,15 @@ public class PetStatistics {
         return petTrackingRepository.getTrackingSummaryByPetId(petId, startDate, targetDay);
     }
 
+    /**
+     * 펫들의 전체 산책 누적 통계를 조회합니다.
+     */
+    public List<TotalPetStat> getTotalPetTrackingSummary(List<UUID> petIds) {
+        if (petIds.isEmpty()) {
+            return List.of();
+        }
+
+        return petTrackingRepository.getTotalTrackingSummaryByPetIds(petIds);
+    }
 
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/DTO/TotalMemberTracking.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/DTO/TotalMemberTracking.java
@@ -1,0 +1,13 @@
+package org.zerock.puppyrun.tracking.DTO;
+
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record TotalMemberTracking(
+        UUID memberId,
+        Integer totalDistance,
+        Integer totalDuration,
+        Long totalCount
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/tracking/DTO/TotalPetStat.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/DTO/TotalPetStat.java
@@ -1,0 +1,16 @@
+package org.zerock.puppyrun.tracking.DTO;
+
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record TotalPetStat(
+        UUID petId,
+        String name,
+        String profileImageUrl,
+        String themeColor,
+        Integer totalDistance,
+        Integer totalDuration,
+        Long totalCount
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustom.java
@@ -3,6 +3,7 @@ package org.zerock.puppyrun.tracking.repository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
+import org.zerock.puppyrun.tracking.DTO.TotalPetStat;
 import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
 
 public interface PetTrackingRepoCustom {
@@ -12,9 +13,10 @@ public interface PetTrackingRepoCustom {
 
     List<TotalPetTracking> getTrackingSummaryByPetId(List<UUID> petId, LocalDate startDate, LocalDate endDate);
 
+    List<TotalPetStat> getTotalTrackingSummaryByPetIds(List<UUID> petIds);
+
     int countTogetherTracking(UUID memberId, LocalDate startDate, LocalDate endDate);
 
 //    TotalPetTracking getTrackingSummaryByPetId(UUID id, LocalDate startDate, LocalDate targetDay);
 
 }
-

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustomImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.tracking.DTO.TotalPetStat;
 import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
 
 import static org.zerock.puppyrun.pet.entity.QPet.pet;
@@ -71,6 +72,26 @@ public class PetTrackingRepoCustomImpl implements PetTrackingRepoCustom {
                 )
                 .where(pet.id.in(petId))
                 .groupBy(pet.id, pet.name, pet.profileImageUrl, pet.color, pet.walkedDistance)
+                .fetch();
+    }
+
+    @Override
+    public List<TotalPetStat> getTotalTrackingSummaryByPetIds(List<UUID> petIds) {
+        return queryFactory
+                .select(Projections.constructor(TotalPetStat.class,
+                        pet.id,
+                        pet.name,
+                        pet.profileImageUrl,
+                        pet.color,
+                        tracking.distance.sum().coalesce(0),
+                        tracking.duration.sum().coalesce(0),
+                        tracking.count()
+                ))
+                .from(pet)
+                .leftJoin(petTracking).on(petTracking.pet.eq(pet))
+                .leftJoin(petTracking.tracking, tracking)
+                .where(pet.id.in(petIds))
+                .groupBy(pet.id, pet.name, pet.profileImageUrl, pet.color)
                 .fetch();
     }
 

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
@@ -13,6 +13,7 @@ import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
 import org.zerock.puppyrun.tracking.DTO.MainTrackingSummary;
 import org.zerock.puppyrun.tracking.DTO.TrackingDetailSummary;
 import org.zerock.puppyrun.tracking.entity.Tracking;
+import org.zerock.puppyrun.tracking.DTO.TotalMemberTracking;
 
 public interface TrackingRepoCustom {
 
@@ -79,4 +80,6 @@ public interface TrackingRepoCustom {
      * @return 기간 내 산책 기록이 있는 회원별 집계 목록
      */
     List<DailyMemberStat> findMemberIdsByDate(List<UUID> memberIds, LocalDate startDate, LocalDate endDate);
+
+    TotalMemberTracking getTotalTrackingSummaryByMemberId(UUID memberId);
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
@@ -21,6 +21,7 @@ import org.zerock.puppyrun.tracking.DTO.DailyTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyTrackingSummary;
 import org.zerock.puppyrun.tracking.DTO.MainTrackingSummary;
 import org.zerock.puppyrun.tracking.DTO.TrackingDetailSummary;
+import org.zerock.puppyrun.tracking.DTO.TotalMemberTracking;
 import org.zerock.puppyrun.tracking.entity.RoutePoint;
 import org.zerock.puppyrun.tracking.entity.Tracking;
 import org.zerock.puppyrun.tracking.entity.TrackingRoute;
@@ -366,6 +367,26 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
                 )
                 .groupBy(tracking.member.id)
                 .fetch();
+    }
+
+    @Override
+    public TotalMemberTracking getTotalTrackingSummaryByMemberId(UUID memberId) {
+        var distanceSumPath = tracking.distance.sum().coalesce(0);
+        var durationSumPath = tracking.duration.sum().coalesce(0);
+        var trackingCountPath = tracking.id.count();
+
+        Tuple result = queryFactory
+                .select(distanceSumPath, durationSumPath, trackingCountPath)
+                .from(tracking)
+                .where(tracking.member.id.eq(memberId))
+                .fetchOne();
+
+        return TotalMemberTracking.builder()
+                .memberId(memberId)
+                .totalDistance(result != null ? result.get(distanceSumPath) : 0)
+                .totalDuration(result != null ? result.get(durationSumPath) : 0)
+                .totalCount(result != null ? result.get(trackingCountPath) : 0L)
+                .build();
     }
 
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/service/TrackingCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/service/TrackingCommandService.java
@@ -133,6 +133,7 @@ public class TrackingCommandService {
      */
     public void deleteTracking(UUID memberId, UUID trackingId) {
         Tracking tracking = trackingRepository.findByIdAndVerifyOwnership(trackingId, memberId);
+        List<Pet> petList = petTrackingRepository.findAllPetsByTrackingId(trackingId);
 
         // 연관된 일기가 있다면 tracking_id를 null로 변경
         diaryRepository.findByTrackingId(trackingId)
@@ -144,6 +145,8 @@ public class TrackingCommandService {
         trackingRouteRepository.deleteById(trackingId);
 
         trackingRepository.delete(tracking);
+        trackingRepository.flush();
+        refreshPetWalkedDistances(petList);
 
         if (!images.isEmpty()) {
             s3Service.deleteAll(images);
@@ -176,6 +179,14 @@ public class TrackingCommandService {
                 .toList();
 
         petTrackingRepository.saveAll(petTrackingList);
+        refreshPetWalkedDistances(petList);
 
+    }
+
+    private void refreshPetWalkedDistances(List<Pet> petList) {
+        petList.forEach(pet -> {
+            int walkedDistance = petTrackingRepository.sumTotalDistanceByPetId(pet.getId());
+            pet.refreshWalkedDistance(walkedDistance);
+        });
     }
 }

--- a/src/test/java/org/zerock/puppyrun/gamification/util/GamificationLevelPolicyTest.java
+++ b/src/test/java/org/zerock/puppyrun/gamification/util/GamificationLevelPolicyTest.java
@@ -1,0 +1,41 @@
+package org.zerock.puppyrun.gamification.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.zerock.puppyrun.gamification.DTO.LevelInfo;
+
+class GamificationLevelPolicyTest {
+
+    @Test
+    @DisplayName("레벨은 누적 경험치 구간에 따라 계산된다")
+    void calculateLevel() {
+        assertThat(GamificationLevelPolicy.calculateLevel(0)).isEqualTo(1);
+        assertThat(GamificationLevelPolicy.calculateLevel(9_999)).isEqualTo(1);
+        assertThat(GamificationLevelPolicy.calculateLevel(10_000)).isEqualTo(2);
+        assertThat(GamificationLevelPolicy.calculateLevel(29_999)).isEqualTo(2);
+        assertThat(GamificationLevelPolicy.calculateLevel(30_000)).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("경험치는 누적 거리와 산책 시간을 함께 반영한다")
+    void calculateExperience() {
+        int experience = GamificationLevelPolicy.calculateExperience(15_000, 3_000);
+
+        assertThat(experience).isEqualTo(15_500);
+    }
+
+    @Test
+    @DisplayName("레벨 정보는 다음 레벨까지 남은 경험치와 진행률을 제공한다")
+    void createLevelInfo() {
+        LevelInfo levelInfo = LevelInfo.of(15_000, 3_000);
+
+        assertThat(levelInfo.level()).isEqualTo(2);
+        assertThat(levelInfo.experience()).isEqualTo(15_500);
+        assertThat(levelInfo.currentLevelExperience()).isEqualTo(10_000);
+        assertThat(levelInfo.nextLevelExperience()).isEqualTo(30_000);
+        assertThat(levelInfo.remainingExperience()).isEqualTo(14_500);
+        assertThat(levelInfo.progressPercent()).isEqualTo(27.5);
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request: 게이미피케이션 레벨 조회 기능 추가

# 📝 작업 요약 (Summary)

- 회원과 반려견의 누적 산책 거리 및 시간을 기반으로 레벨 정보를 제공하는 게이미피케이션 기능을 추가했습니다.
- 기존 펫 진행도 구조를 유지하면서, 거리 기반 뱃지와 레벨 정보를 함께 조회할 수 있도록 연동했습니다.

# 🛠️ 변경 사항 (Changes)

## 1. 게이미피케이션 조회 API

- `GET /api/gamification` API 추가
- 회원 전체 산책 통계와 반려견별 산책 통계를 통합 조회
- 회원 및 반려견별 레벨, 경험치, 다음 레벨까지의 진행 정보를 응답

## 2. 레벨 및 경험치 정책

- 누적 거리와 산책 시간을 경험치로 환산하는 정책 추가
- 경험치 구간에 따른 레벨 계산 로직 추가
- 현재 레벨 경험치, 다음 레벨 경험치, 남은 경험치, 진행률 제공

## 3. 펫 진행도 연동

- 펫 상세 응답에 `level_info` 추가
- 펫 상세/목록 응답에서 누적 산책 거리 기반 뱃지 정보 제공
- 산책 등록 및 삭제 시 반려견 누적 산책 거리 갱신

# 📸 테스트 시나리오 (Test Scenarios)

## 1. 게이미피케이션 레벨 정책

- 누적 경험치 구간에 따른 레벨 계산 검증
- 누적 거리와 산책 시간을 반영한 경험치 계산 검증
- 다음 레벨까지 남은 경험치 및 진행률 계산 검증

```bash
./gradlew compileJava
./gradlew test --tests org.zerock.puppyrun.gamification.util.GamificationLevelPolicyTest
```

## 2. 게이미피케이션 조회 API

* **Method**: `GET`
* **URL**: `/api/gamification`
* **Header**: `Authorization: Bearer {accessToken}`

**Response (200 OK) 구조 예시**

```json
{
  "member_level": {
    "member_id": "회원 UUID",
    "total_distance": 15000,
    "total_duration": 3000,
    "total_count": 12,
    "level_info": {
      "level": 2,
      "experience": 15500,
      "current_level_experience": 10000,
      "next_level_experience": 30000,
      "remaining_experience": 14500,
      "progress_percent": 27.5
    }
  },
  "pet_levels": []
}
```

> 게이미피케이션 조회 API의 통합 테스트는 아직 추가하지 않았고, 현재 컴파일 및 레벨 정책 단위 테스트를 검증했습니다.