### PR TITLE
refactor: 최신·직전 단기예보 병합 조회로 보완

### DIFF
--- a/.github/workflows/deployment/scripts/health-check.sh
+++ b/.github/workflows/deployment/scripts/health-check.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-HEALTH_URL="${1:?Usage: health-check.sh <readiness-url>}"
+HEALTH_URL="${1:?Usage: health-check.sh <readiness-url> [expected-image]}"
+EXPECTED_IMAGE="${2:-}"
 MAX_RETRIES="${MAX_RETRIES:-12}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
 
@@ -13,10 +14,30 @@ for attempt in $(seq 1 "$MAX_RETRIES"); do
   sleep "$SLEEP_SECONDS"
 done
 
-# container_name을 사용하지 않으므로 Compose 서비스 기준으로 최근 로그를 남긴다.
 ROOT="/home/ubuntu/puppyrun"
 COMPOSE_PROJECT_NAME="${BACKEND_COMPOSE_PROJECT_NAME:-puppyrun}"
-docker compose --project-name "$COMPOSE_PROJECT_NAME" \
-  -f "$ROOT/compose/docker-compose.backend.yml" logs --tail 200 backend || true
+
+# Compose 파일을 다시 해석하지 않고, backend 서비스로 생성된 컨테이너만 조회한다.
+while IFS= read -r container_id; do
+  [[ -z "$container_id" ]] && continue
+
+  container_image=$(
+    docker inspect --format '{{.Config.Image}}' "$container_id" 2>/dev/null || true
+  )
+
+  # 배포 대상 이미지 태그를 전달받았다면 해당 이미지로 실행된 컨테이너만 남긴다.
+  if [[ -n "$EXPECTED_IMAGE" && "$container_image" != "$EXPECTED_IMAGE" ]]; then
+    continue
+  fi
+
+  echo "Backend container logs (id=$container_id, image=$container_image)"
+  docker logs --tail 500 "$container_id" || true
+  break
+done < <(
+  docker ps -aq \
+    --filter "label=com.docker.compose.project=$COMPOSE_PROJECT_NAME" \
+    --filter "label=com.docker.compose.service=backend"
+)
+
 echo "Health check failed: $HEALTH_URL"
 exit 1

--- a/src/main/java/org/zerock/puppyrun/weather/repository/WeatherForecastRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/weather/repository/WeatherForecastRepoCustom.java
@@ -1,0 +1,20 @@
+package org.zerock.puppyrun.weather.repository;
+
+import java.util.List;
+import org.zerock.puppyrun.weather.DTO.GridPoint;
+import org.zerock.puppyrun.weather.enity.WeatherForecastEntity;
+import org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType;
+
+/**
+ * 발표 시각을 기준으로 날씨 예보 후보를 조회합니다.
+ */
+public interface WeatherForecastRepoCustom {
+
+    /**
+     * 지정한 격자의 최신 단기예보와 바로 이전 단기예보를 최신 발표 시각 순으로 조회합니다.
+     */
+    List<WeatherForecastEntity> findLatestAndPreviousByGridPoint(
+            GridPoint gridPoint,
+            ForecastType forecastType
+    );
+}

