### PR TITLE
fix: API 예외 응답과 요청 추적 로그 보강 

### DIFF
--- a/src/main/java/org/zerock/puppyrun/common/exception/ErrorCode.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "CLIENT_002", "요청한 값을 찾을 수 없습니다."),
     EXISTS_RESOURCE(HttpStatus.CONFLICT, "CLIENT_003", "이미 존재하는 값입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "CLIENT_004", "지원하지 않는 HTTP 메서드입니다."),
+    UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "CLIENT_005", "지원하지 않는 Content-Type입니다."),
 
     // 인증/인가 관련 에러
     USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "로그인 정보가 유효하지 않습니다."),

--- a/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandler.java
@@ -7,12 +7,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 
 @RestControllerAdvice
@@ -28,11 +30,13 @@ public class GlobalExceptionHandler {
             HttpServletRequest request) {
 
         log.warn(
-                "exceptionType={}, errorCode={}, status={}, uri={}, message={}",
+                "Handled business exception. exceptionType={}, errorCode={}, status={}, method={}, uri={}, contentType={}, message={}",
                 e.getClass().getSimpleName(),
                 e.getErrorCode().getCode(),
                 e.getErrorCode().getHttpStatus().value(),
+                request.getMethod(),
                 request.getRequestURI(),
+                request.getContentType(),
                 e.getMessage()
         );
 
@@ -114,11 +118,13 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
 
         log.warn(
-                "exceptionType={}, errorCode={}, status={}, uri={}, message={}",
+                "Handled exception. exceptionType={}, errorCode={}, status={}, method={}, uri={}, contentType={}, message={}",
                 e.getClass().getSimpleName(),
                 errorCode.getCode(),
                 errorCode.getHttpStatus().value(),
+                request.getMethod(),
                 request.getRequestURI(),
+                request.getContentType(),
                 e.getMessage()
         );
 
@@ -210,6 +216,62 @@ public class GlobalExceptionHandler {
                 ));
     }
 
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(
+            NoResourceFoundException e,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = ErrorCode.RESOURCE_NOT_FOUND;
+
+        log.warn(
+                "Handled exception. exceptionType={}, errorCode={}, status={}, method={}, uri={}, contentType={}, message={}",
+                e.getClass().getSimpleName(),
+                errorCode.getCode(),
+                errorCode.getHttpStatus().value(),
+                request.getMethod(),
+                request.getRequestURI(),
+                request.getContentType(),
+                e.getMessage()
+        );
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(
+                        errorCode.getCode(),
+                        errorCode.getDescription(),
+                        "요청한 리소스를 찾을 수 없습니다.",
+                        request.getRequestURI()
+                ));
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(
+            HttpMediaTypeNotSupportedException e,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = ErrorCode.UNSUPPORTED_MEDIA_TYPE;
+
+        log.warn(
+                "Handled exception. exceptionType={}, errorCode={}, status={}, method={}, uri={}, contentType={}, message={}",
+                e.getClass().getSimpleName(),
+                errorCode.getCode(),
+                errorCode.getHttpStatus().value(),
+                request.getMethod(),
+                request.getRequestURI(),
+                request.getContentType(),
+                e.getMessage()
+        );
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(
+                        errorCode.getCode(),
+                        errorCode.getDescription(),
+                        "지원하지 않는 Content-Type입니다.",
+                        request.getRequestURI()
+                ));
+    }
+
     /**
      * 그 외 예상치 못한 모든 예외
      */
