### PR TITLE
refactor: 펫 누적 산책 거리 실시간 집계 리팩터링

### DIFF
--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetDetailResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetDetailResponse.java
@@ -30,7 +30,7 @@ public record PetDetailResponse(
     /**
      * Pet 엔티티를 PetDetailResponse DTO로 변환하는 정적 팩토리 메서드
      */
-    public static PetDetailResponse of(Pet pet) {
+    public static PetDetailResponse of(Pet pet, int walkedDistance) {
         return PetDetailResponse.builder()
                 .PetId(pet.getId())
                 .name(pet.getName())
@@ -41,7 +41,7 @@ public record PetDetailResponse(
                 .breedCode(pet.getBreed().getCode())
                 .isNeutered(pet.getIsNeutered())
                 .gender(pet.getGender())
-                .badgeInfo(BadgeInfo.from(pet.getWalkedDistance()))
+                .badgeInfo(BadgeInfo.from(walkedDistance))
                 .mbti(pet.getMbti())
                 .build();
     }

--- a/src/main/java/org/zerock/puppyrun/pet/controller/response/PetProgressResponse.java
+++ b/src/main/java/org/zerock/puppyrun/pet/controller/response/PetProgressResponse.java
@@ -1,6 +1,7 @@
 package org.zerock.puppyrun.pet.controller.response;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.Builder;
 import org.zerock.puppyrun.common.s3.support.S3Url;
@@ -11,16 +12,10 @@ public record PetProgressResponse(
         List<PetProgress> petProgresses
 ) {
 
-    public static PetProgressResponse from(List<Pet> pets) {
+    public static PetProgressResponse from(List<Pet> pets, Map<UUID, Integer> walkedDistances) {
         List<PetProgress> petProgresses = pets.stream()
-                .map(PetProgress::from)
+                .map(pet -> PetProgress.from(pet, walkedDistances.getOrDefault(pet.getId(), 0)))
                 .toList();
-
-        return new PetProgressResponse(petProgresses);
-    }
-
-    public static PetProgressResponse from(Pet pets) {
-        List<PetProgress> petProgresses = List.of(PetProgress.from(pets));
 
         return new PetProgressResponse(petProgresses);
     }
@@ -33,12 +28,12 @@ public record PetProgressResponse(
             TrackingProgress trackingProgress
     ) {
 
-        public static PetProgress from(Pet pet) {
+        public static PetProgress from(Pet pet, int walkedDistance) {
             return PetProgress.builder()
                     .petId(pet.getId())
                     .name(pet.getName())
                     .profileImage(pet.getProfileImageUrl())
-                    .trackingProgress(TrackingProgress.from(pet.getWalkedDistance()))
+                    .trackingProgress(TrackingProgress.from(walkedDistance))
                     .build();
         }
 

--- a/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
+++ b/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
@@ -46,9 +46,6 @@ public class Pet extends BaseEntity {
     @Column(name = "profile_image_url", length = 1000)
     private String profileImageUrl;
 
-    @Column(name = "walked_distance")
-    private int walkedDistance;
-
     @Column(name = "color")
     private String color;
 
@@ -78,7 +75,6 @@ public class Pet extends BaseEntity {
         this.isNeutered = isNeutered;
         this.gender = gender;
         this.profileImageUrl = null;
-        this.walkedDistance = 0;
         this.mbti = null;
     }
 
@@ -105,13 +101,6 @@ public class Pet extends BaseEntity {
 
     public boolean isNotOwner(UUID memberId) {
         return !this.member.getId().equals(memberId);
-    }
-
-    public void addWalkedDistance(int distance) {
-        if (distance < 0) {
-            throw new DataIntegrityException("산책거리는 음수일 수 없습니다.");
-        }
-        this.walkedDistance += distance;
     }
 
     public void updateMbti(String mbti) {

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetCommandService.java
@@ -60,7 +60,7 @@ public class PetCommandService {
         petRepository.save(newPet);
         petStatistics.savePetWeightLog(newPet, request.weight());
 
-        return PetDetailResponse.of(newPet);
+        return PetDetailResponse.of(newPet, 0);
     }
 
     /**

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetQueryService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetQueryService.java
@@ -37,7 +37,7 @@ public class PetQueryService {
      */
     public PetDetailResponse getPet(UserPrincipal userPrincipal, UUID petId) {
         Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
-        return PetDetailResponse.of(pet);
+        return PetDetailResponse.of(pet, petStatistics.getTotalWalkedDistance(pet));
     }
 
     /**
@@ -67,7 +67,7 @@ public class PetQueryService {
         // 사용자 소유 펫 전체 조회
         if (petIds == null || petIds.isEmpty()) {
             List<Pet> pets = petRepository.findAllByMemberId(userPrincipal.id());
-            return PetProgressResponse.from(pets);
+            return progressResponse(pets);
         }
 
         // 중복 제거
@@ -81,7 +81,7 @@ public class PetQueryService {
                     distinctPetIds.getFirst(),
                     userPrincipal.id()
             );
-            return PetProgressResponse.from(pet);
+            return progressResponse(List.of(pet));
         }
 
         // 복수 조회
@@ -97,7 +97,18 @@ public class PetQueryService {
                 .map(petById::get)
                 .toList();
 
-        return PetProgressResponse.from(orderedPets);
+        return progressResponse(orderedPets);
+    }
+
+    private PetProgressResponse progressResponse(List<Pet> pets) {
+        if (pets.isEmpty()) {
+            return PetProgressResponse.from(List.of(), Map.of());
+        }
+
+        Map<UUID, Integer> walkedDistances = petStatistics.getTotalWalkedDistances(
+                pets.stream().map(Pet::getId).toList()
+        );
+        return PetProgressResponse.from(pets, walkedDistances);
     }
 
 }

--- a/src/main/java/org/zerock/puppyrun/statistics/service/PetStatistics.java
+++ b/src/main/java/org/zerock/puppyrun/statistics/service/PetStatistics.java
@@ -2,8 +2,11 @@ package org.zerock.puppyrun.statistics.service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,6 +16,7 @@ import org.zerock.puppyrun.pet.entity.Pet;
 import org.zerock.puppyrun.pet.entity.PetWeightLog;
 import org.zerock.puppyrun.pet.repository.PetWeightLogRepository;
 import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
+import org.zerock.puppyrun.tracking.DTO.PetWalkedDistance;
 import org.zerock.puppyrun.tracking.repository.PetTrackingRepository;
 
 @Component
@@ -86,7 +90,15 @@ public class PetStatistics {
      * @param pet 펫 엔티티
      */
     public int getTotalWalkedDistance(Pet pet) {
-        return petTrackingRepository.sumTotalDistanceByPetId(pet.getId());
+        return getTotalWalkedDistances(List.of(pet.getId())).getOrDefault(pet.getId(), 0);
+    }
+
+    /**
+     * 펫 목록의 실제 누적 산책 거리를 GROUP BY 집계로 한 번에 조회합니다.
+     */
+    public Map<UUID, Integer> getTotalWalkedDistances(List<UUID> petIds) {
+        return petTrackingRepository.findTotalWalkedDistancesByPetIds(petIds).stream()
+                .collect(Collectors.toMap(PetWalkedDistance::petId, PetWalkedDistance::walkedDistance));
     }
 
     /**

--- a/src/main/java/org/zerock/puppyrun/tracking/DTO/PetWalkedDistance.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/DTO/PetWalkedDistance.java
@@ -1,0 +1,6 @@
+package org.zerock.puppyrun.tracking.DTO;
+
+import java.util.UUID;
+
+public record PetWalkedDistance(UUID petId, int walkedDistance) {
+}

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustom.java
@@ -7,8 +7,6 @@ import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
 import org.zerock.puppyrun.tracking.DTO.PetWalkedDistance;
 
 public interface PetTrackingRepoCustom {
-    int sumTotalDistanceByPetId(UUID petId);
-
     List<PetWalkedDistance> findTotalWalkedDistancesByPetIds(List<UUID> petIds);
 
     int sumTotalDurationByPetId(UUID petId);

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustom.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustom.java
@@ -4,9 +4,12 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
+import org.zerock.puppyrun.tracking.DTO.PetWalkedDistance;
 
 public interface PetTrackingRepoCustom {
     int sumTotalDistanceByPetId(UUID petId);
+
+    List<PetWalkedDistance> findTotalWalkedDistancesByPetIds(List<UUID> petIds);
 
     int sumTotalDurationByPetId(UUID petId);
 
@@ -17,4 +20,3 @@ public interface PetTrackingRepoCustom {
 //    TotalPetTracking getTrackingSummaryByPetId(UUID id, LocalDate startDate, LocalDate targetDay);
 
 }
-

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustomImpl.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
+import org.zerock.puppyrun.tracking.DTO.PetWalkedDistance;
 
 import static org.zerock.puppyrun.pet.entity.QPet.pet;
 import static org.zerock.puppyrun.tracking.entity.QPetTracking.petTracking;
@@ -30,6 +31,26 @@ public class PetTrackingRepoCustomImpl implements PetTrackingRepoCustom {
                 .fetchOne();
 
         return result != null ? result : 0;
+    }
+
+    @Override
+    public List<PetWalkedDistance> findTotalWalkedDistancesByPetIds(List<UUID> petIds) {
+        if (petIds.isEmpty()) {
+            return List.of();
+        }
+
+        return queryFactory
+                .select(Projections.constructor(
+                        PetWalkedDistance.class,
+                        pet.id,
+                        tracking.distance.sum().coalesce(0)
+                ))
+                .from(pet)
+                .leftJoin(petTracking).on(petTracking.pet.eq(pet))
+                .leftJoin(petTracking.tracking, tracking)
+                .where(pet.id.in(petIds))
+                .groupBy(pet.id)
+                .fetch();
     }
 
     @Override

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustomImpl.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/PetTrackingRepoCustomImpl.java
@@ -2,6 +2,7 @@ package org.zerock.puppyrun.tracking.repository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
@@ -10,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.zerock.puppyrun.tracking.DTO.TotalPetTracking;
 import org.zerock.puppyrun.tracking.DTO.PetWalkedDistance;
+import org.zerock.puppyrun.tracking.entity.QPetTracking;
+import org.zerock.puppyrun.tracking.entity.QTracking;
 
 import static org.zerock.puppyrun.pet.entity.QPet.pet;
 import static org.zerock.puppyrun.tracking.entity.QPetTracking.petTracking;
@@ -20,18 +23,6 @@ import static org.zerock.puppyrun.tracking.entity.QTracking.tracking;
 public class PetTrackingRepoCustomImpl implements PetTrackingRepoCustom {
 
     private final JPAQueryFactory queryFactory;
-
-    @Override
-    public int sumTotalDistanceByPetId(UUID petId) {
-        Integer result = queryFactory
-                .select(tracking.distance.sum().coalesce(0))
-                .from(petTracking)
-                .join(petTracking.tracking, tracking)
-                .where(petTracking.pet.id.eq(petId))
-                .fetchOne();
-
-        return result != null ? result : 0;
-    }
 
     @Override
     public List<PetWalkedDistance> findTotalWalkedDistancesByPetIds(List<UUID> petIds) {
@@ -67,6 +58,9 @@ public class PetTrackingRepoCustomImpl implements PetTrackingRepoCustom {
 
     @Override
     public List<TotalPetTracking> getTrackingSummaryByPetId(List<UUID> petId, LocalDate startDate, LocalDate endDate) {
+        QPetTracking totalPetTracking = new QPetTracking("totalPetTracking");
+        QTracking totalTracking = new QTracking("totalTracking");
+
         return queryFactory
                 .select(Projections.constructor(TotalPetTracking.class,
                         pet.id,
@@ -75,7 +69,11 @@ public class PetTrackingRepoCustomImpl implements PetTrackingRepoCustom {
                         pet.name,
                         pet.profileImageUrl,
                         pet.color,
-                        pet.walkedDistance,
+                        JPAExpressions
+                                .select(totalTracking.distance.sum().coalesce(0))
+                                .from(totalPetTracking)
+                                .join(totalPetTracking.tracking, totalTracking)
+                                .where(totalPetTracking.pet.eq(pet)),
                         tracking.distance.sum().coalesce(0),
                         tracking.duration.sum().coalesce(0),
                         tracking.count(),
@@ -91,7 +89,7 @@ public class PetTrackingRepoCustomImpl implements PetTrackingRepoCustom {
                                 .and(tracking.startedAt.lt(endDate.plusDays(1).atStartOfDay())) // < endDate+1 00:00
                 )
                 .where(pet.id.in(petId))
-                .groupBy(pet.id, pet.name, pet.profileImageUrl, pet.color, pet.walkedDistance)
+                .groupBy(pet.id, pet.name, pet.profileImageUrl, pet.color)
                 .fetch();
     }
 

--- a/src/main/java/org/zerock/puppyrun/tracking/service/TrackingCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/service/TrackingCommandService.java
@@ -166,8 +166,6 @@ public class TrackingCommandService {
             throw new UserForbiddenException("본인의 소유가 아닌 강아지는 산책에 등록할 수 없습니다.");
         }
 
-        petList.forEach(pet -> pet.addWalkedDistance(savedTracking.getDistance()));
-
         List<PetTracking> petTrackingList = petList.stream()
                 .map(pet -> PetTracking.builder()
                         .pet(pet)

--- a/src/test/java/org/zerock/puppyrun/pet/service/PetQueryServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/pet/service/PetQueryServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,8 +48,12 @@ class PetQueryServiceTest {
         UserPrincipal principal = principal();
         Pet firstPet = pet("몽이", 12_000);
         Pet secondPet = pet("초코", 55_000);
+        UUID firstPetId = firstPet.getId();
+        UUID secondPetId = secondPet.getId();
         when(petRepository.findAllByMemberId(principal.id()))
                 .thenReturn(List.of(firstPet, secondPet));
+        when(petStatistics.getTotalWalkedDistances(List.of(firstPetId, secondPetId)))
+                .thenReturn(Map.of(firstPetId, 12_000, secondPetId, 55_000));
 
         // when
         PetProgressResponse result = petQueryService.getPetProgress(principal, null);
@@ -85,6 +90,7 @@ class PetQueryServiceTest {
         UUID petId = UUID.randomUUID();
         Pet pet = pet(petId, "몽이", 12_000);
         when(petRepository.findByIdAndVerifyOwnership(petId, principal.id())).thenReturn(pet);
+        when(petStatistics.getTotalWalkedDistances(List.of(petId))).thenReturn(Map.of(petId, 12_000));
 
         // when
         PetProgressResponse result = petQueryService.getPetProgress(principal, List.of(petId));
@@ -106,9 +112,13 @@ class PetQueryServiceTest {
         UserPrincipal principal = principal();
         Pet firstPet = pet("몽이", 12_000);
         Pet secondPet = pet("초코", 55_000);
-        List<UUID> requestedIds = List.of(firstPet.getId(), secondPet.getId());
+        UUID firstPetId = firstPet.getId();
+        UUID secondPetId = secondPet.getId();
+        List<UUID> requestedIds = List.of(firstPetId, secondPetId);
         when(petRepository.findAllByMemberIdAndIdIn(principal.id(), requestedIds))
                 .thenReturn(List.of(secondPet, firstPet));
+        when(petStatistics.getTotalWalkedDistances(requestedIds))
+                .thenReturn(Map.of(firstPetId, 12_000, secondPetId, 55_000));
 
         // when
         PetProgressResponse result = petQueryService.getPetProgress(principal, requestedIds);
@@ -149,7 +159,6 @@ class PetQueryServiceTest {
         Pet pet = mock(Pet.class);
         when(pet.getId()).thenReturn(petId);
         when(pet.getName()).thenReturn(name);
-        when(pet.getWalkedDistance()).thenReturn(walkedDistance);
         return pet;
     }
 }

--- a/src/test/java/org/zerock/puppyrun/tracking/repository/PetTrackingSummaryPerformanceTest.java
+++ b/src/test/java/org/zerock/puppyrun/tracking/repository/PetTrackingSummaryPerformanceTest.java
@@ -278,7 +278,7 @@ class PetTrackingSummaryPerformanceTest extends TestContainerConfig {
         }
         return new TotalPetTracking(
                 pet.getId(), startDate, endDate, pet.getName(), pet.getProfileImageUrl(),
-                pet.getColor(), pet.getWalkedDistance(),
+                pet.getColor(), 0,
                 Math.toIntExact(totals.get("distance", Long.class)),
                 Math.toIntExact(totals.get("duration", Long.class)),
                 totals.get("count", Long.class),
@@ -297,7 +297,7 @@ class PetTrackingSummaryPerformanceTest extends TestContainerConfig {
         }
         return new TotalPetTracking(
                 pet.getId(), startDate, endDate, pet.getName(), pet.getProfileImageUrl(),
-                pet.getColor(), pet.getWalkedDistance(),
+                pet.getColor(), 0,
                 Math.toIntExact(totals.distance),
                 Math.toIntExact(totals.duration),
                 totals.count,
@@ -308,7 +308,7 @@ class PetTrackingSummaryPerformanceTest extends TestContainerConfig {
     private TotalPetTracking emptySummary(Pet pet, LocalDate startDate, LocalDate endDate) {
         return new TotalPetTracking(
                 pet.getId(), startDate, endDate, pet.getName(), pet.getProfileImageUrl(),
-                pet.getColor(), pet.getWalkedDistance(), 0, 0, 0L, 0.0, 0);
+                pet.getColor(), 0, 0, 0, 0L, 0.0, 0);
     }
 
     private double medianMillis(Supplier<List<TotalPetTracking>> invocation) {


### PR DESCRIPTION
# 📌 Pull Request: 펫 누적 산책 거리 실시간 집계 리팩터링

# 📝 작업 요약 (Summary)

`Pet.walkedDistance`에 산책 거리를 누적 저장하던 구조를 제거하고, 실제 `pet_tracking`과 `tracking` 기록을 기준으로 누적 거리를 계산하도록 변경했습니다.

산책 삭제나 향후 거리 수정 시 별도의 차감·보정 로직 없이도 진행도와 뱃지가 실제 산책 기록과 일치합니다. 진행도 목록은 펫별 반복 조회 없이 `GROUP BY` 집계 쿼리 한 번으로 계산합니다.

# 🛠️ 변경 사항 (Changes)

## 1. 누적 거리 필드 제거

- `Pet`
    - `walkedDistance` JPA 필드와 `addWalkedDistance()`를 제거했습니다.
- `TrackingCommandService`
    - 산책 저장 시 펫의 누적 거리를 직접 증가시키던 로직을 제거했습니다.
    - 산책과 펫의 관계(`PetTracking`)만 저장하므로, 거리의 원천 데이터는 `Tracking.distance`로 단일화됩니다.

> DB 영향: JPA 매핑에서만 `walked_distance` 컬럼을 제거했습니다. 운영 DB의 물리 컬럼은 즉시 삭제하지 않아도 동작하며, 데이터 백업 검증 후 별도 마이그레이션으로 제거할 수 있습니다.

## 2. 펫별 누적 거리 GROUP BY 집계

- `PetTrackingRepoCustom`
    - 선택한 펫 ID 목록의 누적 산책 거리를 한 번에 조회하는 `findTotalWalkedDistancesByPetIds()`를 추가했습니다.
- `PetTrackingRepoCustomImpl`
    - `pet → pet_tracking → tracking`을 `LEFT JOIN`하고 `GROUP BY pet.id`로 집계합니다.
    - 산책 기록이 없는 펫도 `0` 거리로 반환합니다.
- `PetStatistics`
    - 조회 결과를 `Map<petId, walkedDistance>`로 변환해 진행도·상세 조회에서 재사용합니다.

## 3. 응답 및 통계 조회 정합성 개선

- `PetQueryService`, `PetProgressResponse`
    - 전체·단건·복수 펫 진행도 조회에서 펫 목록 조회 후, 선택된 펫 전체의 누적 거리를 한 번에 집계합니다.
    - 요청한 펫 순서는 유지하면서 집계 거리를 진행도와 뱃지 계산에 사용합니다.
- `PetDetailResponse`, `PetCommandService`
    - 상세 응답의 뱃지 거리도 실제 산책 기록 기준으로 계산합니다.
    - 신규 펫 등록 직후에는 산책 기록이 없으므로 `0` 거리로 응답합니다.
- `TotalPetTracking`
    - 주간 통계의 뱃지용 누적 거리도 `Pet` 컬럼이 아닌 전체 산책 기록 합계 기준으로 조회합니다.