--- a/src/main/java/org/zerock/puppyrun/weather/repository/WeatherForecastRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/weather/repository/WeatherForecastRepoCustomImpl.java
@@ -1,0 +1,40 @@
+package org.zerock.puppyrun.weather.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.weather.DTO.GridPoint;
+import org.zerock.puppyrun.weather.enity.WeatherForecastEntity;
+import org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType;
+
+import static org.zerock.puppyrun.weather.enity.QWeatherForecastEntity.weatherForecastEntity;
+
+/**
+ * 날씨 예보 후보 Querydsl 구현체입니다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class WeatherForecastRepoCustomImpl implements WeatherForecastRepoCustom {
+
+    private static final long LATEST_AND_PREVIOUS_FORECAST_COUNT = 2L;
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<WeatherForecastEntity> findLatestAndPreviousByGridPoint(
+            GridPoint gridPoint,
+            ForecastType forecastType
+    ) {
+        return queryFactory
+                .selectFrom(weatherForecastEntity)
+                .where(
+                        weatherForecastEntity.nx.eq(gridPoint.nx()),
+                        weatherForecastEntity.ny.eq(gridPoint.ny()),
+                        weatherForecastEntity.type.eq(forecastType)
+                )
+                .orderBy(weatherForecastEntity.baseDateTime.desc())
+                .limit(LATEST_AND_PREVIOUS_FORECAST_COUNT)
+                .fetch();
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/weather/repository/WeatherForecastRepository.java
+++ b/src/main/java/org/zerock/puppyrun/weather/repository/WeatherForecastRepository.java
@@ -1,9 +1,7 @@
 package org.zerock.puppyrun.weather.repository;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -14,17 +12,7 @@ import org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType;
  * {@link WeatherForecastEntity} 엔티티의 영속성 조작을 위한 Spring Data JPA 레포지토리 인터페이스입니다.
  */
 @Repository