@@ -218,8 +280,19 @@ public class GlobalExceptionHandler {
             Exception e,
             HttpServletRequest request) {
 
-        log.error("Unhandled RuntimeException: ", e.getMessage(), e); // 스택 트레이스 전체 로깅
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+
+        log.error(
+                "Unhandled exception. exceptionType={}, errorCode={}, status={}, method={}, uri={}, contentType={}, message={}",
+                e.getClass().getSimpleName(),
+                errorCode.getCode(),
+                errorCode.getHttpStatus().value(),
+                request.getMethod(),
+                request.getRequestURI(),
+                request.getContentType(),
+                e.getMessage(),
+                e
+        );
 
         ErrorResponse errorResponse = ErrorResponse.of(
                 errorCode.getCode(),

--- a/src/main/java/org/zerock/puppyrun/common/logging/TraceIdFilter.java
+++ b/src/main/java/org/zerock/puppyrun/common/logging/TraceIdFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -14,6 +15,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
+@Slf4j
 public class TraceIdFilter extends OncePerRequestFilter {
 
     public static final String TRACE_ID = "traceId";
@@ -28,11 +30,44 @@ public class TraceIdFilter extends OncePerRequestFilter {
         String traceId = UUID.randomUUID().toString();
         MDC.put(TRACE_ID, traceId);
         response.setHeader(TRACE_ID_HEADER, traceId);
+        long startedAt = System.nanoTime();
 
         try {
             filterChain.doFilter(request, response);
         } finally {
+            logRequestCompletion(request, response, startedAt);
             MDC.remove(TRACE_ID);
         }
+    }
+
+    private void logRequestCompletion(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            long startedAt
+    ) {
+        long durationMs = (System.nanoTime() - startedAt) / 1_000_000;
+        int status = response.getStatus();
+        String contentType = request.getContentType() == null ? "-" : request.getContentType();
+
+        if (status >= 400) {
+            log.warn(
+                    "HTTP request completed. method={}, uri={}, status={}, contentType={}, durationMs={}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    status,
+                    contentType,
+                    durationMs
+            );
+            return;
+        }
+
+        log.info(
+                "HTTP request completed. method={}, uri={}, status={}, contentType={}, durationMs={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                status,
+                contentType,
+                durationMs
+        );
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -74,6 +74,10 @@
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
         </logger>
+        <logger name="org.zerock.puppyrun.common.logging.TraceIdFilter" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </logger>
 
         <root level="ERROR">
             <appender-ref ref="CONSOLE"/>

--- a/src/test/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/org/zerock/puppyrun/common/exception/GlobalExceptionHandlerTest.java
@@ -5,10 +5,15 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 class GlobalExceptionHandlerTest {
 
@@ -31,5 +36,47 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody())
                 .extracting(ErrorResponse::getCode, ErrorResponse::getMessage, ErrorResponse::getPath)
                 .containsExactly("SERVER_001", "소셜 이메일 제공 동의가 필요합니다.", "/api/oauth2/kakao/sign-in");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리소스 요청은 404 응답으로 변환한다")
+    void handleNoResourceFoundException() {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getRequestURI()).willReturn("/api/not-found");
+        NoResourceFoundException exception = new NoResourceFoundException(HttpMethod.GET, "api/not-found");
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler
+                .handleNoResourceFoundException(exception, request);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody())
+                .extracting(ErrorResponse::getCode, ErrorResponse::getMessage, ErrorResponse::getPath)
+                .containsExactly("CLIENT_002", "요청한 리소스를 찾을 수 없습니다.", "/api/not-found");
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 Content-Type 요청은 415 응답으로 변환한다")
+    void handleHttpMediaTypeNotSupportedException() {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getRequestURI()).willReturn("/api/diaries");
+        HttpMediaTypeNotSupportedException exception = new HttpMediaTypeNotSupportedException(
+                MediaType.MULTIPART_FORM_DATA,
+                List.of(MediaType.APPLICATION_JSON),
+                HttpMethod.POST
+        );
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler
+                .handleHttpMediaTypeNotSupportedException(exception, request);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        assertThat(response.getBody())
+                .extracting(ErrorResponse::getCode, ErrorResponse::getMessage, ErrorResponse::getPath)
+                .containsExactly("CLIENT_005", "지원하지 않는 Content-Type입니다.", "/api/diaries");
     }
 }


### PR DESCRIPTION
# 📌 Pull Request: API 예외 응답과 요청 추적 로그 보강

# 📝 작업 요약 (Summary)

- 지원하지 않는 Content-Type과 존재하지 않는 리소스 요청이 일반 서버 오류로 처리되는 문제를 각각 415, 404 응답으로 바로잡았습니다.
- 같은 traceId로 요청의 HTTP 메서드와 URI를 추적할 수 있도록 접근 로그를 보강했습니다.

# 🛠️ 변경 사항 (Changes)

## 1. 전역 예외 처리

- **ErrorCode**
  - 지원하지 않는 Content-Type에 사용할 `CLIENT_005` 오류 코드를 추가했습니다.
- **GlobalExceptionHandler**
  - `NoResourceFoundException`을 `404 Not Found`, `CLIENT_002`로 변환합니다.
  - `HttpMediaTypeNotSupportedException`을 `415 Unsupported Media Type`, `CLIENT_005`로 변환합니다.
  - 처리된 예외 및 미처리 예외 로그에 HTTP 메서드, URI, Content-Type을 기록합니다.

## 2. 요청 추적 로그

- **TraceIdFilter**
  - 모든 요청 완료 시 method, URI, status, Content-Type, 처리 시간을 기록합니다.
  - 4xx/5xx 응답은 WARN, 정상 응답은 INFO로 기록합니다.
- **운영 로그 설정**
  - 운영 환경에서도 접근 로그를 콘솔 및 파일에 남깁니다.
  - 요청 본문, 쿼리 값, Authorization 헤더는 기록하지 않습니다.

# 📸 테스트 시나리오 (Test Scenarios)

- `./gradlew clean test` 통과

## 1. 지원하지 않는 Content-Type 요청

* **Method**: POST
* **URL**: `/api/diaries`
* **Content-Type**: `multipart/form-data`
* **Header**: `Authorization: Bearer {accessToken}`

### ❌ 1-1 : JSON API에 multipart 요청 전송

**Response (415 Unsupported Media Type)**

```json
{
  "code": "CLIENT_005",
  "description": "지원하지 않는 Content-Type입니다.",
  "message": "지원하지 않는 Content-Type입니다.",
  "path": "/api/diaries",
  "timestamp": "2026-08-24T10:00:00"
}
```

## 2. 존재하지 않는 리소스 요청

* **Method**: GET
* **URL**: `/api/not-found`
* **Content-Type**: 없음
* **Header**: `Authorization: Bearer {accessToken}`

### ❌ 2-1 : 존재하지 않는 경로 요청

**Response (404 Not Found)**

```json
{
  "code": "CLIENT_002",
  "description": "요청한 값을 찾을 수 없습니다.",
  "message": "요청한 리소스를 찾을 수 없습니다.",
  "path": "/api/not-found",
  "timestamp": "2026-08-24T10:00:00"
}
```
