### PR TITLE
refactor: 알러지 severity 미지정 값을 NONE으로 처리

### DIFF
--- a/src/main/java/org/zerock/puppyrun/care/controller/response/AllergyListResponse.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/response/AllergyListResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import org.zerock.puppyrun.care.entity.AllergyRecord;
+import org.zerock.puppyrun.care.entity.AllergySeverity;
 import org.zerock.puppyrun.pet.entity.Pet;
 
 @Builder
@@ -42,7 +43,9 @@ public record AllergyListResponse(
                     .allergyId(allergyRecord.getId())
                     .allergenName(allergyRecord.getAllergenName())
                     .symptom(allergyRecord.getSymptom())
-                    .severity(allergyRecord.getSeverity() != null ? allergyRecord.getSeverity().name() : null)
+                    .severity(allergyRecord.getSeverity() != null
+                            ? allergyRecord.getSeverity().name()
+                            : AllergySeverity.NONE.name())
                     .identifiedAt(allergyRecord.getIdentifiedAt())
                     .isActive(allergyRecord.getIsActive())
                     .memo(allergyRecord.getMemo())

--- a/src/main/java/org/zerock/puppyrun/care/controller/response/AllergyRecordResponse.java
+++ b/src/main/java/org/zerock/puppyrun/care/controller/response/AllergyRecordResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.UUID;
 import lombok.Builder;
 import org.zerock.puppyrun.care.entity.AllergyRecord;
+import org.zerock.puppyrun.care.entity.AllergySeverity;
 
 @Builder
 public record AllergyRecordResponse(
@@ -23,7 +24,9 @@ public record AllergyRecordResponse(
                 .petId(allergyRecord.getPet().getId())
                 .allergenName(allergyRecord.getAllergenName())
                 .symptom(allergyRecord.getSymptom())
-                .severity(allergyRecord.getSeverity() != null ? allergyRecord.getSeverity().name() : null)
+                .severity(allergyRecord.getSeverity() != null
+                        ? allergyRecord.getSeverity().name()
+                        : AllergySeverity.NONE.name())
                 .identifiedAt(allergyRecord.getIdentifiedAt())
                 .isActive(allergyRecord.getIsActive())
                 .memo(allergyRecord.getMemo())

--- a/src/main/java/org/zerock/puppyrun/care/entity/AllergySeverity.java
+++ b/src/main/java/org/zerock/puppyrun/care/entity/AllergySeverity.java
@@ -3,11 +3,16 @@ package org.zerock.puppyrun.care.entity;
 import org.zerock.puppyrun.common.exception.InvalidValueException;
 
 public enum AllergySeverity {
+    NONE,
     MILD,
     MODERATE,
     SEVERE;
 
     public static AllergySeverity from(String severity) {
+        if (severity == null || severity.isBlank()) {
+            return NONE;
+        }
+
         try {
             return AllergySeverity.valueOf(severity);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/zerock/puppyrun/care/service/AllergyCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/care/service/AllergyCommandService.java
@@ -75,9 +75,6 @@ public class AllergyCommandService {
     }
 
     private AllergySeverity toSeverity(String severity) {
-        if (severity == null) {
-            return null;
-        }
         return AllergySeverity.from(severity);
     }
 }

--- a/src/test/java/org/zerock/puppyrun/care/service/CareServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/care/service/CareServiceTest.java
@@ -23,6 +23,7 @@ import org.zerock.puppyrun.care.controller.response.MedicationRecordResponse;
 import org.zerock.puppyrun.care.controller.response.VaccinationListResponse;
 import org.zerock.puppyrun.care.controller.response.VaccinationRecordResponse;
 import org.zerock.puppyrun.care.entity.CareEventType;
+import org.zerock.puppyrun.care.entity.AllergySeverity;
 import org.zerock.puppyrun.care.repository.AllergyRecordRepository;
 import org.zerock.puppyrun.care.repository.MedicationRecordRepository;
 import org.zerock.puppyrun.care.repository.VaccinationRecordRepository;
@@ -135,6 +136,94 @@ class CareServiceTest extends TestContainerConfig {
         assertThat(updated.allergenName()).isEqualTo("소고기");
         assertThat(updated.severity()).isEqualTo("MILD");
         assertThat(updated.isActive()).isFalse();
+        assertThat(allergyRecordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("알러지 심각도 미입력 시 NONE으로 저장하고 조회한다")
+    void registerAllergyWithoutSeverityStoresNone() {
+        // given
+        OwnerPetData fixture = new MemberPetTestData(
+                memberRegistrationService,
+                petCommandService
+        ).create(
+                MemberFixture.CARE_OWNER,
+                PetFixture.MALTESE,
+                3.5
+        );
+
+        // when
+        AllergyRecordResponse registered = allergyCommandService.registerAllergy(
+                fixture.ownerPrincipal(),
+                fixture.petId(),
+                new RegisterAllergyRequest("닭고기", null, null, null, true, null)
+        );
+        AllergyListResponse found = allergyQueryService.getAllergyList(
+                fixture.ownerPrincipal(),
+                fixture.petId()
+        );
+
+        // then
+        assertThat(registered.severity()).isEqualTo("NONE");
+        assertThat(found.allergyList().getFirst().severity()).isEqualTo("NONE");
+        assertThat(allergyRecordRepository.findById(registered.allergyId()).orElseThrow().getSeverity())
+                .isEqualTo(AllergySeverity.NONE);
+    }
+
+    @Test
+    @DisplayName("알러지 심각도는 수정 시 미입력하면 NONE으로 변경한다")
+    void updateAllergyWithoutSeverityStoresNone() {
+        // given
+        OwnerPetData fixture = new MemberPetTestData(
+                memberRegistrationService,
+                petCommandService
+        ).create(
+                MemberFixture.CARE_OWNER,
+                PetFixture.MALTESE,
+                3.5
+        );
+        AllergyRecordResponse registered = allergyCommandService.registerAllergy(
+                fixture.ownerPrincipal(),
+                fixture.petId(),
+                new RegisterAllergyRequest("닭고기", null, "SEVERE", null, true, null)
+        );
+
+        // when
+        AllergyRecordResponse updated = allergyCommandService.updateAllergy(
+                fixture.ownerPrincipal(),
+                fixture.petId(),
+                registered.allergyId(),
+                new UpdateAllergyRequest("닭고기", null, " ", null, true, null)
+        );
+
+        // then
+        assertThat(updated.severity()).isEqualTo("NONE");
+        assertThat(allergyRecordRepository.findById(registered.allergyId()).orElseThrow().getSeverity())
+                .isEqualTo(AllergySeverity.NONE);
+    }
+
+    @Test
+    @DisplayName("알러지 심각도는 정의되지 않은 값이면 예외를 발생시킨다")
+    void registerAllergyWithInvalidSeverityThrowsException() {
+        // given
+        OwnerPetData fixture = new MemberPetTestData(
+                memberRegistrationService,
+                petCommandService
+        ).create(
+                MemberFixture.CARE_OWNER,
+                PetFixture.MALTESE,
+                3.5
+        );
+
+        // when
+        Throwable thrown = catchThrowable(() -> allergyCommandService.registerAllergy(
+                fixture.ownerPrincipal(),
+                fixture.petId(),
+                new RegisterAllergyRequest("닭고기", null, "UNKNOWN", null, true, null)
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidValueException.class);
         assertThat(allergyRecordRepository.count()).isZero();
     }
 


### PR DESCRIPTION
# 📌 Pull Request: 알러지 severity 미지정 값을 NONE으로 처리

# 📝 작업 요약 (Summary)

알러지 심각도는 선택 입력값이므로, 미입력 값을 `null`로 저장하지 않고 `NONE`으로 명시적으로 관리하도록 개선했습니다.

기존에 `severity`가 `null`로 저장된 알러지 기록도 조회 응답에서는 `NONE`으로 반환해, 프론트엔드가 심각도 미지정 상태를 일관되게 처리할 수 있도록 했습니다.

# 🛠️ 변경 사항 (Changes)

## 1. 알러지 심각도 기본값 정책 개선

- `AllergySeverity`에 `NONE` 값을 추가했습니다.
- 알러지 등록 및 수정 시 `severity`가 `null` 또는 blank이면 `NONE`으로 변환해 저장합니다.
- 정의되지 않은 severity 값은 기존과 같이 `InvalidValueException`으로 검증합니다.
- 오류 응답은 `CLIENT_001`, `잘못된 요청입니다.` 규칙을 사용합니다.

## 2. 기존 데이터 조회 호환성

- 기존 DB에 `severity = null`로 저장된 알러지 기록은 상세 및 목록 조회 시 `NONE`으로 반환합니다.
- `AllergyRecord.severity`는 기존 `EnumType.STRING` 방식을 유지합니다.
- 신규 테이블, 컬럼 변경, DB 마이그레이션은 없습니다.

## 3. 테스트

- 알러지 등록 시 severity 미입력 값이 `NONE`으로 저장되고 조회 응답에도 반환되는 서비스 통합 테스트를 추가했습니다.
- 알러지 수정 시 severity 미입력 값이 `NONE`으로 변경되는 서비스 통합 테스트를 추가했습니다.
- 정의되지 않은 severity 입력 시 예외가 발생하고 데이터가 저장되지 않는지 검증했습니다.

# 📸 테스트 시나리오 (Test Scenarios)

## 1. 알러지 심각도 미입력 등록

* **Method**: `POST`
* **URL**: `/api/pets/{petId}/allergies`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### ✅ 1-1 : severity 미입력 시 NONE 저장

**Request Body**

```json
{
  "allergen_name": "닭고기",
  "symptom": null,
  "identified_at": null,
  "is_active": true,
  "memo": null
}
```

**Response (200 OK)**

```json
{
  "allergy_id": "00000000-0000-0000-0000-000000000001",
  "pet_id": "00000000-0000-0000-0000-000000000002",
  "allergen_name": "닭고기",
  "symptom": null,
  "severity": "NONE",
  "identified_at": null,
  "is_active": true,
  "memo": null
}
```

### ❌ 1-2 : 정의되지 않은 severity 입력

**Request Body**

```json
{
  "allergen_name": "닭고기",
  "symptom": null,
  "severity": "UNKNOWN",
  "identified_at": null,
  "is_active": true,
  "memo": null
}
```

**Response (400 Bad Request)**

```json
{
  "code": "CLIENT_001",
  "description": "잘못된 요청입니다.",
  "message": "알러지 심각도 값이 올바르지 않습니다. | UNKNOWN",
  "path": "/api/pets/{petId}/allergies",
  "timestamp": "2026-08-18T12:00:00"
}
```

## 2. 알러지 심각도 미입력 수정

* **Method**: `PUT`
* **URL**: `/api/pets/{petId}/allergies/{allergyId}`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### ✅ 2-1 : 기존 severity를 NONE으로 변경

**Request Body**

```json
{
  "allergen_name": "닭고기",
  "symptom": null,
  "severity": " ",
  "identified_at": null,
  "is_active": true,
  "memo": null
}
```

**Response (200 OK)**

```json
{
  "allergy_id": "00000000-0000-0000-0000-000000000001",
  "pet_id": "00000000-0000-0000-0000-000000000002",
  "allergen_name": "닭고기",
  "symptom": null,
  "severity": "NONE",
  "identified_at": null,
  "is_active": true,
  "memo": null
}
```

## 3. 테스트 실행 결과

- `CareServiceTest`는 Testcontainers가 사용할 Docker 환경을 찾지 못해 실행 전 실패했습니다.
- Docker 실행 환경에서 아래 명령으로 재검증이 필요합니다.

```bash
./gradlew test --tests org.zerock.puppyrun.care.service.CareServiceTest
```