-public interface WeatherForecastRepository extends JpaRepository<WeatherForecastEntity, UUID> {
-
-    /**
-     * 지정된 격자 좌표(nx, ny)와 예보 타입(type)에 해당하는 가장 최신의 발표 시각을 가진 백업 날씨 예보 엔티티를 조회합니다.
-     *
-     * @param nx   격자 X 좌표
-     * @param ny   격자 Y 좌표
-     * @param type 예보 타입
-     * @return 최신 날씨 예보 엔티티 Optional
-     */
-    Optional<WeatherForecastEntity> findFirstByNxAndNyAndTypeOrderByBaseDateTimeDesc(int nx, int ny, ForecastType type);
+public interface WeatherForecastRepository extends JpaRepository<WeatherForecastEntity, UUID>, WeatherForecastRepoCustom {
 
     /**
      * 특정 예보 발표 시각과 예보 타입에 해당하는 모든 백업 날씨 예보 엔티티를 조회합니다.
@@ -33,6 +21,9 @@ public interface WeatherForecastRepository extends JpaRepository<WeatherForecast
      * @param type         예보 타입
      * @return 해당 조건의 날씨 예보 엔티티 리스트
      */
-    List<WeatherForecastEntity> findAllByBaseDateTimeAndType(LocalDateTime baseDateTime, ForecastType type);
+    List<WeatherForecastEntity> findAllByBaseDateTimeAndType(
+            LocalDateTime baseDateTime,
+            ForecastType type
+    );
 
 }

--- a/src/main/java/org/zerock/puppyrun/weather/service/WeatherQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/weather/service/WeatherQueryService.java
@@ -203,7 +203,10 @@ public class WeatherQueryService {
     }
 
     /**
-     * DB의 최신 단기예보를 조회하여 기존 예보에 추가합니다.
+     * 최신 발표본과 직전 발표본을 한 번에 조회해 최신 발표본을 우선으로 병합합니다.
+     *
+     * <p>새 단기예보가 현재 시각의 예보를 아직 포함하지 않을 수 있으므로, 최신 발표본에서 비는 시간만
+     * 직전 발표본으로 보완합니다.</p>
      */
     private void addDbForecasts(
             ForecastType forecastType,
@@ -212,26 +215,42 @@ public class WeatherQueryService {
             LocalDateTime endTime,
             Map<LocalDateTime, WeatherDTO.WeatherList> forecasts
     ) {
-        weatherForecastRepository
-                .findFirstByNxAndNyAndTypeOrderByBaseDateTimeDesc(
-                        gridPoint.nx(),
-                        gridPoint.ny(),
-                        forecastType
-                )
-                .map(WeatherForecastEntity::getWeather)
-                .ifPresentOrElse(
-                        weather -> addForecasts(
-                                weather.weatherList(),
-                                startTime,
-                                endTime,
-                                forecasts
-                        ),
-                        () -> log.debug(
-                                "DB 백업 날씨가 없습니다. nx={}, ny={}",
-                                gridPoint.nx(),
-                                gridPoint.ny()
-                        )
-                );
+        List<WeatherForecastEntity> candidates = weatherForecastRepository
+                .findLatestAndPreviousByGridPoint(gridPoint, forecastType);
+
+        if (candidates.isEmpty()) {
+            log.debug(
+                    "DB 백업 날씨가 없습니다. nx={}, ny={}",
+                    gridPoint.nx(),
+                    gridPoint.ny()
+            );
+            return;
+        }
+
+        WeatherDTO mergedWeather = mergeLatestAndPreviousForecasts(candidates);
+        addForecasts(mergedWeather.weatherList(), startTime, endTime, forecasts);
+    }
+
+    private WeatherDTO mergeLatestAndPreviousForecasts(
+            List<WeatherForecastEntity> candidates
+    ) {
+        Map<LocalDateTime, WeatherDTO.WeatherList> mergedForecasts = new TreeMap<>();
+
+        for (WeatherForecastEntity candidate : candidates) {
+            List<WeatherDTO.WeatherList> weatherList = candidate.getWeather().weatherList();
+
+            if (weatherList == null) {
+                continue;
+            }
+
+            for (WeatherDTO.WeatherList weather : weatherList) {
+                if (hasValidDateTime(weather)) {
+                    mergedForecasts.putIfAbsent(toDateTime(weather), weather);
+                }
+            }
+        }
+
+        return new WeatherDTO(new ArrayList<>(mergedForecasts.values()));
     }
 
     /**

--- a/src/test/java/org/zerock/puppyrun/weather/WeatherQueryServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/weather/WeatherQueryServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.mock;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -109,9 +108,9 @@ class WeatherQueryServiceTest {
                 .type(org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType.SHORT_TERM)
                 .weather(dbWeatherData)
                 .build();
-        given(weatherForecastRepository.findFirstByNxAndNyAndTypeOrderByBaseDateTimeDesc(
-                98, 76, org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType.SHORT_TERM
-        )).willReturn(Optional.of(mockEntity));
+        given(weatherForecastRepository.findLatestAndPreviousByGridPoint(
+                gridPoint, org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType.SHORT_TERM
+        )).willReturn(List.of(mockEntity));
 
         // when (limit = 4)
         WeatherDTO result = weatherQueryService.getFcstWeather(gridPoint, now, 4);
@@ -120,6 +119,44 @@ class WeatherQueryServiceTest {
         assertThat(result.weatherList())
                 .extracting(WeatherDTO.WeatherList::temp)
                 .containsExactly("ultra", "short", "db", "db");
+    }
+
+    @Test
+    @DisplayName("최신 단기예보에 없는 시간은 직전 단기예보로 보완하고 겹치는 시간은 최신 값을 사용한다")
+    void mergeLatestAndPreviousDbForecasts() {
+        // given
+        GridPoint gridPoint = new GridPoint(63, 103);
+        LocalDateTime now = LocalDateTime.of(2026, 8, 18, 17, 35);
+        org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType forecastType =
+                org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType.SHORT_TERM;
+
+        WeatherForecastEntity latestForecast = WeatherForecastEntity.builder()
+                .baseDateTime(LocalDateTime.of(2026, 8, 18, 14, 0))
+                .nx(gridPoint.nx())
+                .ny(gridPoint.ny())
+                .type(forecastType)
+                .weather(weatherWithTemp("20260818", "latest", "1800", "1900"))
+                .build();
+        WeatherForecastEntity previousForecast = WeatherForecastEntity.builder()
+                .baseDateTime(LocalDateTime.of(2026, 8, 18, 11, 0))
+                .nx(gridPoint.nx())
+                .ny(gridPoint.ny())
+                .type(forecastType)
+                .weather(weatherWithTemp("20260818", "previous", "1700", "1800", "1900"))
+                .build();
+        given(weatherForecastRepository.findLatestAndPreviousByGridPoint(gridPoint, forecastType))
+                .willReturn(List.of(latestForecast, previousForecast));
+
+        // when
+        WeatherDTO result = weatherQueryService.getFcstWeather(gridPoint, now, 3);
+
+        // then
+        assertThat(result.weatherList())
+                .extracting(WeatherDTO.WeatherList::time)
+                .containsExactly("1700", "1800", "1900");
+        assertThat(result.weatherList())
+                .extracting(WeatherDTO.WeatherList::temp)
+                .containsExactly("previous", "latest", "latest");
     }
 
     @Test
@@ -185,9 +222,9 @@ class WeatherQueryServiceTest {
         // given
         GridPoint gridPoint = new GridPoint(98, 76);
         LocalDateTime now = LocalDateTime.of(2026, 8, 3, 10, 30);
-        given(weatherForecastRepository.findFirstByNxAndNyAndTypeOrderByBaseDateTimeDesc(
-                98, 76, org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType.SHORT_TERM
-        )).willReturn(Optional.empty());
+        given(weatherForecastRepository.findLatestAndPreviousByGridPoint(
+                gridPoint, org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType.SHORT_TERM
+        )).willReturn(List.of());
 
         // when & then
         assertThatThrownBy(() -> weatherQueryService.getFcstWeather(

--- a/src/test/java/org/zerock/puppyrun/weather/repository/WeatherForecastRepositoryIntegrationTest.java
+++ b/src/test/java/org/zerock/puppyrun/weather/repository/WeatherForecastRepositoryIntegrationTest.java
@@ -1,0 +1,77 @@
+package org.zerock.puppyrun.weather.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.zerock.puppyrun.a_config.TestContainerConfig;
+import org.zerock.puppyrun.weather.DTO.GridPoint;
+import org.zerock.puppyrun.weather.DTO.PrecipitationType;
+import org.zerock.puppyrun.weather.DTO.SkyType;
+import org.zerock.puppyrun.weather.DTO.WeatherDTO;
+import org.zerock.puppyrun.weather.enity.WeatherForecastEntity;
+import org.zerock.puppyrun.weather.utils.WeatherForecast.ForecastType;
+
+class WeatherForecastRepositoryIntegrationTest extends TestContainerConfig {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private WeatherForecastRepository weatherForecastRepository;
+
+    @Test
+    @DisplayName("격자와 예보 타입으로 최신 발표본과 직전 발표본만 최신순으로 조회한다")
+    void findLatestAndPreviousByGridPoint() {
+        // given
+        GridPoint gridPoint = new GridPoint(63, 103);
+        weatherForecastRepository.saveAll(List.of(
+                forecast(gridPoint, LocalDateTime.of(2026, 8, 18, 8, 0), ForecastType.SHORT_TERM),
+                forecast(gridPoint, LocalDateTime.of(2026, 8, 18, 11, 0), ForecastType.SHORT_TERM),
+                forecast(gridPoint, LocalDateTime.of(2026, 8, 18, 14, 0), ForecastType.SHORT_TERM),
+                forecast(new GridPoint(64, 103), LocalDateTime.of(2026, 8, 18, 17, 0), ForecastType.SHORT_TERM),
+                forecast(gridPoint, LocalDateTime.of(2026, 8, 18, 17, 0), ForecastType.ULTRA_SHORT)
+        ));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<WeatherForecastEntity> result = weatherForecastRepository
+                .findLatestAndPreviousByGridPoint(gridPoint, ForecastType.SHORT_TERM);
+
+        // then
+        assertThat(result)
+                .extracting(WeatherForecastEntity::getBaseDateTime)
+                .containsExactly(
+                        LocalDateTime.of(2026, 8, 18, 14, 0),
+                        LocalDateTime.of(2026, 8, 18, 11, 0)
+                );
+    }
+
+    private WeatherForecastEntity forecast(
+            GridPoint gridPoint,
+            LocalDateTime baseDateTime,
+            ForecastType forecastType
+    ) {
+        return WeatherForecastEntity.builder()
+                .baseDateTime(baseDateTime)
+                .nx(gridPoint.nx())
+                .ny(gridPoint.ny())
+                .type(forecastType)
+                .weather(new WeatherDTO(List.of(
+                        new WeatherDTO.WeatherList(
+                                "20260818",
+                                "1800",
+                                "25",
+                                SkyType.SUNNY,
+                                PrecipitationType.NONE,
+                                0.0
+                        )
+                )))
+                .build();
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request: 단기예보 발표본 병합 조회 및 배포 실패 로그 조회 개선

# 📝 작업 요약 (Summary)

단기예보가 갱신되는 경계 시점에 최신 발표본만 조회하면서 현재 시간대 예보가 누락되는 문제를 보완했습니다.

동일 격자와 예보 타입의 최신·직전 발표본을 한 번에 조회한 뒤, 최신 발표본을 우선으로 병합합니다. 최신 발표본에 없는 시간대만 직전 발표본으로 채워 `WeatherQueryService`가 요청 시간 범위를
완성할 수 있도록 했습니다.

또한 readiness 실패 시 로그를 남기기 위해 Compose 파일을 다시 해석하던 방식을 제거하고, 실제 backend 컨테이너의 로그를 직접 조회하도록 변경했습니다.

# 🛠️ 변경 사항 (Changes)

## 1. 단기예보 DB fallback 병합 조회

- `WeatherForecastRepoCustom`, `WeatherForecastRepoCustomImpl`
    - QueryDSL로 동일 `nx`, `ny`, 예보 타입의 최신 발표본과 직전 발표본을 단일 쿼리로 조회합니다.
    - `baseDateTime DESC`와 `limit 2`를 적용해 최신 발표본이 항상 먼저 반환되도록 보장합니다.
- `WeatherForecastRepository`
    - 최신 단건만 반환하던 파생 쿼리를 제거하고 QueryDSL 커스텀 조회를 연결했습니다.
- `WeatherQueryService`
    - 최신·직전 발표본의 `WeatherDTO`를 시간대별로 병합합니다.
    - 중복된 예보 시각은 최신 발표본 값을 유지하고, 최신 발표본에서 비는 시각만 직전 발표본으로 보완합니다.
    - 병합 결과에서 기존처럼 요청 시작 시각과 개수에 해당하는 예보만 추출합니다.

예시: 17시부터 3시간을 조회할 때 최신 17시 발표본이 `18~19시`만 포함하면, 직전 14시 발표본의 `17시` 데이터로 보완합니다. `18~19시`는 최신 17시 발표본을 유지합니다.

## 2. 배포 실패 시 backend 로그 조회 방식 변경

- `health-check.sh`
    - 실패 로그를 위해 `docker compose logs`를 재실행하던 방식을 제거했습니다.
    - Compose 프로젝트·서비스 라벨로 backend 컨테이너를 찾고 `docker logs --tail 500`으로 직접 로그를 출력합니다.
    - 선택적으로 전달받은 이미지 태그와 실제 컨테이너 이미지를 비교해, 배포 후보 이미지의 로그만 조회합니다.

Compose 파일을 다시 파싱하지 않으므로, 실패 로그 출력 단계에서 `BACKEND_IMAGE`, `BACKEND_PORT`, `SPRING_PROFILE` 등의 변수 보간 오류가 발생하지 않습니다.

```mermaid
sequenceDiagram
    autonumber
    participant Caller as 날씨 조회 호출부
    participant QueryService as WeatherQueryService
    participant Repository as WeatherForecastRepoCustom
    participant DB as MySQL weather_forecast

    Caller->>QueryService: getFcstWeather(gridPoint, 17:35, 3)
    QueryService->>QueryService: 캐시에서 17~19시 조회
    Note right of QueryService: 요청 시간대가 부족한 경우만 DB fallback

    QueryService->>Repository: 최신·직전 발표본 조회
    Repository->>DB: nx, ny, type 조건<br/>baseDateTime DESC, LIMIT 2
    DB-->>Repository: 최신 17시 발표본, 직전 14시 발표본
    Repository-->>QueryService: 발표본 2건

    QueryService->>QueryService: 최신 17시 예보부터 병합
    Note right of QueryService: 18·19시는 최신 예보 사용
    QueryService->>QueryService: 직전 14시 예보로 빈 시간 보완
    Note right of QueryService: 17시만 직전 예보에서 추가

    QueryService-->>Caller: 17·18·19시 WeatherDTO 반환
```
