### PR TITLE
feat: 날씨 기반 산책 시간 추천 알림

### DIFF
--- a/src/main/java/org/zerock/puppyrun/notification/entity/NotificationType.java
+++ b/src/main/java/org/zerock/puppyrun/notification/entity/NotificationType.java
@@ -15,6 +15,7 @@ public enum NotificationType {
     // 활동/산책 (ACT)
     DAILY_WALKING_REMINDER("ACT_001", Priority.HIGH, "일일 산책 리마인더"),
     WALK_GOAL_ACHIEVED("ACT_002", Priority.NORMAL, "주간 산책 목표 달성"),
+    RECOMMEND_TIME_REMINDER("ACT_003", Priority.NORMAL, "산책 시간 추천"),
 
     //  마케팅/이벤트 (MKT)
     EVENT_PROMO("MKT_001", Priority.NORMAL, "이벤트 및 프로모션 안내");

--- a/src/main/java/org/zerock/puppyrun/notification/entity/UserSelectedWalkingTime.java
+++ b/src/main/java/org/zerock/puppyrun/notification/entity/UserSelectedWalkingTime.java
@@ -1,0 +1,56 @@
+package org.zerock.puppyrun.notification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.zerock.puppyrun.common.entity.BaseEntity;
+import org.zerock.puppyrun.member.entity.Member;
+
+/** 회원이 직접 선택한 날씨 추천 산책 시간과 위치입니다. */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_selected_walking_time")
+public class UserSelectedWalkingTime extends BaseEntity {
+
+    @Id
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
+    private Member member;
+
+    @Column(nullable = false)
+    private LocalTime time;
+
+    @Column(nullable = false)
+    private Double latitude;
+
+    @Column(nullable = false)
+    private Double longitude;
+
+    @Builder
+    public UserSelectedWalkingTime(UUID id, Member member, LocalTime time, Double latitude, Double longitude) {
+        this.id = id != null ? id : UUID.randomUUID();
+        this.member = member;
+        this.time = time;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public void update(LocalTime time, Double latitude, Double longitude) {
+        this.time = time;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/repository/UserSelectedWalkingTimeRepository.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/UserSelectedWalkingTimeRepository.java
@@ -1,0 +1,12 @@
+package org.zerock.puppyrun.notification.repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zerock.puppyrun.notification.entity.UserSelectedWalkingTime;
+
+public interface UserSelectedWalkingTimeRepository extends JpaRepository<UserSelectedWalkingTime, UUID> {
+
+    List<UserSelectedWalkingTime> findAllByMemberIdIn(Collection<UUID> memberIds);
+}

--- a/src/main/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepoCustom.java
@@ -1,0 +1,22 @@
+package org.zerock.puppyrun.notification.repository;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.zerock.puppyrun.notification.entity.WalkingPreference;
+
+/**
+ * 산책 선호도 스냅샷의 조회 조건을 담당합니다.
+ */
+public interface WalkingPreferenceRepoCustom {
+
+    /**
+     * 지정한 회원의 기준 시각 범위 내 산책 선호도 스냅샷을 조회합니다.
+     */
+    List<WalkingPreference> findByMemberIdsAndCreatedAtBetween(
+            Collection<UUID> memberIds,
+            LocalDateTime from,
+            LocalDateTime to
+    );
+}

--- a/src/main/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepoCustomImpl.java
@@ -1,0 +1,38 @@
+package org.zerock.puppyrun.notification.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.notification.entity.WalkingPreference;
+
+import static org.zerock.puppyrun.notification.entity.QWalkingPreference.walkingPreference;
+
+/**
+ * 산책 선호도 스냅샷 Querydsl 구현체입니다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class WalkingPreferenceRepoCustomImpl implements WalkingPreferenceRepoCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<WalkingPreference> findByMemberIdsAndCreatedAtBetween(
+            Collection<UUID> memberIds,
+            LocalDateTime from,
+            LocalDateTime to
+    ) {
+        return queryFactory
+                .selectFrom(walkingPreference)
+                .where(
+                        walkingPreference.member.id.in(memberIds),
+                        walkingPreference.createdAt.between(from, to)
+                )
+                .orderBy(walkingPreference.createdAt.desc(), walkingPreference.id.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepository.java
+++ b/src/main/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepository.java
@@ -10,10 +10,11 @@ import org.zerock.puppyrun.notification.entity.WalkingPreference;
 /**
  * 회원별 산책 선호도 영속화를 담당합니다.
  */
-public interface WalkingPreferenceRepository extends JpaRepository<WalkingPreference, UUID> {
+public interface WalkingPreferenceRepository extends JpaRepository<WalkingPreference, UUID>, WalkingPreferenceRepoCustom {
 
     List<WalkingPreference> findAllByMemberIdInAndAnalysisDate(
             Collection<UUID> memberIds,
             LocalDate analysisDate
     );
+
 }

--- a/src/main/java/org/zerock/puppyrun/notification/scheduler/RecommendedWeatherNotification.java
+++ b/src/main/java/org/zerock/puppyrun/notification/scheduler/RecommendedWeatherNotification.java
@@ -1,0 +1,39 @@
+package org.zerock.puppyrun.notification.scheduler;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.service.NotificationProcessor;
+import org.zerock.puppyrun.notification.service.sender.SnapshotWeatherRecommendSender;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RecommendedWeatherNotification {
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final NotificationProcessor notificationProcessor;
+    private final SnapshotWeatherRecommendSender weatherRecommendSender;
+
+    @Scheduled(cron = "0 0 9 * * *")
+    public void sendRecommendedWeatherNotification() {
+        LocalDateTime now = LocalDateTime.now(KOREA_ZONE);
+        log.info("event=weather_recommendation_started, startedAt={}", now);
+        try {
+            notificationProcessor.broadcast(
+                    NotificationType.RECOMMEND_TIME_REMINDER,
+                    weatherRecommendSender
+            );
+        } catch (Exception exception) {
+            log.error(
+                    "event=weather_recommendation_failed, exceptionType={}",
+                    exception.getClass().getSimpleName(),
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/sender/SnapshotWeatherRecommendSender.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/sender/SnapshotWeatherRecommendSender.java
@@ -1,0 +1,94 @@
+package org.zerock.puppyrun.notification.service.sender;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.zerock.puppyrun.notification.client.DTO.PushTask;
+import org.zerock.puppyrun.notification.entity.WalkingPreference;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+import org.zerock.puppyrun.notification.repository.WalkingPreferenceRepository;
+
+/**
+ * 최근 7일 산책 스냅샷을 기준으로 추천 시간을 정하는 Sender입니다.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SnapshotWeatherRecommendSender implements Sender {
+
+    private static final int PREFERENCE_VALID_DAYS = 7;
+    private static final java.time.ZoneId KOREA_ZONE = java.time.ZoneId.of("Asia/Seoul");
+
+    private final WalkingPreferenceRepository walkingPreferenceRepository;
+    private final WeatherRecommendationMessageComposer weatherRecommendationMessageComposer;
+
+    @Override
+    public List<PushTask> createPushTasks(List<EnabledNotifications> memberSettings) {
+        if (memberSettings == null || memberSettings.isEmpty()) {
+            return List.of();
+        }
+
+        // 추천 시간은 발송 시점의 평일/주말 여부로 결정한다.
+        LocalDateTime referenceTime = LocalDateTime.now(KOREA_ZONE);
+
+        // NotificationProcessor가 조회한 현재 청크의 회원만 한 번에 스냅샷으로 조회한다.
+        List<UUID> memberIds = memberSettings.stream().map(EnabledNotifications::memberId).toList();
+
+        List<WeatherRecommendationTarget> targets = findTargets(memberIds, referenceTime);
+
+        log.info("event=snapshot_weather_recommendation_targets_resolved, recipientCount={}, targetCount={}",
+                memberSettings.size(), targets.size());
+
+        // 날씨 조회와 TokenPushTask 생성은 두 추천 정책이 공유하는 Composer에 위임한다.
+        return weatherRecommendationMessageComposer.createPushTasks(memberSettings, targets, referenceTime);
+    }
+
+    private List<WeatherRecommendationTarget> findTargets(List<UUID> memberIds, LocalDateTime referenceTime) {
+        List<UUID> distinctMemberIds = memberIds.stream().filter(Objects::nonNull).distinct().toList();
+
+        // 7일 이내 스냅샷만 허용한다. 오래된 산책 패턴은 추천 근거로 사용하지 않는다.
+        Map<UUID, WalkingPreference> latestByMemberId = walkingPreferenceRepository
+                .findByMemberIdsAndCreatedAtBetween(
+                        distinctMemberIds, referenceTime.minusDays(PREFERENCE_VALID_DAYS), referenceTime)
+                .stream()
+                .collect(Collectors.toMap(
+                        preference -> preference.getMember().getId(), Function.identity(), this::latestOf));
+        boolean weekend = isWeekend(referenceTime.getDayOfWeek());
+
+        return distinctMemberIds.stream()
+                // 스냅샷이 없거나 해당 요일의 선호 시간이 없으면 알림 대상에서 제외된다.
+                .map(memberId -> toTarget(memberId, latestByMemberId.get(memberId), weekend))
+                .flatMap(java.util.Optional::stream)
+                .toList();
+    }
+
+    private WalkingPreference latestOf(WalkingPreference first, WalkingPreference second) {
+        return Comparator.comparing(WalkingPreference::getCreatedAt).thenComparing(WalkingPreference::getId)
+                .compare(first, second) >= 0 ? first : second;
+    }
+
+    private java.util.Optional<WeatherRecommendationTarget> toTarget(
+            UUID memberId, WalkingPreference preference, boolean weekend
+    ) {
+        if (preference == null) {
+            return java.util.Optional.empty();
+        }
+        LocalTime time = weekend ? preference.getWeekendTime() : preference.getWeekdayTime();
+        return time == null ? java.util.Optional.empty() : java.util.Optional.of(new WeatherRecommendationTarget(
+                memberId, preference.getLastKnownLatitude(), preference.getLastKnownLongitude(), time));
+    }
+
+    private boolean isWeekend(DayOfWeek dayOfWeek) {
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/sender/UserSelectedWeatherRecommendSender.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/sender/UserSelectedWeatherRecommendSender.java
@@ -1,0 +1,55 @@
+package org.zerock.puppyrun.notification.service.sender;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.zerock.puppyrun.notification.client.DTO.PushTask;
+import org.zerock.puppyrun.notification.entity.UserSelectedWalkingTime;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+import org.zerock.puppyrun.notification.repository.UserSelectedWalkingTimeRepository;
+
+/**
+ * 회원이 직접 저장한 산책 시간을 기준으로 추천 시간을 정하는 Sender입니다.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class UserSelectedWeatherRecommendSender implements Sender {
+
+    private final UserSelectedWalkingTimeRepository userSelectedWalkingTimeRepository;
+    private final WeatherRecommendationMessageComposer weatherRecommendationMessageComposer;
+
+
+    @Override
+    public List<PushTask> createPushTasks(List<EnabledNotifications> memberSettings) {
+        if (memberSettings == null || memberSettings.isEmpty()) {
+            return List.of();
+        }
+
+        LocalDateTime referenceTime = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul"));
+        // 사용자 선택값은 회원당 한 건으로 저장되어 있으므로 현재 청크의 회원 ID로 일괄 조회한다.
+        List<UUID> memberIds = memberSettings.stream().map(EnabledNotifications::memberId).toList();
+        List<WeatherRecommendationTarget> targets = userSelectedWalkingTimeRepository
+                .findAllByMemberIdIn(memberIds)
+                .stream()
+                // 선택 시간 또는 위치를 저장하지 않은 회원은 조회 결과에 없으므로 자동으로 제외된다.
+                .map(this::toTarget)
+                .toList();
+        log.info("event=user_selected_weather_recommendation_targets_resolved, recipientCount={}, targetCount={}",
+                memberSettings.size(), targets.size());
+        // 사용자 선택값의 출처와 무관하게 날씨, 메시지 생성 규칙은 Composer와 공유한다.
+        return weatherRecommendationMessageComposer.createPushTasks(memberSettings, targets, referenceTime);
+    }
+
+    private WeatherRecommendationTarget toTarget(UserSelectedWalkingTime selection) {
+        return new WeatherRecommendationTarget(
+                selection.getMember().getId(),
+                selection.getLatitude(),
+                selection.getLongitude(),
+                selection.getTime()
+        );
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/sender/WeatherRecommendationMessageComposer.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/sender/WeatherRecommendationMessageComposer.java
@@ -1,0 +1,118 @@
+package org.zerock.puppyrun.notification.service.sender;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.puppyrun.notification.client.DTO.PushTask;
+import org.zerock.puppyrun.notification.client.DTO.TokenPushTask;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+import org.zerock.puppyrun.weather.DTO.GridPoint;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+import org.zerock.puppyrun.weather.DTO.WeatherRegion;
+import org.zerock.puppyrun.weather.service.WeatherQueryService;
+import org.zerock.puppyrun.weather.utils.WeatherRegionCatalog;
+
+/**
+ * 시간 출처와 무관하게 날씨 추천 TokenPushTask를 생성하는 Bean입니다.
+ */
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class WeatherRecommendationMessageComposer {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+    private static final int FORECAST_HOURS = 3;
+
+    private final WeatherRegionCatalog weatherRegionCatalog;
+    private final WeatherQueryService weatherQueryService;
+
+    public List<PushTask> createPushTasks(
+            List<EnabledNotifications> memberSettings,
+            List<WeatherRecommendationTarget> targets,
+            LocalDateTime referenceTime
+    ) {
+        if (memberSettings.isEmpty() || targets.isEmpty()) {
+            return List.of();
+        }
+        Map<UUID, WeatherRecommendationTarget> targetByMemberId = targets.stream()
+                .collect(Collectors.toMap(WeatherRecommendationTarget::memberId, Function.identity(),
+                        (first, ignored) -> first));
+        Map<WeatherRequest, Optional<WeatherDTO>> weatherCache = new HashMap<>();
+        return memberSettings.stream()
+                .map(member -> createTask(member, targetByMemberId.get(member.memberId()), referenceTime, weatherCache))
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    private Optional<PushTask> createTask(
+            EnabledNotifications member, WeatherRecommendationTarget target,
+            LocalDateTime referenceTime, Map<WeatherRequest, Optional<WeatherDTO>> weatherCache
+    ) {
+        if (target == null || target.latitude() == null || target.longitude() == null) {
+            return Optional.empty();
+        }
+        WeatherRegion region = weatherRegionCatalog.findNearestRegion(target.latitude(), target.longitude());
+
+        WeatherRequest request = new WeatherRequest(new GridPoint(region.nx(), region.ny()),
+                forecastStartTime(target, referenceTime));
+
+        Optional<WeatherDTO> weather = weatherCache.computeIfAbsent(request, this::findForecast);
+
+        return weather.map(value -> new TokenPushTask(
+                        member.fcmToken(),
+                        member.type(),
+                        "산책하기 좋은 시간이에요!",
+                        target.time().format(TIME_FORMATTER) + " 전후 날씨예요.\n" + formatForecasts(value)
+                )
+        );
+    }
+
+    private LocalDateTime forecastStartTime(WeatherRecommendationTarget target, LocalDateTime referenceTime) {
+        LocalDateTime preferredAt = referenceTime.withHour(target.time().getHour())
+                .withMinute(target.time().getMinute())
+                .withSecond(0).withNano(0);
+        return (preferredAt.isBefore(referenceTime) ?
+                preferredAt.plusDays(1) :
+                preferredAt
+        ).minusHours(1);
+    }
+
+    private Optional<WeatherDTO> findForecast(WeatherRequest request) {
+        try {
+            return Optional.of(
+                    weatherQueryService.getFcstWeather(request.gridPoint(), request.startTime(), FORECAST_HOURS));
+        } catch (RuntimeException exception) {
+            log.warn("event=weather_recommendation_forecast_not_found, nx={}, ny={}, startTime={}",
+                    request.gridPoint().nx(), request.gridPoint().ny(), request.startTime(), exception);
+            return Optional.empty();
+        }
+    }
+
+    private String formatForecasts(WeatherDTO weather) {
+        return weather.weatherList().stream().map(this::formatForecast).collect(Collectors.joining("\n"));
+    }
+
+    private String formatForecast(WeatherDTO.WeatherList forecast) {
+        String precipitation = forecast.pty().getDescription();
+        if (forecast.pcp() != null && forecast.pcp() > 0) {
+            precipitation += " " + forecast.pcp() + "mm";
+        }
+        String time = forecast.time() != null && forecast.time().matches("\\d{4}")
+                ? forecast.time().substring(0, 2) + ":" + forecast.time().substring(2) : forecast.time();
+        return time + " " + forecast.temp() + "℃ · " + forecast.sky().getDescription() + " · " + precipitation;
+    }
+
+    private record WeatherRequest(GridPoint gridPoint, LocalDateTime startTime) {
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/notification/service/sender/WeatherRecommendationTarget.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/sender/WeatherRecommendationTarget.java
@@ -1,0 +1,13 @@
+package org.zerock.puppyrun.notification.service.sender;
+
+import java.time.LocalTime;
+import java.util.UUID;
+
+/** 날씨 추천 메시지 생성에 필요한 회원별 시간과 위치입니다. */
+public record WeatherRecommendationTarget(
+        UUID memberId,
+        Double latitude,
+        Double longitude,
+        LocalTime time
+) {
+}

--- a/src/test/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepositoryIntegrationTest.java
+++ b/src/test/java/org/zerock/puppyrun/notification/repository/WalkingPreferenceRepositoryIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
@@ -51,6 +52,47 @@ class WalkingPreferenceRepositoryIntegrationTest extends TestContainerConfig {
                     assertThat(preference.getAnalysisDate()).isEqualTo(analysisDate);
                     assertThat(preference.getWeekdayTime()).isEqualTo(LocalTime.of(18, 0));
                     assertThat(preference.getWeekdayScore()).isEqualTo(10);
+                });
+    }
+
+    @Test
+    @DisplayName("회원 목록과 생성 시각 범위로 산책 선호도 스냅샷을 조회한다")
+    void findByMemberIdsAndCreatedAtBetween() {
+        // given
+        Member targetMember = Member.builder()
+                .email("walking-preference-target@test.com")
+                .nickName("walking-preference-target")
+                .password("encoded-password")
+                .build();
+        Member excludedMember = Member.builder()
+                .email("walking-preference-excluded@test.com")
+                .nickName("walking-preference-excluded")
+                .password("encoded-password")
+                .build();
+        entityManager.persist(targetMember);
+        entityManager.persist(excludedMember);
+        LocalDateTime from = LocalDateTime.now().minusMinutes(1);
+        walkingPreferenceRepository.saveAll(List.of(
+                preference(targetMember, LocalDate.of(2026, 8, 14), LocalTime.of(18, 0), 10),
+                preference(excludedMember, LocalDate.of(2026, 8, 14), LocalTime.of(8, 0), 4)
+        ));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<WalkingPreference> preferences = walkingPreferenceRepository
+                .findByMemberIdsAndCreatedAtBetween(
+                        List.of(targetMember.getId()),
+                        from,
+                        LocalDateTime.now().plusMinutes(1)
+                );
+
+        // then
+        assertThat(preferences)
+                .singleElement()
+                .satisfies(preference -> {
+                    assertThat(preference.getMember().getId()).isEqualTo(targetMember.getId());
+                    assertThat(preference.getWeekdayTime()).isEqualTo(LocalTime.of(18, 0));
                 });
     }
 

--- a/src/test/java/org/zerock/puppyrun/notification/scheduler/RecommendedWeatherNotificationTest.java
+++ b/src/test/java/org/zerock/puppyrun/notification/scheduler/RecommendedWeatherNotificationTest.java
@@ -1,0 +1,40 @@
+package org.zerock.puppyrun.notification.scheduler;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.service.NotificationProcessor;
+import org.zerock.puppyrun.notification.service.sender.SnapshotWeatherRecommendSender;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendedWeatherNotificationTest {
+
+    @Mock
+    private NotificationProcessor notificationProcessor;
+
+    @Mock
+    private SnapshotWeatherRecommendSender weatherRecommendSender;
+
+    @InjectMocks
+    private RecommendedWeatherNotification recommendedWeatherNotification;
+
+    @Test
+    @DisplayName("스케줄 실행 시 날씨 기반 산책 시간 추천 발송을 요청한다")
+    void sendRecommendedWeatherNotification() {
+        // given
+        // when
+        recommendedWeatherNotification.sendRecommendedWeatherNotification();
+
+        // then
+        verify(notificationProcessor).broadcast(
+                NotificationType.RECOMMEND_TIME_REMINDER,
+                weatherRecommendSender
+        );
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/notification/service/sender/SnapshotWeatherRecommendSenderTest.java
+++ b/src/test/java/org/zerock/puppyrun/notification/service/sender/SnapshotWeatherRecommendSenderTest.java
@@ -1,0 +1,82 @@
+package org.zerock.puppyrun.notification.service.sender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.notification.client.DTO.PushTask;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.entity.WalkingPreference;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+import org.zerock.puppyrun.notification.repository.WalkingPreferenceRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SnapshotWeatherRecommendSenderTest {
+
+    @Mock
+    private WalkingPreferenceRepository walkingPreferenceRepository;
+
+    @Mock
+    private WeatherRecommendationMessageComposer weatherRecommendationMessageComposer;
+
+    @InjectMocks
+    private SnapshotWeatherRecommendSender weatherRecommendSender;
+
+    @Test
+    @DisplayName("최근 스냅샷이 있는 회원에게만 전후 세 시간 날씨 메시지를 생성한다")
+    void createPushTasksCreatesWeatherTaskForMembersWithSnapshot() {
+        // given
+        UUID preferredMemberId = UUID.randomUUID();
+        EnabledNotifications preferredMember = recipient(preferredMemberId, "preferred-token");
+        Member member = Member.builder()
+                .id(preferredMemberId)
+                .email("snapshot-sender@test.com")
+                .nickName("snapshot-sender")
+                .password("encoded-password")
+                .build();
+        given(walkingPreferenceRepository.findByMemberIdsAndCreatedAtBetween(any(), any(), any()))
+                .willReturn(List.of(WalkingPreference.builder()
+                        .member(member)
+                        .lastKnownLatitude(37.5665)
+                        .lastKnownLongitude(126.9780)
+                        .weekdayTime(LocalTime.of(18, 0))
+                        .weekendTime(LocalTime.of(18, 0))
+                        .build()));
+        given(weatherRecommendationMessageComposer.createPushTasks(any(), any(), any()))
+                .willReturn(List.of(new org.zerock.puppyrun.notification.client.DTO.TokenPushTask(
+                        "preferred-token",
+                        NotificationType.RECOMMEND_TIME_REMINDER,
+                        "산책하기 좋은 시간이에요!",
+                        "18:00 전후 날씨예요."
+                )));
+
+        // when
+        List<PushTask> tasks = weatherRecommendSender.createPushTasks(List.of(preferredMember));
+
+        // then
+        assertThat(tasks).singleElement().satisfies(task -> {
+            assertThat(task.target()).isEqualTo("preferred-token");
+            assertThat(task.body()).contains("18:00 전후 날씨예요.");
+        });
+        verify(weatherRecommendationMessageComposer).createPushTasks(any(), any(), any());
+    }
+
+    private EnabledNotifications recipient(UUID memberId, String fcmToken) {
+        return EnabledNotifications.builder()
+                .memberId(memberId)
+                .fcmToken(fcmToken)
+                .type(NotificationType.RECOMMEND_TIME_REMINDER)
+                .build();
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/notification/service/sender/WeatherRecommendationMessageComposerTest.java
+++ b/src/test/java/org/zerock/puppyrun/notification/service/sender/WeatherRecommendationMessageComposerTest.java
@@ -1,0 +1,68 @@
+package org.zerock.puppyrun.notification.service.sender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.zerock.puppyrun.notification.client.DTO.PushTask;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.repository.DTO.EnabledNotifications;
+import org.zerock.puppyrun.weather.DTO.PrecipitationType;
+import org.zerock.puppyrun.weather.DTO.SkyType;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+import org.zerock.puppyrun.weather.DTO.WeatherRegion;
+import org.zerock.puppyrun.weather.service.WeatherQueryService;
+import org.zerock.puppyrun.weather.utils.WeatherRegionCatalog;
+
+@ExtendWith(MockitoExtension.class)
+class WeatherRecommendationMessageComposerTest {
+
+    @Mock private WeatherRegionCatalog weatherRegionCatalog;
+    @Mock private WeatherQueryService weatherQueryService;
+    @InjectMocks private WeatherRecommendationMessageComposer composer;
+
+    @Test
+    @DisplayName("선호 시간 전후 세 시간 예보를 토큰 메시지 본문으로 만든다")
+    void createPushTasks() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        given(weatherRegionCatalog.findNearestRegion(37.5665, 126.9780))
+                .willReturn(new WeatherRegion(List.of("서울"), 60, 127, 37.5665, 126.9780));
+        given(weatherQueryService.getFcstWeather(any(), any(), eq(3))).willReturn(new WeatherDTO(List.of(
+                weather("1700", "25", SkyType.SUNNY, PrecipitationType.NONE, 0.0),
+                weather("1800", "24", SkyType.CLOUDY, PrecipitationType.RAIN, 1.2),
+                weather("1900", "23", SkyType.OVERCAST, PrecipitationType.NONE, 0.0)
+        )));
+
+        // when
+        List<PushTask> tasks = composer.createPushTasks(
+                List.of(EnabledNotifications.builder().memberId(memberId).fcmToken("token")
+                        .type(NotificationType.RECOMMEND_TIME_REMINDER).build()),
+                List.of(new WeatherRecommendationTarget(memberId, 37.5665, 126.9780, LocalTime.of(18, 0))),
+                LocalDateTime.of(2026, 8, 18, 9, 0)
+        );
+
+        // then
+        assertThat(tasks).singleElement().satisfies(task -> {
+            assertThat(task.body()).contains("17:00 25℃ · 맑음 · 없음");
+            assertThat(task.body()).contains("18:00 24℃ · 구름많음 · 비 1.2mm");
+        });
+        verify(weatherQueryService).getFcstWeather(any(), any(), eq(3));
+    }
+
+    private WeatherDTO.WeatherList weather(String time, String temp, SkyType sky, PrecipitationType pty, double pcp) {
+        return new WeatherDTO.WeatherList("20260818", time, temp, sky, pty, pcp);
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request: #41 날씨 기반 산책 시간 추천 알림

# 📝 작업 요약 (Summary)

회원의 산책 선호 시간과 마지막 산책 위치를 기반으로, 매일 오전 09:00에 선호 시각 전후 3시간의 날씨를 안내하는 개인화 알림 기반을 추가했습니다.

추천 시간의 출처는 스냅샷 분석 또는 사용자가 직접 저장한 시간으로 분리했고, 공통 날씨 조회·메시지 생성은 Composer Bean으로 통합했습니다. 또한 이 기능의 기반이 되는 산책 선호도 스냅샷, 대량 알림 Slice 처리, 강수량 수치화 변경도 포함합니다.


# 🛠️ 변경 사항 (Changes)

## 1. 날씨 기반 산책 시간 추천 알림

- `RECOMMEND_TIME_REMINDER(ACT_003)` 알림 타입을 추가했습니다.
- `RecommendedWeatherNotification`이 매일 09:00에 추천 알림 발송을 시작합니다.
- `SnapshotWeatherRecommendSender`
  - 최근 7일 이내 최신 산책 선호도 스냅샷을 일괄 조회합니다.
  - 발송일이 평일이면 `weekdayTime`, 주말이면 `weekendTime`을 사용합니다.
  - 유효 스냅샷, 해당 요일 선호 시간 또는 위치가 없는 회원은 발송에서 제외합니다.
- `UserSelectedWeatherRecommendSender`
  - 향후 정책 전환 시, 회원이 저장한 시간·위치 기준으로 동일한 추천 알림을 생성합니다.
  - 현재 정기 스케줄러는 스냅샷 Sender를 사용합니다.
- `WeatherRecommendationMessageComposer`
  - 마지막 산책 위치를 가장 가까운 기상 격자로 변환합니다.
  - 선호 시간 전후 1시간, 총 3시간 예보를 조회합니다.
  - 선호 시간이 이미 지났으면 다음 날 동일 시간대 예보를 조회합니다.
  - 같은 청크에서 동일 격자·시간대 예보는 한 번만 조회합니다.
  - 예보 조회 실패·좌표 누락 회원은 전체 배치를 중단하지 않고 해당 회원만 제외합니다.

### 09:00 날씨 추천 알림

```mermaid
sequenceDiagram
    autonumber
    participant Scheduler as RecommendedWeatherNotification
    participant Processor as NotificationProcessor
    participant NotiRepo as NotificationRepository
    participant Sender as SnapshotWeatherRecommendSender
    participant PrefRepo as WalkingPreferenceRepository
    participant Composer as WeatherRecommendationMessageComposer
    participant Weather as WeatherQueryService
    participant FCM as NotificationEventClient

    Note over Scheduler: 매일 09:00 실행
    Scheduler->>Processor: broadcast(RECOMMEND_TIME_REMINDER, snapshotSender)
    loop 수신 대상 Slice마다 (최대 1,000명)
        Processor->>NotiRepo: 활성·동의·미거부 수신자 조회
        NotiRepo-->>Processor: SliceResult(content, hasNext)
        Processor->>Sender: createPushTasks(수신자 청크)
        Sender->>PrefRepo: 최근 7일 최신 스냅샷 일괄 조회
        Sender->>Sender: 평일/주말 선호 시간 선택
        Sender->>Composer: 시간·위치 대상 목록 전달
        Composer->>Weather: 격자별 선호 시간 전후 3시간 예보 조회
        Weather-->>Composer: WeatherDTO
        Composer-->>Sender: TokenPushTask 목록
        Sender-->>Processor: TokenPushTask 목록
        Processor->>FCM: sendMessagesInBulk(tasks)
    end
```

## 2. 산책 선호도 스냅샷 분석

- 최근 28일 산책 기록을 2시간 버킷으로 분류합니다.
- 최근 1주부터 4주까지 4·3·2·1점 가중치로 평일·주말 선호 시간을 계산합니다.
- 최신 산책 경로의 마지막 좌표와 산책일을 함께 저장합니다.
- 매일 03:00에 회원 ID 300명 단위로 분석하며, 같은 회원·분석일 스냅샷은 중복 생성하지 않습니다.
- 개발 환경에서는 `GET /test/preferences`로 수동 실행할 수 있습니다.

### 산책 선호도 스냅샷 생성

```mermaid
sequenceDiagram
    autonumber
    participant Scheduler as WalkingPreferenceScheduler
    participant Service as WalkingPreferenceService
    participant TrackingRepo as TrackingRepository
    participant RouteRepo as TrackingRouteRepository
    participant PrefRepo as WalkingPreferenceRepository

    Note over Scheduler: 매일 03:00 실행
    Scheduler->>Service: createDailySnapshots(analysisAt)
    loop 회원 300명 청크마다
        Service->>TrackingRepo: 최근 28일 활동 회원 ID 조회
        Service->>PrefRepo: 당일 기존 스냅샷 조회
        Service->>TrackingRepo: 미분석 회원 산책 기록 일괄 조회
        Service->>RouteRepo: 최신 산책 경로 일괄 조회
        Service->>Service: 평일/주말 버킷 점수 계산
        Service->>PrefRepo: 시간·점수·마지막 위치 스냅샷 저장
    end
```

## 3. 알림·날씨 데이터 기반 보완

- `SliceResult<T>`로 알림 수신자와 메인 산책 목록의 `content`·`hasNext` 계약을 통일했습니다.
- Repository가 `pageSize + 1` 조회를 내부 처리하고, Processor는 정확히 1,000명씩 발송합니다.
- `WeatherDTO.WeatherList.pcp`를 문자열에서 `Double` 밀리미터 값으로 변경했습니다.
- `강수없음`, `-`, `1mm 미만`, 범위형 강수량 등 기상청 표현을 수치로 변환합니다.
