### PR TITLE
feat: 사용자 맞춤 알림 및 산책 선호도 분석

### DIFF
--- a/src/main/java/org/zerock/puppyrun/a_dev/preference/PreferenceController.java
+++ b/src/main/java/org/zerock/puppyrun/a_dev/preference/PreferenceController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.zerock.puppyrun.a_dev.config.DevOnly;
-import org.zerock.puppyrun.common.scheduler.WalkingPreferenceScheduler;
+import org.zerock.puppyrun.tracking.scheduler.WalkingPreferenceScheduler;
 
 @DevOnly
 @RestController

--- a/src/main/java/org/zerock/puppyrun/a_dev/preference/PreferenceController.java
+++ b/src/main/java/org/zerock/puppyrun/a_dev/preference/PreferenceController.java
@@ -1,0 +1,25 @@
+package org.zerock.puppyrun.a_dev.preference;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.zerock.puppyrun.a_dev.config.DevOnly;
+import org.zerock.puppyrun.common.scheduler.WalkingPreferenceScheduler;
+
+@DevOnly
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/test/preferences")
+public class PreferenceController {
+
+    private final WalkingPreferenceScheduler walkingPreferenceScheduler;
+
+    @GetMapping("")
+    public ResponseEntity<Void> preferenceController() {
+        walkingPreferenceScheduler.scheduledPreferenceUpdate();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/pagination/SliceResult.java
+++ b/src/main/java/org/zerock/puppyrun/common/pagination/SliceResult.java
@@ -1,0 +1,17 @@
+package org.zerock.puppyrun.common.pagination;
+
+import java.util.List;
+
+/**
+ * 페이지 또는 커서 기반 조회 결과와 다음 조회 가능 여부를 함께 전달합니다.
+ *
+ * @param content 조회 데이터
+ * @param hasNext 다음 조회 가능 여부
+ * @param <T>     조회 데이터 타입
+ */
+public record SliceResult<T>(List<T> content, boolean hasNext) {
+
+    public SliceResult {
+        content = List.copyOf(content);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/common/scheduler/WalkingPreferenceScheduler.java
+++ b/src/main/java/org/zerock/puppyrun/common/scheduler/WalkingPreferenceScheduler.java
@@ -1,5 +1,7 @@
 package org.zerock.puppyrun.common.scheduler;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -19,11 +21,12 @@ public class WalkingPreferenceScheduler {
     /**
      * 매일 오전 3시에 최근 산책 기록을 분석합니다.
      */
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     public void scheduledPreferenceUpdate() {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
         log.info("정기 산책 패턴 분석을 시작합니다.");
         try {
-            walkingPreferenceService.updateAllMemberPreferences();
+            walkingPreferenceService.createDailySnapshots(now);
         } catch (Exception exception) {
             log.error("산책 패턴 분석 중 오류가 발생했습니다.", exception);
         }

--- a/src/main/java/org/zerock/puppyrun/notification/entity/WalkingPreference.java
+++ b/src/main/java/org/zerock/puppyrun/notification/entity/WalkingPreference.java
@@ -5,8 +5,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,20 +19,29 @@ import org.zerock.puppyrun.common.entity.BaseEntity;
 import org.zerock.puppyrun.member.entity.Member;
 
 /**
- * 회원의 최근 산책 위치와 평일·주말 선호 산책 시간을 저장합니다.
+ * 특정 분석일의 회원 산책 선호 시간 결과를 저장합니다.
+ *
+ * <p>생성 시각은 결과의 24시간 유효성 판단에 사용하고, 분석일은 같은 회원의 같은 날
+ * 스케줄 재실행으로 인한 중복 적재를 방지합니다.</p>
  */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "uk_walking_preference_member_analysis_date",
+        columnNames = {"member_id", "analysis_date"}
+))
 public class WalkingPreference extends BaseEntity {
 
     @Id
     private UUID id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @MapsId
-    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    @Column(name = "analysis_date", nullable = false)
+    private LocalDate analysisDate;
 
     @Column(name = "last_known_latitude")
     private Double lastKnownLatitude;
@@ -37,31 +49,50 @@ public class WalkingPreference extends BaseEntity {
     @Column(name = "last_known_longitude")
     private Double lastKnownLongitude;
 
-    @Column(name = "preferred_weekday_time")
-    private Integer preferredWeekdayTime;
+    @Column(name = "last_known_date")
+    private LocalDate lastKnownDate;
 
-    @Column(name = "preferred_weekend_time")
-    private Integer preferredWeekendTime;
+    @Column(name = "weekday_time")
+    private LocalTime weekdayTime;
+
+    @Column(name = "weekday_score")
+    private Integer weekdayScore;
+
+    @Column(name = "weekend_time")
+    private LocalTime weekendTime;
+
+    @Column(name = "weekend_score")
+    private Integer weekendScore;
 
     @Builder
     public WalkingPreference(
+            UUID id,
             Member member,
+            LocalDate analysisDate,
             Double lastKnownLatitude,
             Double lastKnownLongitude,
-            Integer preferredWeekdayTime,
-            Integer preferredWeekendTime
+            LocalDate lastKnownDate,
+            LocalTime weekdayTime,
+            Integer weekdayScore,
+            LocalTime weekendTime,
+            Integer weekendScore
     ) {
+        this.id = id != null ? id : UUID.randomUUID();
         this.member = member;
+        this.analysisDate = analysisDate;
         this.lastKnownLatitude = lastKnownLatitude;
         this.lastKnownLongitude = lastKnownLongitude;
-        this.preferredWeekdayTime = preferredWeekdayTime;
-        this.preferredWeekendTime = preferredWeekendTime;
+        this.lastKnownDate = lastKnownDate;
+        this.weekdayTime = weekdayTime;
+        this.weekdayScore = weekdayScore;
+        this.weekendTime = weekendTime;
+        this.weekendScore = weekendScore;
     }
 
     /**
      * 마지막으로 확인된 산책 위치를 갱신합니다.
      *
-     * @param latitude 최근 산책 위치의 위도
+     * @param latitude  최근 산책 위치의 위도
      * @param longitude 최근 산책 위치의 경도
      */
     public void updateLocation(double latitude, double longitude) {
@@ -75,8 +106,15 @@ public class WalkingPreference extends BaseEntity {
      * @param weekdayTime 평일 선호 시간
      * @param weekendTime 주말 선호 시간
      */
-    public void updateTimePreferences(Integer weekdayTime, Integer weekendTime) {
-        this.preferredWeekdayTime = weekdayTime;
-        this.preferredWeekendTime = weekendTime;
+    public void updateTimePreferences(
+            LocalTime weekdayTime,
+            Integer weekdayScore,
+            LocalTime weekendTime,
+            Integer weekendScore
+    ) {
+        this.weekdayTime = weekdayTime;
+        this.weekdayScore = weekdayScore;
+        this.weekendTime = weekendTime;
+        this.weekendScore = weekendScore;
     }
 }

--- a/src/main/java/org/zerock/puppyrun/notification/repository/NotificationRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/NotificationRepoCustom.java
@@ -6,10 +6,11 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.common.pagination.SliceResult;
 import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
 
 public interface NotificationRepoCustom {
-    List<EnabledNotifications> findNextMembers(
+    SliceResult<EnabledNotifications> findNextMembers(
             LocalDateTime lastCreatedAt,
             UUID lastMemberId,
             Pageable pageable,

--- a/src/main/java/org/zerock/puppyrun/notification/repository/NotificationRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/NotificationRepoCustomImpl.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.common.pagination.SliceResult;
 import org.zerock.puppyrun.member.entity.Status;
 import org.zerock.puppyrun.notification.entity.NotificationType;
 import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
@@ -23,14 +24,14 @@ public class NotificationRepoCustomImpl implements NotificationRepoCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<EnabledNotifications> findNextMembers(
+    public SliceResult<EnabledNotifications> findNextMembers(
             LocalDateTime lastCreatedAt,
             UUID lastMemberId,
             Pageable pageable,
             NotificationType type
     ) {
 
-        return queryFactory
+        List<EnabledNotifications> fetched = queryFactory
                 .select(Projections.constructor(EnabledNotifications.class,
                         notificationSettings.member.id,
                         Expressions.constant(type),
@@ -49,7 +50,12 @@ public class NotificationRepoCustomImpl implements NotificationRepoCustom {
                 .orderBy(member.createdAt.asc(), member.id.asc())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
+        boolean hasNext = fetched.size() > pageable.getPageSize();
+        List<EnabledNotifications> content = hasNext
+                ? fetched.subList(0, pageable.getPageSize())
+                : fetched;
 
+        return new SliceResult<>(content, hasNext);
     }
 
     private BooleanExpression afterCursor(LocalDateTime lastCreatedAt, UUID lastMemberId) {

--- a/src/main/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepository.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepository.java
@@ -1,6 +1,8 @@
 package org.zerock.puppyrun.notification.repository;
 
-import java.util.Optional;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.zerock.puppyrun.notification.entity.WalkingPreference;
@@ -10,5 +12,8 @@ import org.zerock.puppyrun.notification.entity.WalkingPreference;
  */
 public interface WalkingPreferenceRepository extends JpaRepository<WalkingPreference, UUID> {
 
-    Optional<WalkingPreference> findByMemberId(UUID memberId);
+    List<WalkingPreference> findAllByMemberIdInAndAnalysisDate(
+            Collection<UUID> memberIds,
+            LocalDate analysisDate
+    );
 }

--- a/src/main/java/org/zerock/puppyrun/notification/scheduler/WalkingRemindScheduler.java
+++ b/src/main/java/org/zerock/puppyrun/notification/scheduler/WalkingRemindScheduler.java
@@ -1,5 +1,7 @@
-package org.zerock.puppyrun.common.scheduler;
+package org.zerock.puppyrun.notification.scheduler;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -12,13 +14,22 @@ import org.zerock.puppyrun.notification.service.sender.ReminderSender;
 @Slf4j
 @RequiredArgsConstructor
 public class WalkingRemindScheduler {
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
     private final NotificationProcessor processor;
     private final ReminderSender sender;
 
     // 매일 밤 20:00에 실행
     @Scheduled(cron = "0 0 20 * * *")
     public void sendDailyWalkingReminder() {
-        log.info("데일리 산책 리마인드 발송 시작");
-        processor.broadcast(NotificationType.DAILY_WALKING_REMINDER, sender);
+        LocalDateTime startedAt = LocalDateTime.now(KOREA_ZONE);
+        log.info("event=walking_reminder_started, startedAt={}", startedAt);
+        try {
+            processor.broadcast(NotificationType.DAILY_WALKING_REMINDER, sender);
+        } catch (Exception exception) {
+            log.error("event=walking_reminder_failed, exceptionType={}",
+                    exception.getClass().getSimpleName(), exception
+            );
+        }
     }
 }

--- a/src/main/java/org/zerock/puppyrun/notification/service/NotificationProcessor.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/NotificationProcessor.java
@@ -7,9 +7,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.common.pagination.SliceResult;
 import org.zerock.puppyrun.notification.entity.NotificationType;
 import org.zerock.puppyrun.notification.client.NotificationEventClient;
 import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
@@ -33,48 +33,54 @@ public class NotificationProcessor {
     private final NotificationRepository notificationRepository;
     private final NotificationEventClient notificationEventClient;
 
-    private static final int CHUNK_SIZE = 1000;
+    private static final int PAGE_SIZE = 1000;
 
     /**
      * 알림 수신 대상자를 순차 조회해 회원별로 개인화된 토큰 메시지를 발송합니다.
      *
-     * <p>대상자는 생성 시각과 회원 ID로 구성된 커서를 기준으로 페이지 크기보다 한 명 더 조회해
-     * 다음 데이터 존재 여부를 판단하고, 실제 메시지 내용은 전달받은 {@link Sender} 구현체가 생성합니다.</p>
+     * <p>대상자는 생성 시각과 회원 ID로 구성된 커서를 기준으로 조회하며, 다음 조회 여부는
+     * Repository가 반환한 {@link SliceResult#hasNext()}로 판단합니다.</p>
      *
      * @param type   조회할 알림 유형
      * @param sender 회원별 토큰 메시지 생성 전략
      */
-    @Async("notificationTaskExecutor")
     public void broadcast(NotificationType type, Sender sender) {
-        // Limit만 1000으로 걸어주는 용도의 Pageable
-        Pageable limitOnly = PageRequest.of(0, CHUNK_SIZE);
+        Pageable limitOnly = PageRequest.of(0, PAGE_SIZE);
 
         LocalDateTime lastCreatedAt = null;
         UUID lastMemberId = null;
-        List<EnabledNotifications> memberSettings;
+        SliceResult<EnabledNotifications> recipientSlice;
+        int pageCount = 0;
+        int requestedCount = 0;
 
         do {
-            memberSettings = notificationRepository.findNextMembers(
+            recipientSlice = notificationRepository.findNextMembers(
                     lastCreatedAt,
                     lastMemberId,
                     limitOnly,
                     type
             );
+            List<EnabledNotifications> memberSettings = recipientSlice.content();
             if (memberSettings.isEmpty()) {
                 break; // 더 이상 데이터가 없으면 탈출
             }
-            // 메세지를 다르게 만드는 분기
+
             List<PushTask> pushTasks = sender.createPushTasks(memberSettings);
 
             // 검색된 멤버 알림 처리
             notificationEventClient.sendMessagesInBulk(pushTasks);
+            pageCount++;
+            requestedCount += pushTasks.size();
 
             EnabledNotifications lastMember = memberSettings.getLast();
             lastCreatedAt = lastMember.createdAt();
             lastMemberId = lastMember.memberId();
 
-            // CHUNK_SIZE 보다 크면 다시 조회
-        } while (memberSettings.size() > CHUNK_SIZE);
+        } while (recipientSlice.hasNext());
+
+        log.info("event=walking_reminder_requests_queued, type={}, pageCount={}, requestedCount={}",
+                type, pageCount, requestedCount
+        );
     }
 
     /**
@@ -84,7 +90,6 @@ public class NotificationProcessor {
      * @param title 알림 제목
      * @param body  알림 본문
      */
-    @Async("notificationTaskExecutor")
     public void broadcast(NotificationType type, String title, String body) {
 
         // 공통 메세지 생성

--- a/src/main/java/org/zerock/puppyrun/notification/service/WalkingPreferenceService.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/WalkingPreferenceService.java
@@ -3,15 +3,18 @@ package org.zerock.puppyrun.notification.service;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -19,104 +22,338 @@ import org.springframework.transaction.annotation.Transactional;
 import org.zerock.puppyrun.common.logging.LogExecutionTime;
 import org.zerock.puppyrun.notification.entity.WalkingPreference;
 import org.zerock.puppyrun.notification.repository.WalkingPreferenceRepository;
+import org.zerock.puppyrun.tracking.entity.RoutePoint;
 import org.zerock.puppyrun.tracking.entity.Tracking;
+import org.zerock.puppyrun.tracking.entity.TrackingRoute;
 import org.zerock.puppyrun.tracking.repository.TrackingRepository;
+import org.zerock.puppyrun.tracking.repository.TrackingRouteRepository;
 
 /**
- * 최근 산책 기록을 분석해 회원별 선호 산책 시간대를 갱신합니다.
+ * 최근 산책 기록을 분석하여 회원별 일일 선호 산책 시간대 스냅샷을 생성 및 적재하는 서비스입니다.
+ * <p>
+ * 주요 기능:
+ * <ul>
+ *   <li>최근 28일간의 회원별 산책 기록(Tracking)을 분석합니다.</li>
+ *   <li>하루 24시간을 2시간 단위(총 12개 버킷)로 나누어 산책 시작 시각을 분류합니다.</li>
+ *   <li>최근에 진행한 산책일수록 높은 가중치(1~4점)를 부여하여 평일/주말 선호 시간대를 결정합니다.</li>
+ *   <li>대용량 데이터를 안전하게 처리하기 위해 청크(Chunk) 단위로 배치 분석 및 스냅샷을 적재합니다.</li>
+ * </ul>
  */
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class WalkingPreferenceService {
 
-    private static final int ANALYSIS_WINDOW_DAYS = 30;
+    /**
+     * 산책 기록 분석 대상 기간 (최근 28일)
+     */
+    private static final int ANALYSIS_WINDOW_DAYS = 28;
+
+    /**
+     * 시간대 분류 버킷 단위 (2시간 단위: 00시, 02시, 04시 ... 22시)
+     */
     private static final int BUCKET_SIZE_HOURS = 2;
+
+    /**
+     * 배치 처리 시 한 번에 조회/분석할 회원 청크 크기
+     */
     private static final int CHUNK_SIZE = 300;
 
+
     private final TrackingRepository trackingRepository;
+    private final TrackingRouteRepository trackingRouteRepository;
     private final WalkingPreferenceRepository walkingPreferenceRepository;
 
     /**
-     * 최근 30일 내 산책 회원을 청크 단위로 조회해 평일·주말 선호 시간을 갱신합니다.
+     * 지정된 분석 시각(analysisAt)을 기준으로 회원별 산책 패턴을 분석하고 스냅샷을 저장합니다.
+     * <p>
+     * 1. 최근 28일 내 활동한 회원 ID 목록을 청크 단위로 조회합니다.<br>
+     * 2. 이미 당일 스냅샷이 존재하는 회원은 분석 대상에서 제외합니다.<br>
+     * 3. 분석 대상 회원의 산책 기록 데이터를 일괄 조회하여 평일/주말 버킷 점수를 산출합니다.<br>
+     * 4. 생성된 선호도 스냅샷({@link WalkingPreference})을 저장합니다.
+     *
+     * @param analysisAt 분석 실행 시각
      */
     @LogExecutionTime
-    public void updateAllMemberPreferences() {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime startDateTime = now.minusDays(ANALYSIS_WINDOW_DAYS);
+    public void createDailySnapshots(LocalDateTime analysisAt) {
+        LocalDateTime startDateTime = analysisAt.minusDays(ANALYSIS_WINDOW_DAYS);
+        LocalDate analysisDate = analysisAt.toLocalDate();
         int pageNumber = 0;
+        int savedCount = 0;
         List<UUID> memberIds;
 
+        log.info(
+                "event=walking_preference_analysis_started, analysisAt={}, from={}, to={}, bucketSizeHours={}",
+                analysisAt, startDateTime, analysisAt, BUCKET_SIZE_HOURS
+        );
         do {
             Pageable pageable = PageRequest.of(pageNumber, CHUNK_SIZE);
-            memberIds = trackingRepository.findActiveMemberIds(startDateTime, pageable);
+            // 최근 28일 동안 활동 기록이 있는 회원 ID 페이지 조회
+            memberIds = trackingRepository.findActiveMemberIds(startDateTime, analysisAt, pageable);
             if (memberIds.isEmpty()) {
                 break;
             }
-            List<Tracking> trackings = trackingRepository
-                    .findAllByMemberIdsAndDateRange(memberIds, startDateTime);
+
+            // 당일 분석 스냅샷이 이미 존재하는 회원 조회 (중복 분석 방지)
+            Map<UUID, WalkingPreference> existingSnapshots = walkingPreferenceRepository
+                    .findAllByMemberIdInAndAnalysisDate(memberIds, analysisDate)
+                    .stream()
+                    .collect(Collectors.toMap(
+                            snapshot -> snapshot.getMember().getId(),
+                            snapshot -> snapshot
+                    ));
+
+            // 당일 스냅샷이 없는 미분석 회원 추출
+            List<UUID> candidateMemberIds = memberIds.stream()
+                    .filter(memberId -> !existingSnapshots.containsKey(memberId))
+                    .toList();
+
+            // 후보 회원들의 최근 28일간 산책 기록 조회
+            List<Tracking> trackings = candidateMemberIds.isEmpty()
+                    ? List.of()
+                    : trackingRepository.findAllByMemberIdsAndDateRange(candidateMemberIds, startDateTime, analysisAt);
+
+            // 전체 산책 기록 목록을 회원 ID별로 그룹화
             Map<UUID, List<Tracking>> trackingMap = trackings.stream()
                     .filter(tracking -> tracking.getMember().getId() != null)
                     .collect(Collectors.groupingBy(tracking -> tracking.getMember().getId()));
-            Map<UUID, WalkingPreference> preferenceMap = walkingPreferenceRepository.findAllById(memberIds)
+
+            // 회원별 산책 기록 목록에서 가장 최근의 산책 기록(Tracking) 1개씩만 추출
+            Map<UUID, Tracking> latestTrackingMap = trackingMap.entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> findLatestTracking(entry.getValue())));
+
+            // 각 회원의 최신 산책 기록에 대한 경로(TrackingRoute) 데이터를 일괄 조회하여 Map으로 매핑
+            Map<UUID, TrackingRoute> routeMap = trackingRouteRepository.findAllByTrackingIdIn(
+                            latestTrackingMap.values().stream().map(Tracking::getId).toList()
+                    )
                     .stream()
-                    .collect(Collectors.toMap(preference -> preference.getMember().getId(), preference -> preference));
+                    .collect(Collectors.toMap(TrackingRoute::getTrackingId, route -> route));
 
-            List<WalkingPreference> updates = new ArrayList<>();
-            for (UUID memberId : memberIds) {
-                WalkingPreference preference = preferenceMap.get(memberId);
-                List<Tracking> memberTrackings = trackingMap.getOrDefault(memberId, List.of());
-                if (preference == null || memberTrackings.isEmpty()) {
-                    continue;
-                }
+            // 각 회원별 스냅샷 객체 생성 및 null 필터링
+            List<WalkingPreference> snapshots = candidateMemberIds.stream()
+                    .map(memberId -> createSnapshot(
+                            memberId,
+                            trackingMap.getOrDefault(memberId, List.of()),
+                            latestTrackingMap.get(memberId),
+                            routeMap,
+                            analysisAt,
+                            analysisDate
+                    ))
+                    .filter(Objects::nonNull)
+                    .toList();
 
-                updatePreference(preference, memberTrackings, now.toLocalDate());
-                updates.add(preference);
+            // 생성된 스냅샷 DB 저장
+            if (!snapshots.isEmpty()) {
+                walkingPreferenceRepository.saveAll(snapshots);
             }
-
-            walkingPreferenceRepository.saveAll(updates);
+            savedCount += snapshots.size();
+            log.info(
+                    "event=walking_preference_analysis_chunk_completed, page={}, memberCount={}, savedCount={}, skippedExistingCount={}",
+                    pageNumber, memberIds.size(), snapshots.size(), existingSnapshots.size()
+            );
             pageNumber++;
         } while (memberIds.size() == CHUNK_SIZE);
+
+        log.info(
+                "event=walking_preference_analysis_completed, analysisDate={}, savedCount={}",
+                analysisDate, savedCount
+        );
     }
 
-    private void updatePreference(
-            WalkingPreference preference,
+    /**
+     * 단일 회원의 산책 기록을 기반으로 평일/주말 선호 시간을 점수화하고 스냅샷 엔티티를 생성합니다.
+     *
+     * @param memberId     회원 ID
+     * @param trackings    회원의 최근 산책 기록 리스트
+     * @param analysisAt   분석 기준 시각
+     * @param analysisDate 분석 기준 일자
+     * @return 생성된 WalkingPreference 스냅샷 엔티티 (산책 기록이 없는 경우 null)
+     */
+    private WalkingPreference createSnapshot(
+            UUID memberId,
             List<Tracking> trackings,
-            LocalDate today
+            Tracking latestTracking,
+            Map<UUID, TrackingRoute> routeMap,
+            LocalDateTime analysisAt,
+            LocalDate analysisDate
     ) {
-        Map<Integer, Double> weekdayScores = new HashMap<>();
-        Map<Integer, Double> weekendScores = new HashMap<>();
+        if (trackings.isEmpty()) {
+            log.debug("event=walking_preference_member_skipped, memberId={}, reason=no_tracking", memberId);
+            return null;
+        }
+
+        // 평일 및 주말 시간대별 선호 점수 분석
+        PreferenceScore weekdayScore = scoreByTimeBucket(trackings, analysisAt, false);
+        PreferenceScore weekendScore = scoreByTimeBucket(trackings, analysisAt, true);
+        LastWalkingLocation lastWalkingLocation = getLastWalkingLocation(latestTracking, routeMap);
+        log.debug(
+                "event=walking_preference_member_scored, memberId={}, trackingCount={}, weekdayBucketScores={}, weekdayPreferredTime={}, weekdayScore={}, weekendBucketScores={}, weekendPreferredTime={}, weekendScore={}",
+                memberId,
+                trackings.size(),
+                weekdayScore.bucketScores(), weekdayScore.preferredTime(), weekdayScore.score(),
+                weekendScore.bucketScores(), weekendScore.preferredTime(), weekendScore.score()
+        );
+
+        return WalkingPreference.builder()
+                .member(trackings.getFirst().getMember())
+                .analysisDate(analysisDate)
+                .lastKnownLatitude(lastWalkingLocation.latitude())
+                .lastKnownLongitude(lastWalkingLocation.longitude())
+                .lastKnownDate(lastWalkingLocation.walkedDate())
+                .weekdayTime(weekdayScore.preferredTime())
+                .weekdayScore(weekdayScore.score())
+                .weekendTime(weekendScore.preferredTime())
+                .weekendScore(weekendScore.score())
+                .build();
+    }
+
+    private Tracking findLatestTracking(List<Tracking> trackings) {
+        return trackings.stream()
+                .max(Comparator.comparing(Tracking::getStartedAt).thenComparing(Tracking::getId))
+                .orElseThrow();
+    }
+
+    private LastWalkingLocation getLastWalkingLocation(
+            Tracking latestTracking,
+            Map<UUID, TrackingRoute> routeMap
+    ) {
+        TrackingRoute trackingRoute = routeMap.get(latestTracking.getId());
+        if (trackingRoute == null || trackingRoute.getOriginalPath().isEmpty()) {
+            return new LastWalkingLocation(null, null, latestTracking.getStartedAt().toLocalDate());
+        }
+
+        RoutePoint lastPoint = trackingRoute.getOriginalPath().getLast();
+        return new LastWalkingLocation(lastPoint.lat(), lastPoint.lng(), latestTracking.getStartedAt().toLocalDate());
+    }
+
+    /**
+     * 산책 기록들을 2시간 단위 시간대 버킷으로 분류하고 최근성 가중치를 누적하여 최고 선호 시간을 산출합니다.
+     *
+     * @param trackings  회원의 산책 기록 목록
+     * @param analysisAt 분석 기준 시각
+     * @param weekend    주말 여부 (true: 주말 산책 분석, false: 평일 산책 분석)
+     * @return 버킷별 점수 분포와 최고 선호 시간을 담은 PreferenceScore
+     */
+    private PreferenceScore scoreByTimeBucket(
+            List<Tracking> trackings,
+            LocalDateTime analysisAt,
+            boolean weekend
+    ) {
+        Map<Integer, ScoreAccumulator> scores = new HashMap<>();
 
         for (Tracking tracking : trackings) {
             LocalDateTime startedAt = tracking.getStartedAt();
-            int bucketIndex = startedAt.getHour() / BUCKET_SIZE_HOURS;
-            long daysAgo = ChronoUnit.DAYS.between(startedAt.toLocalDate(), today);
-            double weight = calculateTimeDecayWeight(daysAgo);
-
-            if (isWeekend(startedAt.getDayOfWeek())) {
-                weekendScores.merge(bucketIndex, weight, Double::sum);
-            } else {
-                weekdayScores.merge(bucketIndex, weight, Double::sum);
+            // 평일/주말 데이터 필터링
+            if (isWeekend(startedAt.getDayOfWeek()) != weekend) {
+                continue;
             }
+
+            // 산책 시작 시간을 2시간 버킷 인덱스로 전환 (예: 14시 -> 7번 버킷)
+            int bucketIndex = startedAt.getHour() / BUCKET_SIZE_HOURS;
+            // 경과 일수에 따른 가중치 산출 (1~4점)
+            int weight = calculateWeight(startedAt, analysisAt);
+            // 해당 버킷에 점수 및 최근 산책 시작 시각 누적
+            scores.computeIfAbsent(bucketIndex, ignored -> new ScoreAccumulator()).add(weight, startedAt);
         }
 
-        preference.updateTimePreferences(getBestHour(weekdayScores), getBestHour(weekendScores));
+        // 전체 시간대 버킷별 점수 맵 생성 (LocalTime 기준 정렬)
+        Map<LocalTime, Integer> bucketScores = scores.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .collect(Collectors.toMap(
+                        entry -> LocalTime.of(entry.getKey() * BUCKET_SIZE_HOURS, 0),
+                        entry -> entry.getValue().score,
+                        (left, right) -> left,
+                        java.util.LinkedHashMap::new
+                ));
+        return getBestScore(scores, bucketScores);
     }
 
+    /**
+     * 요일(DayOfWeek)이 토요일 또는 일요일인지 확인합니다.
+     */
     private boolean isWeekend(DayOfWeek dayOfWeek) {
         return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
     }
 
-    private double calculateTimeDecayWeight(long daysAgo) {
-        double halfLife = 10.0;
-        double lambda = Math.log(2) / halfLife;
-        return Math.max(0.1, Math.exp(-lambda * daysAgo));
+    /**
+     * 분석 시점 기준 산책 일자의 최근성(Recency)에 따른 가중치를 계산합니다.
+     * <ul>
+     *   <li>최근 7일 미만: 4점</li>
+     *   <li>7일 이상 ~ 14일 미만: 3점</li>
+     *   <li>14일 이상 ~ 21일 미만: 2점</li>
+     *   <li>21일 이상 ~ 28일 미만: 1점</li>
+     * </ul>
+     */
+    private int calculateWeight(LocalDateTime startedAt, LocalDateTime analysisAt) {
+        long daysAgo = ChronoUnit.DAYS.between(startedAt.toLocalDate(), analysisAt.toLocalDate());
+        if (daysAgo < 7) {
+            return 4;
+        }
+        if (daysAgo < 14) {
+            return 3;
+        }
+        if (daysAgo < 21) {
+            return 2;
+        }
+        return 1;
     }
 
-    private Integer getBestHour(Map<Integer, Double> scores) {
+    /**
+     * 집계된 버킷 점수 중 가장 높은 점수의 시간대(LocalTime)를 결정합니다.
+     * <p>
+     * **동점 우위 처리 규칙**:
+     * <ol>
+     *   <li>1순위: 버킷의 총 누적 점수 (최대점)</li>
+     *   <li>2순위: 버킷 내 가장 최근에 진행된 산책 시각 (최신성)</li>
+     *   <li>3순위: 더 늦은 시간대 버킷 (인덱스가 큰 버킷)</li>
+     * </ol>
+     */
+    private PreferenceScore getBestScore(
+            Map<Integer, ScoreAccumulator> scores,
+            Map<LocalTime, Integer> bucketScores
+    ) {
         return scores.entrySet().stream()
-                .max(Comparator.comparingDouble(Map.Entry::getValue))
-                .map(entry -> entry.getKey() * BUCKET_SIZE_HOURS)
-                .orElse(null);
+                .max(Comparator
+                        .comparingInt((Map.Entry<Integer, ScoreAccumulator> entry) -> entry.getValue().score)
+                        .thenComparing(entry -> entry.getValue().latestStartedAt)
+                        .thenComparing(Map.Entry<Integer, ScoreAccumulator>::getKey, Comparator.reverseOrder()))
+                .map(entry -> new PreferenceScore(
+                        LocalTime.of(entry.getKey() * BUCKET_SIZE_HOURS, 0),
+                        entry.getValue().score,
+                        bucketScores
+                ))
+                .orElse(new PreferenceScore(null, null, bucketScores));
+    }
+
+    /**
+     * 버킷 분석 결과(선호 시간, 점수, 전체 버킷별 점수 분포)를 담는 불변 객체입니다.
+     */
+    private record PreferenceScore(
+            LocalTime preferredTime,
+            Integer score,
+            Map<LocalTime, Integer> bucketScores
+    ) {
+    }
+
+    private record LastWalkingLocation(Double latitude, Double longitude, LocalDate walkedDate) {
+    }
+
+    /**
+     * 시간대 버킷별 누적 점수와 가장 최근에 시작된 산책 시각을 집계하기 위한 헬퍼 클래스입니다.
+     */
+    private static class ScoreAccumulator {
+        private int score;
+        private LocalDateTime latestStartedAt;
+
+        /**
+         * 가중치를 누적하고, 더 최근의 산책 시각이면 latestStartedAt을 갱신합니다.
+         */
+        private void add(int weight, LocalDateTime startedAt) {
+            score += weight;
+            if (latestStartedAt == null || startedAt.isAfter(latestStartedAt)) {
+                latestStartedAt = startedAt;
+            }
+        }
     }
 }

--- a/src/main/java/org/zerock/puppyrun/notification/service/WalkingPreferenceService.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/WalkingPreferenceService.java
@@ -8,8 +8,10 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -121,7 +123,7 @@ public class WalkingPreferenceService {
 
             // 회원별 산책 기록 목록에서 가장 최근의 산책 기록(Tracking) 1개씩만 추출
             Map<UUID, Tracking> latestTrackingMap = trackingMap.entrySet().stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> findLatestTracking(entry.getValue())));
+                    .collect(Collectors.toMap(Entry::getKey, entry -> findLatestTracking(entry.getValue())));
 
             // 각 회원의 최신 산책 기록에 대한 경로(TrackingRoute) 데이터를 일괄 조회하여 Map으로 매핑
             Map<UUID, TrackingRoute> routeMap = trackingRouteRepository.findAllByTrackingIdIn(
@@ -259,12 +261,12 @@ public class WalkingPreferenceService {
 
         // 전체 시간대 버킷별 점수 맵 생성 (LocalTime 기준 정렬)
         Map<LocalTime, Integer> bucketScores = scores.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
+                .sorted(Entry.comparingByKey())
                 .collect(Collectors.toMap(
                         entry -> LocalTime.of(entry.getKey() * BUCKET_SIZE_HOURS, 0),
                         entry -> entry.getValue().score,
                         (left, right) -> left,
-                        java.util.LinkedHashMap::new
+                        LinkedHashMap::new
                 ));
         return getBestScore(scores, bucketScores);
     }
@@ -315,9 +317,9 @@ public class WalkingPreferenceService {
     ) {
         return scores.entrySet().stream()
                 .max(Comparator
-                        .comparingInt((Map.Entry<Integer, ScoreAccumulator> entry) -> entry.getValue().score)
+                        .comparingInt((Entry<Integer, ScoreAccumulator> entry) -> entry.getValue().score)
                         .thenComparing(entry -> entry.getValue().latestStartedAt)
-                        .thenComparing(Map.Entry<Integer, ScoreAccumulator>::getKey, Comparator.reverseOrder()))
+                        .thenComparing(Entry<Integer, ScoreAccumulator>::getKey, Comparator.reverseOrder()))
                 .map(entry -> new PreferenceScore(
                         LocalTime.of(entry.getKey() * BUCKET_SIZE_HOURS, 0),
                         entry.getValue().score,

--- a/src/main/java/org/zerock/puppyrun/notification/service/sender/ReminderSender.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/sender/ReminderSender.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.zerock.puppyrun.notification.entity.NotificationType;
@@ -23,7 +24,7 @@ import org.zerock.puppyrun.tracking.repository.TrackingRepository;
  * <p>산책하지 않은 회원, 3km 이상 산책한 회원, 그 외 회원을 구분해
  * 각 FCM 토큰에 대응하는 개인화된 전송 작업을 반환합니다.</p>
  */
-@Service
+@Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReminderSender implements Sender {

--- a/src/main/java/org/zerock/puppyrun/tracking/DTO/MainTrackingSummary.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/DTO/MainTrackingSummary.java
@@ -1,18 +1,11 @@
 package org.zerock.puppyrun.tracking.DTO;
 
-import java.util.List;
 import java.util.UUID;
 import org.zerock.puppyrun.tracking.entity.RoutePoint;
 
 public record MainTrackingSummary(
-        List<TrackingSummary> trackingSummaries,
-        boolean hasNext
+        UUID trackingId,
+        String featuredImage,
+        java.util.List<RoutePoint> path
 ) {
-    public record TrackingSummary(
-            UUID trackingId,
-            String featuredImage,
-            List<RoutePoint> path
-    ) {
-    }
-
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/controller/response/MainTrackingResponse.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/controller/response/MainTrackingResponse.java
@@ -2,6 +2,7 @@ package org.zerock.puppyrun.tracking.controller.response;
 
 import java.util.List;
 import java.util.UUID;
+import org.zerock.puppyrun.common.pagination.SliceResult;
 import org.zerock.puppyrun.common.s3.support.S3Url;
 import org.zerock.puppyrun.tracking.DTO.MainTrackingSummary;
 import org.zerock.puppyrun.tracking.entity.RoutePoint;
@@ -15,8 +16,8 @@ public record MainTrackingResponse(
     /**
      * 산책 목록 조회 결과를 API 응답으로 변환합니다.
      */
-    public static MainTrackingResponse from(MainTrackingSummary summaries) {
-        List<TrackingDetail> details = summaries.trackingSummaries().stream()
+    public static MainTrackingResponse from(SliceResult<MainTrackingSummary> summaries) {
+        List<TrackingDetail> details = summaries.content().stream()
                 .map(TrackingDetail::from)
                 .toList();
 
@@ -29,7 +30,7 @@ public record MainTrackingResponse(
             List<TrackingPoint> path     // 산책 경로
     ) {
 
-        private static TrackingDetail from(MainTrackingSummary.TrackingSummary summary) {
+        private static TrackingDetail from(MainTrackingSummary summary) {
             return new TrackingDetail(
                     summary.trackingId(),
                     summary.featuredImage(),

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
+import org.zerock.puppyrun.common.pagination.SliceResult;
 import org.zerock.puppyrun.statistics.DTO.PetActivityTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyMemberStat;
 import org.zerock.puppyrun.tracking.DTO.DailyTracking;
@@ -19,7 +20,7 @@ public interface TrackingRepoCustom {
     /**
      * 회원의 산책 목록을 대표 이미지, 경로와 함께 조회합니다.
      */
-    MainTrackingSummary findMainTrackingSummaries(UUID memberId, Pageable pageable);
+    SliceResult<MainTrackingSummary> findMainTrackingSummaries(UUID memberId, Pageable pageable);
 
     /**
      * 산책 상세 기본 정보와 경로 및 일기를 조회합니다.

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustom.java
@@ -39,12 +39,20 @@ public interface TrackingRepoCustom {
     /**
      * 기준 시각 이후 산책한 회원 ID를 페이지 단위로 조회합니다.
      */
-    List<UUID> findActiveMemberIds(LocalDateTime startDateTime, Pageable pageable);
+    List<UUID> findActiveMemberIds(
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            Pageable pageable
+    );
 
     /**
      * 여러 회원의 기준 시각 이후 산책 기록을 회원과 함께 조회합니다.
      */
-    List<Tracking> findAllByMemberIdsAndDateRange(List<UUID> memberIds, LocalDateTime startDateTime);
+    List<Tracking> findAllByMemberIdsAndDateRange(
+            List<UUID> memberIds,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime
+    );
 
     /**
      * 멤버의 특정 기간 동안의 일별 산책 누적 거리, 누적 시간, 산책 횟수를 쿼리로 조회

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.common.pagination.SliceResult;
 import org.zerock.puppyrun.statistics.DTO.PetActivityTracking;
 import org.zerock.puppyrun.tracking.DTO.DailyMemberStat;
 import org.zerock.puppyrun.tracking.DTO.DailyTracking;
@@ -40,7 +41,7 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public MainTrackingSummary findMainTrackingSummaries(UUID memberId, Pageable pageable) {
+    public SliceResult<MainTrackingSummary> findMainTrackingSummaries(UUID memberId, Pageable pageable) {
         List<Tuple> result = queryFactory
                 .select(
                         tracking.id,
@@ -67,10 +68,10 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
             result.remove(pageable.getPageSize()); // 안전하게 마지막 항목 제거
         }
 
-        List<MainTrackingSummary.TrackingSummary> summaries = result.stream()
+        List<MainTrackingSummary> summaries = result.stream()
                 .map(r -> {
                     List<RoutePoint> path = r.get(trackingRoute.rawPath); // originalPath 직접 추출
-                    return new MainTrackingSummary.TrackingSummary(
+                    return new MainTrackingSummary(
                             r.get(tracking.id),
                             r.get(trackingImage.imageUrl),
                             path != null ? path : List.of()
@@ -78,7 +79,7 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
                 })
                 .toList();
 
-        return new MainTrackingSummary(summaries, hasNext);
+        return new SliceResult<>(summaries, hasNext);
     }
 
     @Override

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepoCustomImpl.java
@@ -181,12 +181,19 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
     }
 
     @Override
-    public List<UUID> findActiveMemberIds(LocalDateTime startDateTime, Pageable pageable) {
+    public List<UUID> findActiveMemberIds(
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            Pageable pageable
+    ) {
         return queryFactory
                 .select(tracking.member.id)
                 .distinct()
                 .from(tracking)
-                .where(tracking.startedAt.goe(startDateTime))
+                .where(
+                        tracking.startedAt.goe(startDateTime),
+                        tracking.startedAt.lt(endDateTime)
+                )
                 .orderBy(tracking.member.id.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -196,14 +203,16 @@ public class TrackingRepoCustomImpl implements TrackingRepoCustom {
     @Override
     public List<Tracking> findAllByMemberIdsAndDateRange(
             List<UUID> memberIds,
-            LocalDateTime startDateTime
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime
     ) {
         return queryFactory
                 .selectFrom(tracking)
                 .join(tracking.member, member).fetchJoin()
                 .where(
                         tracking.member.id.in(memberIds),
-                        tracking.startedAt.goe(startDateTime)
+                        tracking.startedAt.goe(startDateTime),
+                        tracking.startedAt.lt(endDateTime)
                 )
                 .fetch();
     }

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRouteRepository.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRouteRepository.java
@@ -1,5 +1,7 @@
 package org.zerock.puppyrun.tracking.repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,5 +19,7 @@ public interface TrackingRouteRepository extends JpaRepository<TrackingRoute, UU
      * @return 경로 데이터. 존재하지 않으면 빈 Optional
      */
     Optional<TrackingRoute> findByTrackingId(UUID trackingId);
+
+    List<TrackingRoute> findAllByTrackingIdIn(Collection<UUID> trackingIds);
 
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/scheduler/WalkingPreferenceScheduler.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/scheduler/WalkingPreferenceScheduler.java
@@ -1,4 +1,4 @@
-package org.zerock.puppyrun.common.scheduler;
+package org.zerock.puppyrun.tracking.scheduler;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -15,15 +15,16 @@ import org.zerock.puppyrun.notification.service.WalkingPreferenceService;
 @RequiredArgsConstructor
 @Slf4j
 public class WalkingPreferenceScheduler {
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     private final WalkingPreferenceService walkingPreferenceService;
 
     /**
      * 매일 오전 3시에 최근 산책 기록을 분석합니다.
      */
-    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 3 * * *")
     public void scheduledPreferenceUpdate() {
-        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalDateTime now = LocalDateTime.now(KOREA_ZONE);
         log.info("정기 산책 패턴 분석을 시작합니다.");
         try {
             walkingPreferenceService.createDailySnapshots(now);

--- a/src/main/java/org/zerock/puppyrun/tracking/service/TrackingQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/service/TrackingQueryService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.common.exception.UserForbiddenException;
+import org.zerock.puppyrun.common.pagination.SliceResult;
 import org.zerock.puppyrun.tracking.DTO.MainTrackingSummary;
 import org.zerock.puppyrun.tracking.DTO.TrackingDetailSummary;
 import org.zerock.puppyrun.tracking.controller.response.MainTrackingResponse;
@@ -25,7 +26,7 @@ public class TrackingQueryService {
      * 산책 리스트 조회
      */
     public MainTrackingResponse getTrackingListResponse(UUID memberId, Pageable pageable) {
-        MainTrackingSummary summaries = trackingRepository.findMainTrackingSummaries(memberId, pageable);
+        SliceResult<MainTrackingSummary> summaries = trackingRepository.findMainTrackingSummaries(memberId, pageable);
         return MainTrackingResponse.from(summaries);
     }
 

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherDTO.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherDTO.java
@@ -14,7 +14,43 @@ public record WeatherDTO(
             String temp, // 온도
             SkyType sky,  // 하늘
             PrecipitationType pty, // 강수 상태
-            String pcp // 강수량
+            Double pcp // 강수량
     ) {
+        public static WeatherList fromString(
+                String date,
+                String time,
+                String temp,
+                String sky,
+                String pty,
+                String pcp
+        ) {
+            return new WeatherList(
+                    date,
+                    time,
+                    temp,
+                    SkyType.fromCode(sky),
+                    PrecipitationType.fromCode(pty),
+                    parsePrecipitationMm(pcp)
+            );
+        }
     }
+
+
+    private static Double parsePrecipitationMm(String raw) {
+        if (raw == null || raw.isBlank()
+                || raw.equals("-")
+                || raw.equals("강수없음")
+                || raw.equals("0")) {
+            return 0.0;
+        }
+
+        return switch (raw) {
+            case "1.0mm 미만" -> 0.1;
+            case "30.0~50.0mm" -> 30.0;
+            case "50.0mm 이상" -> 50.0;
+            default -> Double.parseDouble(raw.replace("mm", ""));
+        };
+
+    }
+
 }

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherDTO.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherDTO.java
@@ -45,7 +45,7 @@ public record WeatherDTO(
         }
 
         return switch (raw) {
-            case "1.0mm 미만" -> 0.1;
+            case "1mm 미만" -> 0.1;
             case "30.0~50.0mm" -> 30.0;
             case "50.0mm 이상" -> 50.0;
             default -> Double.parseDouble(raw.replace("mm", ""));

--- a/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherFilterCategory.java
+++ b/src/main/java/org/zerock/puppyrun/weather/DTO/WeatherFilterCategory.java
@@ -10,6 +10,6 @@ public record WeatherFilterCategory(
         String temp,
         String sky,
         String pty,
-        String precipitationAmount
+        String pcp
 ) {
 }

--- a/src/main/java/org/zerock/puppyrun/weather/controller/response/WeatherForecastResponse.java
+++ b/src/main/java/org/zerock/puppyrun/weather/controller/response/WeatherForecastResponse.java
@@ -58,7 +58,7 @@ public record WeatherForecastResponse(
                     .temp(dtoDetail.temp())
                     .sky(dtoDetail.sky().getCode()) // Enum -> Code String 변환
                     .pty(dtoDetail.pty().getCode()) // Enum -> Code String 변환
-                    .pcp(dtoDetail.pcp())
+                    .pcp(dtoDetail.pcp().toString())
                     .build();
         }
     }

--- a/src/main/java/org/zerock/puppyrun/weather/controller/response/WeatherResponse.java
+++ b/src/main/java/org/zerock/puppyrun/weather/controller/response/WeatherResponse.java
@@ -27,7 +27,7 @@ public record WeatherResponse(
                 .temp(weather.temp())
                 .sky(weather.sky().getCode())
                 .pty(weather.pty().getCode())
-                .pcp(weather.pcp())
+                .pcp(weather.pcp().toString())
                 .build();
         return WeatherResponse.builder()
                 .detail(detail)

--- a/src/main/java/org/zerock/puppyrun/weather/scheduler/WeatherStartupInitializer.java
+++ b/src/main/java/org/zerock/puppyrun/weather/scheduler/WeatherStartupInitializer.java
@@ -45,7 +45,6 @@ public class WeatherStartupInitializer {
         }
 
         LocalDateTime requestTime = LocalDateTime.now(WEATHER_ZONE);
-        log.info("[weather 초기화] 서버 가동 시작 1회 초기 수집 실행 (시각={})", requestTime);
         WeatherForecast forecast = new ShortTerm(requestTime);
 
         // DB 조회 후 존재 격자 목록 반환
@@ -65,6 +64,7 @@ public class WeatherStartupInitializer {
                 .filter(gridPoint -> !existGridPoints.contains(gridPoint))
                 .toList();
 
+        log.info("[weather 초기화] 서버 가동 시작 1회 초기 수집 실행 (시각={}, 미확인 지역={})", requestTime, missingRegions.size());
         weatherForecastCollector.collect(forecast, missingRegions)
                 .collectList()
                 .flatMap(resultHandler::processInitial)

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherMapper.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherMapper.java
@@ -116,7 +116,7 @@ public class WeatherMapper {
         if (baseItem == null) {
             throw new ExternalApiParsingException("기준 날씨 아이템이 존재하지 않습니다.");
         }
-        
+
         // 분류 코드를 키로 만들어 필요한 날씨 값을 빠르게 찾습니다.
         Map<String, String> valueMap = groupItems.stream()
                 .collect(Collectors.toMap(
@@ -125,35 +125,14 @@ public class WeatherMapper {
                         (existing, replacement) -> existing
                 ));
 
-        return buildWeatherDetail(
+        return WeatherDTO.WeatherList.fromString(
                 baseItem.fcstDate(),
                 baseItem.fcstTime(),
-                valueMap,
-                category
+                valueMap.get(category.temp()),
+                valueMap.get(category.sky()),
+                valueMap.get(category.pty()),
+                valueMap.get(category.pcp())
         );
     }
 
-    /**
-     * 분류 코드별 문자열 값을 도메인 Enum으로 변환해 상세 날씨 DTO를 생성합니다.
-     */
-    private WeatherDTO.WeatherList buildWeatherDetail(
-            String forecastDate,
-            String forecastTime,
-            Map<String, String> valueMap,
-            WeatherFilterCategory category
-    ) {
-        SkyType skyType = SkyType.fromCode(valueMap.getOrDefault(category.sky(), "-1"));
-        PrecipitationType ptyType = PrecipitationType.fromCode(valueMap.getOrDefault(category.pty(), "-1"));
-        String temp = valueMap.getOrDefault(category.temp(), "-1");
-        String precipitationAmount = valueMap.getOrDefault(category.precipitationAmount(), "-");
-
-        return WeatherDTO.WeatherList.builder()
-                .date(forecastDate)
-                .time(forecastTime)
-                .sky(skyType)
-                .pty(ptyType)
-                .temp(temp)
-                .pcp(precipitationAmount)
-                .build();
-    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,8 +22,6 @@ logging:
   level:
     root: INFO
     org.zerock.puppyrun: DEBUG
-    org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE
 
 
 # 날씨 보상 재시도 지연 TTL

--- a/src/test/java/org/zerock/puppyrun/common/scheduler/WalkingRemindSchedulerTest.java
+++ b/src/test/java/org/zerock/puppyrun/common/scheduler/WalkingRemindSchedulerTest.java
@@ -1,0 +1,38 @@
+package org.zerock.puppyrun.common.scheduler;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.service.NotificationProcessor;
+import org.zerock.puppyrun.notification.service.sender.ReminderSender;
+import org.zerock.puppyrun.notification.scheduler.WalkingRemindScheduler;
+
+@ExtendWith(MockitoExtension.class)
+class WalkingRemindSchedulerTest {
+
+    @Mock
+    private NotificationProcessor notificationProcessor;
+
+    @Mock
+    private ReminderSender reminderSender;
+
+    @InjectMocks
+    private WalkingRemindScheduler walkingRemindScheduler;
+
+    @Test
+    @DisplayName("스케줄 실행 시 데일리 산책 리마인드 발송을 요청한다")
+    void sendDailyWalkingReminder() {
+        // given
+        // when
+        walkingRemindScheduler.sendDailyWalkingReminder();
+
+        // then
+        verify(notificationProcessor).broadcast(NotificationType.DAILY_WALKING_REMINDER, reminderSender);
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/notification/repository/NotificationRepositoryIntegrationTest.java
+++ b/src/test/java/org/zerock/puppyrun/notification/repository/NotificationRepositoryIntegrationTest.java
@@ -53,13 +53,13 @@ class NotificationRepositoryIntegrationTest extends TestContainerConfig {
                 null,
                 PageRequest.of(0, 100),
                 NotificationType.DAILY_WALKING_REMINDER
-        );
+        ).content();
         List<EnabledNotifications> noticeRecipients = notificationRepository.findNextMembers(
                 null,
                 null,
                 PageRequest.of(0, 100),
                 NotificationType.NOTICE
-        );
+        ).content();
 
         // then
         assertThat(dailyRecipients)
@@ -89,7 +89,7 @@ class NotificationRepositoryIntegrationTest extends TestContainerConfig {
                 null,
                 PageRequest.of(0, 100),
                 NotificationType.DAILY_WALKING_REMINDER
-        );
+        ).content();
 
         // then
         assertThat(deactivatedCount).isEqualTo(1);

--- a/src/test/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepositoryIntegrationTest.java
+++ b/src/test/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepositoryIntegrationTest.java
@@ -1,0 +1,71 @@
+package org.zerock.puppyrun.notification.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.zerock.puppyrun.a_config.TestContainerConfig;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.notification.entity.WalkingPreference;
+
+class WalkingPreferenceRepositoryIntegrationTest extends TestContainerConfig {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private WalkingPreferenceRepository walkingPreferenceRepository;
+
+    @Test
+    @DisplayName("회원과 분석일로 조회하면 해당 날짜의 산책 선호 시간 결과만 반환한다")
+    void findAllByMemberIdInAndAnalysisDate() {
+        // given
+        Member member = Member.builder()
+                .email("walking-preference@test.com")
+                .nickName("walking-preference")
+                .password("encoded-password")
+                .build();
+        entityManager.persist(member);
+        LocalDate analysisDate = LocalDate.of(2026, 8, 14);
+        walkingPreferenceRepository.saveAll(List.of(
+                preference(member, analysisDate, LocalTime.of(18, 0), 10),
+                preference(member, analysisDate.minusDays(1), LocalTime.of(8, 0), 4)
+        ));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<WalkingPreference> preferences = walkingPreferenceRepository
+                .findAllByMemberIdInAndAnalysisDate(List.of(member.getId()), analysisDate);
+
+        // then
+        assertThat(preferences)
+                .singleElement()
+                .satisfies(preference -> {
+                    assertThat(preference.getAnalysisDate()).isEqualTo(analysisDate);
+                    assertThat(preference.getWeekdayTime()).isEqualTo(LocalTime.of(18, 0));
+                    assertThat(preference.getWeekdayScore()).isEqualTo(10);
+                });
+    }
+
+    private WalkingPreference preference(
+            Member member,
+            LocalDate analysisDate,
+            LocalTime weekdayTime,
+            int weekdayScore
+    ) {
+        return WalkingPreference.builder()
+                .id(UUID.randomUUID())
+                .member(member)
+                .analysisDate(analysisDate)
+                .weekdayTime(weekdayTime)
+                .weekdayScore(weekdayScore)
+                .build();
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/notification/service/NotificationProcessorTest.java
+++ b/src/test/java/org/zerock/puppyrun/notification/service/NotificationProcessorTest.java
@@ -1,0 +1,115 @@
+package org.zerock.puppyrun.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.zerock.puppyrun.common.pagination.SliceResult;
+import org.zerock.puppyrun.notification.client.NotificationEventClient;
+import org.zerock.puppyrun.notification.client.DTO.PushTask;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+import org.zerock.puppyrun.notification.repository.NotificationRepository;
+import org.zerock.puppyrun.notification.service.sender.Sender;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationProcessorTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationEventClient notificationEventClient;
+
+    @Mock
+    private Sender sender;
+
+    @InjectMocks
+    private NotificationProcessor notificationProcessor;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    @DisplayName("다음 페이지 확인용 추가 한 명은 다음 조회로 넘기고 정확히 페이지 크기만 발송한다")
+    void broadcastSendsOnlyPageSizeWhenMoreRecipientsExist() {
+        // given
+        List<EnabledNotifications> firstPage = IntStream.range(0, 1_000)
+                .mapToObj(this::recipient)
+                .toList();
+        EnabledNotifications remainingRecipient = recipient(1_001);
+        PushTask pushTask = org.mockito.Mockito.mock(PushTask.class);
+        given(notificationRepository.findNextMembers(any(), any(), any(Pageable.class), any()))
+                .willReturn(
+                        new SliceResult<>(firstPage, true),
+                        new SliceResult<>(List.of(remainingRecipient), false)
+                );
+        given(sender.createPushTasks(any()))
+                .willAnswer(invocation -> {
+                    List<EnabledNotifications> recipients = invocation.getArgument(0);
+                    return java.util.Collections.nCopies(recipients.size(), pushTask);
+                });
+
+        // when
+        notificationProcessor.broadcast(
+                NotificationType.DAILY_WALKING_REMINDER,
+                sender
+        );
+
+        // then
+        ArgumentCaptor<List<PushTask>> pushTasksCaptor = pushTaskListCaptor();
+        verify(notificationEventClient, times(2)).sendMessagesInBulk(pushTasksCaptor.capture());
+        assertThat(pushTasksCaptor.getAllValues())
+                .extracting(List::size)
+                .containsExactly(1_000, 1);
+        verify(notificationRepository).findNextMembers(
+                eq(firstPage.get(999).createdAt()),
+                eq(firstPage.get(999).memberId()),
+                any(Pageable.class),
+                eq(NotificationType.DAILY_WALKING_REMINDER)
+        );
+    }
+
+    @Test
+    @DisplayName("대상자 조회 예외는 호출자에게 전파한다")
+    void broadcastPropagatesRecipientQueryFailure() {
+        // given
+        given(notificationRepository.findNextMembers(any(), any(), any(Pageable.class), any()))
+                .willThrow(new IllegalStateException("database unavailable"));
+
+        // when & then
+        assertThatThrownBy(() -> notificationProcessor.broadcast(
+                NotificationType.DAILY_WALKING_REMINDER,
+                sender
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessage("database unavailable");
+    }
+
+    private EnabledNotifications recipient(int index) {
+        return EnabledNotifications.builder()
+                .memberId(UUID.randomUUID())
+                .type(NotificationType.DAILY_WALKING_REMINDER)
+                .fcmToken("fcm-token-" + index)
+                .createdAt(LocalDateTime.of(2026, 8, 18, 20, 0).plusNanos(index))
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ArgumentCaptor<List<PushTask>> pushTaskListCaptor() {
+        return ArgumentCaptor.forClass(List.class);
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/notification/service/WalkingPreferenceServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/notification/service/WalkingPreferenceServiceTest.java
@@ -1,0 +1,193 @@
+package org.zerock.puppyrun.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.notification.entity.WalkingPreference;
+import org.zerock.puppyrun.notification.repository.WalkingPreferenceRepository;
+import org.zerock.puppyrun.tracking.entity.Tracking;
+import org.zerock.puppyrun.tracking.entity.TrackingRoute;
+import org.zerock.puppyrun.tracking.entity.RoutePoint;
+import org.zerock.puppyrun.tracking.repository.TrackingRepository;
+import org.zerock.puppyrun.tracking.repository.TrackingRouteRepository;
+
+@ExtendWith(MockitoExtension.class)
+class WalkingPreferenceServiceTest {
+
+    @Mock
+    private TrackingRepository trackingRepository;
+
+    @Mock
+    private TrackingRouteRepository trackingRouteRepository;
+
+    @Mock
+    private WalkingPreferenceRepository walkingPreferenceRepository;
+
+    @InjectMocks
+    private WalkingPreferenceService walkingPreferenceService;
+
+    @Test
+    @DisplayName("최근 4주 산책 기록을 주차별 가중치로 합산해 평일 선호 시간 스냅샷을 적재한다")
+    void createDailySnapshotsScoresAllWeeklyBoundaries() {
+        // given
+        LocalDateTime analysisAt = LocalDateTime.of(2026, 8, 14, 3, 0);
+        UUID memberId = UUID.randomUUID();
+        Member member = member(memberId);
+        List<Tracking> trackings = List.of(
+                tracking(member, LocalDateTime.of(2026, 8, 13, 18, 0)),
+                tracking(member, LocalDateTime.of(2026, 8, 7, 18, 0)),
+                tracking(member, LocalDateTime.of(2026, 7, 31, 18, 0)),
+                tracking(member, LocalDateTime.of(2026, 7, 24, 18, 0))
+        );
+        given(trackingRepository.findActiveMemberIds(any(), any(), any(Pageable.class)))
+                .willReturn(List.of(memberId));
+        given(trackingRepository.findAllByMemberIdsAndDateRange(any(), any(), any()))
+                .willReturn(trackings);
+        given(walkingPreferenceRepository.findAllByMemberIdInAndAnalysisDate(
+                any(),
+                any(LocalDate.class)
+        )).willReturn(List.of());
+
+        // when
+        walkingPreferenceService.createDailySnapshots(analysisAt);
+
+        // then
+        WalkingPreference snapshot = savedSnapshot();
+        assertThat(snapshot.getAnalysisDate()).isEqualTo(analysisAt.toLocalDate());
+        assertThat(snapshot.getWeekdayTime()).isEqualTo(LocalTime.of(18, 0));
+        assertThat(snapshot.getWeekdayScore()).isEqualTo(10);
+        assertThat(snapshot.getWeekendTime()).isNull();
+        assertThat(snapshot.getWeekendScore()).isNull();
+    }
+
+    @Test
+    @DisplayName("동점인 시간대는 가장 최근 산책한 시간대를 선호 시간으로 선정한다")
+    void createDailySnapshotsPrefersMostRecentBucketWhenScoresAreTied() {
+        // given
+        LocalDateTime analysisAt = LocalDateTime.of(2026, 8, 14, 3, 0);
+        UUID memberId = UUID.randomUUID();
+        Member member = member(memberId);
+        List<Tracking> trackings = List.of(
+                tracking(member, LocalDateTime.of(2026, 8, 13, 8, 0)),
+                tracking(member, LocalDateTime.of(2026, 7, 31, 18, 0)),
+                tracking(member, LocalDateTime.of(2026, 7, 24, 18, 0)),
+                tracking(member, LocalDateTime.of(2026, 7, 17, 18, 0))
+        );
+        given(trackingRepository.findActiveMemberIds(any(), any(), any(Pageable.class)))
+                .willReturn(List.of(memberId));
+        given(trackingRepository.findAllByMemberIdsAndDateRange(any(), any(), any()))
+                .willReturn(trackings);
+        given(walkingPreferenceRepository.findAllByMemberIdInAndAnalysisDate(
+                any(),
+                any(LocalDate.class)
+        )).willReturn(List.of());
+
+        // when
+        walkingPreferenceService.createDailySnapshots(analysisAt);
+
+        // then
+        WalkingPreference snapshot = savedSnapshot();
+        assertThat(snapshot.getWeekdayTime()).isEqualTo(LocalTime.of(8, 0));
+        assertThat(snapshot.getWeekdayScore()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("가장 최근 산책 경로의 마지막 좌표와 산책 날짜를 스냅샷에 저장한다")
+    void createDailySnapshotsStoresLastWalkingLocation() {
+        // given
+        LocalDateTime analysisAt = LocalDateTime.of(2026, 8, 14, 3, 0);
+        UUID memberId = UUID.randomUUID();
+        Member member = member(memberId);
+        Tracking latestTracking = tracking(member, LocalDateTime.of(2026, 8, 13, 18, 0));
+        UUID trackingId = latestTracking.getId();
+        TrackingRoute route = mock(TrackingRoute.class);
+        given(route.getTrackingId()).willReturn(trackingId);
+        given(route.getOriginalPath()).willReturn(List.of(
+                new RoutePoint(37.5665, 126.9780, 0),
+                new RoutePoint(37.5670, 126.9790, 600)
+        ));
+        given(trackingRepository.findActiveMemberIds(any(), any(), any(Pageable.class)))
+                .willReturn(List.of(memberId));
+        given(trackingRepository.findAllByMemberIdsAndDateRange(any(), any(), any()))
+                .willReturn(List.of(latestTracking));
+        given(walkingPreferenceRepository.findAllByMemberIdInAndAnalysisDate(
+                any(),
+                any(LocalDate.class)
+        )).willReturn(List.of());
+        given(trackingRouteRepository.findAllByTrackingIdIn(any())).willReturn(List.of(route));
+
+        // when
+        walkingPreferenceService.createDailySnapshots(analysisAt);
+
+        // then
+        WalkingPreference snapshot = savedSnapshot();
+        assertThat(snapshot.getLastKnownLatitude()).isEqualTo(37.5670);
+        assertThat(snapshot.getLastKnownLongitude()).isEqualTo(126.9790);
+        assertThat(snapshot.getLastKnownDate()).isEqualTo(LocalDate.of(2026, 8, 13));
+    }
+
+    @Test
+    @DisplayName("같은 회원의 같은 분석일 스냅샷이 있으면 재실행해도 중복 적재하지 않는다")
+    void createDailySnapshotsSkipsMemberWithExistingSnapshot() {
+        // given
+        LocalDateTime analysisAt = LocalDateTime.of(2026, 8, 14, 3, 0);
+        UUID memberId = UUID.randomUUID();
+        Member member = member(memberId);
+        WalkingPreference existing = WalkingPreference.builder()
+                .member(member)
+                .analysisDate(analysisAt.toLocalDate())
+                .build();
+        given(trackingRepository.findActiveMemberIds(any(), any(), any(Pageable.class)))
+                .willReturn(List.of(memberId));
+        given(walkingPreferenceRepository.findAllByMemberIdInAndAnalysisDate(
+                any(),
+                any(LocalDate.class)
+        )).willReturn(List.of(existing));
+
+        // when
+        walkingPreferenceService.createDailySnapshots(analysisAt);
+
+        // then
+        verify(walkingPreferenceRepository, never()).saveAll(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private WalkingPreference savedSnapshot() {
+        ArgumentCaptor<Iterable<WalkingPreference>> captor = ArgumentCaptor.forClass(Iterable.class);
+        verify(walkingPreferenceRepository).saveAll(captor.capture());
+        return captor.getValue().iterator().next();
+    }
+
+    private Member member(UUID memberId) {
+        Member member = mock(Member.class);
+        given(member.getId()).willReturn(memberId);
+        return member;
+    }
+
+    private Tracking tracking(Member member, LocalDateTime startedAt) {
+        Tracking tracking = mock(Tracking.class);
+        lenient().when(tracking.getId()).thenReturn(UUID.randomUUID());
+        given(tracking.getMember()).willReturn(member);
+        given(tracking.getStartedAt()).willReturn(startedAt);
+        return tracking;
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/tracking/repository/MainTrackingQueryRepositoryTest.java
+++ b/src/test/java/org/zerock/puppyrun/tracking/repository/MainTrackingQueryRepositoryTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.zerock.puppyrun.a_config.TestContainerConfig;
+import org.zerock.puppyrun.common.pagination.SliceResult;
 import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.tracking.DTO.MainTrackingSummary;
 import org.zerock.puppyrun.tracking.entity.RoutePoint;
@@ -63,19 +64,22 @@ class MainTrackingQueryRepositoryTest extends TestContainerConfig {
 
         // when
         org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(0, 10);
-        MainTrackingSummary summaryResult = trackingRepository.findMainTrackingSummaries(member.getId(), pageable);
-        List<MainTrackingSummary.TrackingSummary> summaries = summaryResult.trackingSummaries();
+        SliceResult<MainTrackingSummary> summaryResult = trackingRepository.findMainTrackingSummaries(
+                member.getId(),
+                pageable
+        );
+        List<MainTrackingSummary> summaries = summaryResult.content();
 
         // then
         assertThat(statistics.getPrepareStatementCount()).isEqualTo(1L);
         assertThat(summaries).hasSize(2);
 
-        MainTrackingSummary.TrackingSummary latestSummary = summaries.getFirst();
+        MainTrackingSummary latestSummary = summaries.getFirst();
         assertThat(latestSummary.trackingId()).isEqualTo(latestTracking.getId());
         assertThat(latestSummary.featuredImage()).isEqualTo("tracking/featured.jpg");
         assertThat(latestSummary.path()).containsExactlyElementsOf(latestPath);
 
-        MainTrackingSummary.TrackingSummary olderSummary = summaries.getLast();
+        MainTrackingSummary olderSummary = summaries.getLast();
         assertThat(olderSummary.trackingId()).isEqualTo(olderTracking.getId());
         assertThat(olderSummary.featuredImage()).isNull();
         assertThat(olderSummary.path())

--- a/src/test/java/org/zerock/puppyrun/weather/WeatherQueryServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/weather/WeatherQueryServiceTest.java
@@ -10,6 +10,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -256,14 +257,14 @@ class WeatherQueryServiceTest {
     }
 
     private WeatherDTO weatherWithTemp(String date, String temp, String... times) {
-        List<WeatherDTO.WeatherList> forecasts = List.of(times).stream()
+        List<WeatherDTO.WeatherList> forecasts = Stream.of(times)
                 .map(time -> new WeatherDTO.WeatherList(
                         date,
                         time,
                         temp,
                         SkyType.SUNNY,
                         PrecipitationType.NONE,
-                        "강수없음"
+                        0.0
                 ))
                 .toList();
         return new WeatherDTO(forecasts);
@@ -276,7 +277,7 @@ class WeatherQueryServiceTest {
                 temp,
                 SkyType.SUNNY,
                 PrecipitationType.NONE,
-                "강수없음"
+                0.0
         );
     }
 }

--- a/src/testFixtures/java/org/zerock/puppyrun/fixture/weather/WeatherFixture.java
+++ b/src/testFixtures/java/org/zerock/puppyrun/fixture/weather/WeatherFixture.java
@@ -39,7 +39,7 @@ public class WeatherFixture {
                         "25",
                         SkyType.SUNNY,
                         PrecipitationType.NONE,
-                        "강수없음"
+                        0.0
                 )
         ));
     }


### PR DESCRIPTION
# 📌 Pull Request: #41 사용자 맞춤 알림 및 산책 선호도 분석

# 📝 작업 요약 (Summary)

회원의 최근 산책 기록을 분석해 평일·주말 선호 산책 시간과 마지막 산책 위치를 일별 스냅샷으로 적재했습니다. 이 데이터를 개인화 알림의 기반으로 만들고, 대량 알림 발송과 메인 산책 목록 조회에는 공통 Slice 계약을 적용해 청크 경계와 다음 페이지 판단을 일관되게 처리합니다.

날씨 강수량도 문자열이 아닌 수치(`Double`, mm)로 정규화해 이후 날씨 추천·비교 로직에서 사용할 수 있게 했습니다.

> **DB 영향**: `walking_preference`는 회원·분석일 조합을 유니크하게 보장하며, 평일·주말 선호 시간·점수와 마지막 산책 위치·일자를 저장합니다.

# 🛠️ 변경 사항 (Changes)

## 1. 산책 선호도 스냅샷 분석

- 최근 28일 산책 기록을 2시간 단위 버킷으로 분류합니다.
- 최근 1주부터 4주까지 4·3·2·1점의 가중치를 적용해 평일·주말별 선호 시간을 계산합니다.
- 최신 산책 경로의 마지막 위도·경도와 산책일을 스냅샷에 저장합니다.
- 회원 ID 300개 단위로 분석하며, 같은 회원·분석일 스냅샷은 다시 만들지 않습니다.
- 회원별 버킷 점수, 선택 시간과 점수를 디버그 로그로 남깁니다.
- 매일 03:00에 정기 실행하며 개발 환경에서는 `GET /test/preferences`로 수동 실행할 수 있습니다.

### 산책 선호도 스냅샷 생성

```mermaid
sequenceDiagram
    autonumber
    participant Dev as 개발자(선택)
    participant DevAPI as PreferenceController
    participant Scheduler as WalkingPreferenceScheduler
    participant Service as WalkingPreferenceService
    participant TrackingRepo as TrackingRepository
    participant RouteRepo as TrackingRouteRepository
    participant PreferenceRepo as WalkingPreferenceRepository

    opt 개발 환경 수동 실행
        Dev->>DevAPI: GET /test/preferences
        DevAPI->>Scheduler: scheduledPreferenceUpdate()
    end

    Note over Scheduler: 매일 03:00 정기 실행
    Scheduler->>Service: createDailySnapshots(analysisAt)
    loop 회원 300명 청크마다
        Service->>TrackingRepo: 최근 28일 활동 회원 ID 조회
        Service->>PreferenceRepo: 회원별 당일 스냅샷 존재 여부 조회
        Service->>TrackingRepo: 미분석 회원의 산책 기록 일괄 조회
        Service->>RouteRepo: 최신 산책의 경로 일괄 조회
        Service->>Service: 평일/주말 버킷 점수와 선호 시간 계산
        alt 산책 기록이 있음
            Service->>PreferenceRepo: 선호 시간·점수·마지막 위치 저장
        else 산책 기록이 없음
            Service-->>Service: 회원 제외 로그 기록
        end
    end
```

## 2. 개인화 알림 발송과 공통 Slice 계약

- `SliceResult<T>`를 추가해 `content`와 `hasNext`를 공통으로 전달합니다.
- Repository가 `pageSize + 1`을 내부에서 조회하고, 실제 반환 목록은 정확히 1,000명으로 제한합니다.
- `NotificationProcessor`는 실제 발송한 마지막 회원의 생성 시각·회원 ID를 다음 커서로 사용합니다.
- 외부 `@Async` 위임은 제거하고, FCM 클라이언트의 비동기 배치 발송은 유지합니다.
- 메인 산책 목록 조회도 같은 Slice 계약을 사용합니다.

### 일일 개인화 알림 발송

```mermaid
sequenceDiagram
    autonumber
    participant Scheduler as WalkingRemindScheduler
    participant Processor as NotificationProcessor
    participant NotiRepo as NotificationRepository
    participant Sender as ReminderSender
    participant TrackingRepo as TrackingRepository
    participant FCM as NotificationEventClient

    Note over Scheduler: 매일 20:00 정기 실행
    Scheduler->>Processor: broadcast(DAILY_WALKING_REMINDER, sender)
    loop 다음 페이지가 있는 동안
        Processor->>NotiRepo: 활성·동의·미거부 수신자 조회 (커서, 1,001명)
        NotiRepo-->>Processor: SliceResult(최대 1,000명, hasNext)
        alt 수신자가 없음
            Processor-->>Scheduler: 발송 종료
        else 수신자가 있음
            Processor->>Sender: createPushTasks(수신자 청크)
            Sender->>TrackingRepo: 당일 산책 통계 일괄 조회
            Sender-->>Processor: 회원별 TokenPushTask
            Processor->>FCM: sendMessagesInBulk(tasks)
            FCM-->>FCM: FCM 비동기 배치 발송
            Processor->>Processor: 실제 발송 청크 마지막 회원으로 커서 이동
        end
    end
```

## 3. 날씨 강수량 수치화 및 초기화 보완

- `WeatherDTO.WeatherList.pcp`를 `String`에서 `Double` 밀리미터 값으로 변경했습니다.
- `강수없음`, `-`, `1mm 미만`, 범위형 강수량 등 기상청 표현을 숫자로 변환합니다.
- WeatherMapper, 날씨 응답, Fixture와 테스트를 수치 강수량에 맞춰 갱신했습니다.
- 개발 환경의 불필요한 Hibernate SQL·바인딩 로그 설정을 제거했습니다.

### 기상청 강수량 변환

```mermaid
sequenceDiagram
    autonumber
    participant API as 기상청 예보 응답
    participant Mapper as WeatherMapper
    participant DTO as WeatherDTO.WeatherList
    participant Consumer as 날씨 조회/응답 로직

    API-->>Mapper: PCP 문자열 (예: 6.2mm, 1mm 미만, 강수없음)
    Mapper->>DTO: fromString(..., pcp)
    DTO->>DTO: 문자열을 Double(mm)로 변환
    DTO-->>Mapper: 수치 강수량 포함 WeatherList
    Mapper-->>Consumer: WeatherDTO 반환
```
