### PR TITLE
fix: 헬스체크와 HTTP 메서드 예외를 처리

### DIFF
--- a/.github/workflows/deployment/compose/docker-compose.backend.yml
+++ b/.github/workflows/deployment/compose/docker-compose.backend.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "${BACKEND_PORT}:8080"
       # Alloy만 metrics를 수집하므로 외부에는 노출하지 않는다.
-      - "127.0.0.1:8081:8081"
+      - "8081:8081"
     volumes:
       - /home/ubuntu/logs:/app/logs
       - /home/ubuntu/puppyrun/config/firebase-service-account.json:/run/secrets/firebase-service-account.json:ro

--- a/src/main/java/org/zerock/puppyrun/common/exception/ErrorCode.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "CLIENT_001", "잘못된 요청입니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "CLIENT_002", "요청한 값을 찾을 수 없습니다."),
     EXISTS_RESOURCE(HttpStatus.CONFLICT, "CLIENT_003", "이미 존재하는 값입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "CLIENT_004", "지원하지 않는 HTTP 메서드입니다."),
 
     // 인증/인가 관련 에러
     USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "로그인 정보가 유효하지 않습니다."),

--- a/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 
@@ -165,6 +166,22 @@ public class GlobalExceptionHandler {
                 .body(errorResponse);
     }
 
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(
+                        errorCode.getCode(),
+                        errorCode.getDescription(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
 
     /**
      * 그 외 예상치 못한 모든 예외
@@ -174,7 +191,7 @@ public class GlobalExceptionHandler {
             Exception e,
             HttpServletRequest request) {
 
-        log.error("Unhandled RuntimeException: ", e); // 스택 트레이스 전체 로깅
+        log.error("Unhandled RuntimeException: ", e.getMessage(), e); // 스택 트레이스 전체 로깅
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
 
         ErrorResponse errorResponse = ErrorResponse.of(


### PR DESCRIPTION
- docker-compose.backend.yml:
  - ALB 대상 그룹이 8081 헬스체크 엔드포인트에 접근하도록 Actuator 포트를 모든 인터페이스에 공개
- ErrorCode:
  - 지원하지 않는 HTTP 메서드용 CLIENT_004 오류 코드를 추가
- GlobalExceptionHandler:
  - HttpRequestMethodNotSupportedException을 500 대신 405 응답으로 변환

