### PR TITLE
Chae joo/fix/batch upload

### DIFF
--- a/src/main/java/org/zerock/puppyrun/common/config/AsyncConfig.java
+++ b/src/main/java/org/zerock/puppyrun/common/config/AsyncConfig.java
@@ -1,20 +1,64 @@
 package org.zerock.puppyrun.common.config;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
+import org.slf4j.MDC;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @EnableAsync
 @Configuration
 public class AsyncConfig {
+
+    @Bean
+    public TaskDecorator mdcTaskDecorator() {
+        return runnable -> {
+            Map<String, String> parentContext = MDC.getCopyOfContextMap();
+
+            return () -> {
+                Map<String, String> previousContext = MDC.getCopyOfContextMap();
+                try {
+                    if (parentContext == null) {
+                        MDC.clear();
+                    } else {
+                        MDC.setContextMap(parentContext);
+                    }
+                    runnable.run();
+                } finally {
+                    if (previousContext == null) {
+                        MDC.clear();
+                    } else {
+                        MDC.setContextMap(previousContext);
+                    }
+                }
+            };
+        };
+    }
+
+    /**
+     * 파일 보상 삭제 등 일반 비동기 작업을 처리합니다.
+     */
+    @Bean(name = "applicationTaskExecutor")
+    public Executor applicationTaskExecutor(TaskDecorator mdcTaskDecorator) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(Runtime.getRuntime().availableProcessors());
+        executor.setMaxPoolSize(Runtime.getRuntime().availableProcessors() * 2);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("App-Async-");
+        executor.setTaskDecorator(mdcTaskDecorator);
+        executor.initialize();
+        return executor;
+    }
+
     /**
      * 알림 설정을 위한 스레드 풀 생성
      */
     @Bean(name = "notificationTaskExecutor")
-    public Executor notificationTaskExecutor() {
+    public Executor notificationTaskExecutor(TaskDecorator mdcTaskDecorator) {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 
         // 기본 스레드 수: 코어 수와 동일하게 설정
@@ -31,6 +75,7 @@ public class AsyncConfig {
 
         // 로그에 스레드 이름이 찍혀 디버깅에 용이
         executor.setThreadNamePrefix("FCM-Noti-");
+        executor.setTaskDecorator(mdcTaskDecorator);
 
         executor.initialize();
         return executor;

--- a/src/main/java/org/zerock/puppyrun/common/logging/TraceIdFilter.java
+++ b/src/main/java/org/zerock/puppyrun/common/logging/TraceIdFilter.java
@@ -49,25 +49,15 @@ public class TraceIdFilter extends OncePerRequestFilter {
         int status = response.getStatus();
         String contentType = request.getContentType() == null ? "-" : request.getContentType();
 
-        if (status >= 400) {
-            log.warn(
-                    "HTTP request completed. method={}, uri={}, status={}, contentType={}, durationMs={}",
-                    request.getMethod(),
-                    request.getRequestURI(),
-                    status,
-                    contentType,
-                    durationMs
-            );
-            return;
-        }
+        switch (status / 100) {
+            case 5 -> log.error("HTTP request error. method={}, uri={}, status={}, contentType={}, durationMs={}",
+                    request.getMethod(), request.getRequestURI(), status, contentType, durationMs);
 
-        log.info(
-                "HTTP request completed. method={}, uri={}, status={}, contentType={}, durationMs={}",
-                request.getMethod(),
-                request.getRequestURI(),
-                status,
-                contentType,
-                durationMs
-        );
+            case 4 -> log.warn("HTTP request warn. method={}, uri={}, status={}, contentType={}, durationMs={}",
+                    request.getMethod(), request.getRequestURI(), status, contentType, durationMs);
+
+            default -> log.info("HTTP request completed. method={}, uri={}, status={}, contentType={}, durationMs={}",
+                    request.getMethod(), request.getRequestURI(), status, contentType, durationMs);
+        }
     }
 }

--- a/src/main/java/org/zerock/puppyrun/common/s3/S3Service.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/S3Service.java
@@ -120,7 +120,7 @@ public class S3Service {
      *
      * @param files 삭제할 파일들의 Key 또는 Full URL 리스트
      */
-    @Async
+    @Async("applicationTaskExecutor")
     public void deleteAll(List<String> files) {
         if (files == null || files.isEmpty()) {
             return;
@@ -134,7 +134,7 @@ public class S3Service {
      *
      * @param file 삭제할 파일의 Key 또는 Full URL
      */
-    @Async
+    @Async("applicationTaskExecutor")
     public void delete(String file) {
         if (file == null) {
             return; // null이면 넘어감

--- a/src/main/java/org/zerock/puppyrun/common/s3/S3Service.java
+++ b/src/main/java/org/zerock/puppyrun/common/s3/S3Service.java
@@ -15,15 +15,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import org.zerock.puppyrun.common.exception.DataIntegrityException;
 import org.zerock.puppyrun.common.s3.rollback.S3RollbackEvent;
 
 /**
- * AWS S3 파일 업로드 및 삭제를 담당하는 인프라 서비스입니다. 모든 업로드 작업은 DB 트랜잭션 롤백 시 자동 삭제를 위한 이벤트를 발행합니다.
+ * AWS S3 파일 업로드 및 삭제를 담당하는 인프라 서비스입니다. 다중 업로드는 성공한 객체를 롤백 보상 이벤트에 등록해 현재 DB 트랜잭션이 실패할 때 정리합니다.
  */
 @Slf4j
 @Service
@@ -58,7 +57,7 @@ public class S3Service {
     }
 
     /**
-     * 여러 파일을 병렬로 S3에 업로드합니다.
+     * 여러 파일을 순차적으로 S3에 업로드합니다.
      *
      * @param files 업로드할 멀티파트 파일 리스트
      * @param path  저장될 도메인 경로(PathContext)
@@ -68,40 +67,33 @@ public class S3Service {
         if (files == null || files.isEmpty()) {
             return List.of();
         }
-        
+
         // null이거나 비어있는 파일은 "첨부하지 않은 것"으로 간주하여 필터링 (skip)
-        List<CompletableFuture<String>> futures = files.stream()
+        List<MultipartFile> validFiles = files.stream()
                 .filter(file -> file != null && !file.isEmpty())
-                .map(file -> CompletableFuture.supplyAsync(() -> uploadOne(file, path)))
                 .toList();
 
-        if (futures.isEmpty()) {
+        if (validFiles.isEmpty()) {
             return List.of();
         }
 
-        // 일부 업로드가 실패해도 나머지 작업까지 모두 끝나야 정확한 보상 대상을 알 수 있음
+        List<String> uploadedKeys = new ArrayList<>(validFiles.size());
         try {
-            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
-        } catch (CompletionException e) {
-            List<String> uploadedKeys = futures.stream()
-                    .filter(future -> !future.isCompletedExceptionally())
-                    .map(CompletableFuture::join)
-                    .toList();
-
-            // 성공한 파일은 현재 트랜잭션이 롤백될 때 함께 삭제되도록 등록
+            for (MultipartFile file : validFiles) {
+                uploadedKeys.add(uploadOne(file, path));
+            }
+        } catch (RuntimeException e) {
+            // 첫 실패 이전까지 성공한 객체를 현재 트랜잭션의 롤백 대상으로 등록
             publishRollbackEvent(uploadedKeys);
-            log.warn("다중 S3 업로드가 일부 실패했습니다. 롤백 대상: {}건", uploadedKeys.size(), e);
+            log.warn("순차 S3 업로드가 중단되었습니다. 성공: {}건, 롤백 대상: {}건",
+                    uploadedKeys.size(), uploadedKeys.size(), e);
             throw e;
         }
 
-        List<String> uploadedKeys = futures.stream()
-                .map(CompletableFuture::join)
-                .toList();
-
-        // 업로드된 모든 파일에 대해 통합 롤백 이벤트 발행
+        // 모두 성공한 경우에도 이후 DB 트랜잭션 실패에 대비해 통합 롤백 이벤트 발행
         publishRollbackEvent(uploadedKeys);
 
-        return uploadedKeys;
+        return List.copyOf(uploadedKeys);
     }
 
     private String uploadOne(MultipartFile file, PathContext path) {

--- a/src/test/java/org/zerock/puppyrun/common/config/AsyncConfigTest.java
+++ b/src/test/java/org/zerock/puppyrun/common/config/AsyncConfigTest.java
@@ -1,0 +1,55 @@
+package org.zerock.puppyrun.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+class AsyncConfigTest {
+
+    @Test
+    @DisplayName("비동기 작업은 요청 traceId를 전달하고 종료 후 MDC를 정리한다")
+    void propagateAndClearMdc() throws Exception {
+        // given
+        AsyncConfig asyncConfig = new AsyncConfig();
+        TaskDecorator taskDecorator = asyncConfig.mdcTaskDecorator();
+        ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) asyncConfig.applicationTaskExecutor(taskDecorator);
+        AtomicReference<String> propagatedTraceId = new AtomicReference<>();
+        AtomicReference<String> nextTaskTraceId = new AtomicReference<>();
+        CountDownLatch firstTaskCompleted = new CountDownLatch(1);
+        CountDownLatch secondTaskCompleted = new CountDownLatch(1);
+
+        try {
+            MDC.put("traceId", "request-trace-id");
+
+            // when
+            executor.execute(() -> {
+                propagatedTraceId.set(MDC.get("traceId"));
+                firstTaskCompleted.countDown();
+            });
+
+            assertThat(firstTaskCompleted.await(3, TimeUnit.SECONDS)).isTrue();
+            MDC.clear();
+
+            executor.execute(() -> {
+                nextTaskTraceId.set(MDC.get("traceId"));
+                secondTaskCompleted.countDown();
+            });
+
+            assertThat(secondTaskCompleted.await(3, TimeUnit.SECONDS)).isTrue();
+
+            // then
+            assertThat(propagatedTraceId).hasValue("request-trace-id");
+            assertThat(nextTaskTraceId).hasValue(null);
+        } finally {
+            MDC.clear();
+            executor.shutdown();
+        }
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/s3/S3CompensationPerformanceTest.java
+++ b/src/test/java/org/zerock/puppyrun/s3/S3CompensationPerformanceTest.java
@@ -1,0 +1,163 @@
+package org.zerock.puppyrun.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+
+import io.awspring.cloud.s3.S3Template;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.multipart.MultipartFile;
+import org.zerock.puppyrun.a_config.TestContainerConfig;
+import org.zerock.puppyrun.common.s3.PathContext;
+import org.zerock.puppyrun.common.s3.S3Service;
+import org.zerock.puppyrun.support.BenchmarkStatistics;
+
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@EnabledIfEnvironmentVariable(named = "S3_COMPENSATION_BENCHMARK_ENABLED", matches = "true")
+@TestPropertySource(properties = {
+        "logging.level.org.zerock.puppyrun.common.s3=OFF"
+})
+@DisplayName("S3 다중 업로드와 트랜잭션 보상 수동 성능 테스트")
+class S3CompensationPerformanceTest extends TestContainerConfig {
+
+    private static final int WARM_UP_COUNT = 5;
+    private static final int SAMPLE_COUNT = 30;
+    private static final PathContext PATH = new PathContext.UserProfileContext(
+            UUID.fromString("00000000-0000-0000-0000-000000000001")
+    );
+
+    @Autowired
+    private S3Service s3Service;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @MockBean
+    private S3Template s3Template;
+
+    private final AtomicReference<String> failureMarker = new AtomicReference<>();
+    private final AtomicInteger uploadAttempts = new AtomicInteger();
+    private final AtomicInteger deleteAttempts = new AtomicInteger();
+
+    @BeforeEach
+    void setUp() {
+        reset(s3Template);
+
+        doAnswer(invocation -> {
+            uploadAttempts.incrementAndGet();
+            String key = invocation.getArgument(1, String.class);
+            String marker = failureMarker.get();
+            if (marker != null && key.endsWith(marker)) {
+                throw new RuntimeException("controlled S3 upload failure");
+            }
+            return null;
+        }).when(s3Template).upload(any(), any(), any(), any());
+
+        doAnswer(invocation -> {
+            deleteAttempts.incrementAndGet();
+            return null;
+        }).when(s3Template).deleteObject(any(), any());
+    }
+
+    @Test
+    @DisplayName("Mock S3 경계에서 100장 순차 업로드와 81번째 실패 보상 완료 시간을 반복 측정한다")
+    void benchmarkUploadAndRollbackCompensation() {
+        // given
+        List<MultipartFile> successFiles = files(false);
+        List<MultipartFile> failureFiles = files(true);
+
+        IntStream.range(0, WARM_UP_COUNT).forEach(ignored -> measureSuccessfulUpload(successFiles));
+        IntStream.range(0, WARM_UP_COUNT).forEach(ignored -> measureRollback(failureFiles));
+
+        // when
+        List<Long> uploadSamples = new ArrayList<>(SAMPLE_COUNT);
+        List<Long> rollbackSamples = new ArrayList<>(SAMPLE_COUNT);
+        for (int sample = 0; sample < SAMPLE_COUNT; sample++) {
+            clearInvocations(s3Template);
+            uploadSamples.add(measureSuccessfulUpload(successFiles));
+            rollbackSamples.add(measureRollback(failureFiles));
+        }
+
+        BenchmarkStatistics uploadStats = BenchmarkStatistics.fromNanos(uploadSamples);
+        BenchmarkStatistics rollbackStats = BenchmarkStatistics.fromNanos(rollbackSamples);
+
+        // then
+        System.out.println(uploadStats.format("s3_upload_all_100", 100, "files"));
+        System.out.println(rollbackStats.format("s3_fail_at_81_and_delete_80", 80, "deleted-files"));
+    }
+
+    private long measureSuccessfulUpload(List<MultipartFile> files) {
+        failureMarker.set(null);
+        uploadAttempts.set(0);
+        deleteAttempts.set(0);
+
+        long startedAt = System.nanoTime();
+        List<String> keys = transactionTemplate.execute(status -> s3Service.uploadAll(files, PATH));
+        long elapsed = System.nanoTime() - startedAt;
+
+        assertThat(keys).hasSize(100).doesNotHaveDuplicates();
+        assertThat(uploadAttempts).hasValue(100);
+        assertThat(deleteAttempts).hasValue(0);
+        return elapsed;
+    }
+
+    private long measureRollback(List<MultipartFile> files) {
+        failureMarker.set("_fail-80.png");
+        uploadAttempts.set(0);
+        deleteAttempts.set(0);
+
+        long startedAt = System.nanoTime();
+        Throwable thrown = catchThrowable(() -> transactionTemplate.executeWithoutResult(
+                status -> s3Service.uploadAll(files, PATH)
+        ));
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(1))
+                .until(() -> deleteAttempts.get() == 80);
+        long elapsed = System.nanoTime() - startedAt;
+
+        assertThat(thrown)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("controlled S3 upload failure");
+        assertThat(uploadAttempts).hasValue(81);
+        assertThat(deleteAttempts).hasValue(80);
+        return elapsed;
+    }
+
+    private List<MultipartFile> files(boolean includeFailure) {
+        return IntStream.range(0, 100)
+                .mapToObj(index -> {
+                    String name = includeFailure && index == 80
+                            ? "fail-80.png"
+                            : "success-" + index + ".png";
+                    return (MultipartFile) new MockMultipartFile(
+                            "file",
+                            name,
+                            "image/png",
+                            new byte[1_024]
+                    );
+                })
+                .toList();
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/s3/S3ServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/s3/S3ServiceTest.java
@@ -5,18 +5,22 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.awspring.cloud.s3.S3Template;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletionException;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -94,8 +98,8 @@ class S3ServiceTest {
     }
 
     @Test
-    @DisplayName("다중 업로드가 일부 실패하면 성공한 파일을 보상 대상으로 남긴다")
-    void registerSuccessfulFilesForRollbackOnPartialFailure() {
+    @DisplayName("순차 업로드가 일부 실패하면 이전에 성공한 파일을 롤백 이벤트에 등록한다")
+    void registerPreviousSuccessfulFilesOnUploadFailure() {
         // given
         MockMultipartFile success = file("success.png", "success");
         MockMultipartFile failure = file("failure.png", "failure");
@@ -114,9 +118,11 @@ class S3ServiceTest {
 
         // then
         assertThat(thrown)
-                .isInstanceOf(CompletionException.class)
-                .hasRootCauseMessage("S3 upload failed");
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("S3 upload failed");
+        verify(s3Template, times(2)).upload(eq("test-bucket"), any(), any(), any());
 
+        verify(s3Template, never()).deleteObject(eq("test-bucket"), any());
         ArgumentCaptor<S3RollbackEvent> eventCaptor = ArgumentCaptor.forClass(S3RollbackEvent.class);
         verify(eventPublisher).publishEvent(eventCaptor.capture());
         assertThat(eventCaptor.getValue().filePaths())
@@ -146,6 +152,119 @@ class S3ServiceTest {
                         "local/profile/first.png",
                         "local/profile/second file.png"
                 );
+    }
+
+    @Test
+    @DisplayName("파일명이 같은 사진 100장을 모두 업로드하고 중복 없는 Key 100개를 보상 대상으로 등록한다")
+    void uploadOneHundredFilesTogether() {
+        // given
+        List<MultipartFile> files = IntStream.range(0, 100)
+                .mapToObj(index -> (MultipartFile) file("same-name.png", "image-" + index))
+                .toList();
+
+        // when
+        List<String> uploadedKeys = s3Service.uploadAll(files, path);
+
+        // then
+        assertThat(uploadedKeys)
+                .hasSize(100)
+                .doesNotHaveDuplicates()
+                .allSatisfy(key -> assertThat(key)
+                        .startsWith("local/" + path.getPath())
+                        .endsWith("_same-name.png"));
+        verify(s3Template, times(100)).upload(eq("test-bucket"), any(), any(), any());
+
+        ArgumentCaptor<S3RollbackEvent> eventCaptor = ArgumentCaptor.forClass(S3RollbackEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().filePaths())
+                .hasSize(100)
+                .containsExactlyElementsOf(uploadedKeys);
+    }
+
+    @Test
+    @DisplayName("사진 입력 100개에 정상·빈 파일·null이 섞이면 정상 파일 60개만 업로드한다")
+    void uploadOnlyValidFilesFromOneHundredMixedInputs() {
+        // given
+        List<MultipartFile> files = new ArrayList<>();
+        for (int index = 0; index < 100; index++) {
+            if (index % 5 == 0) {
+                files.add(null);
+            } else if (index % 5 == 1) {
+                files.add(file("empty-" + index + ".png", ""));
+            } else {
+                files.add(file("photo-" + index + ".png", "image-" + index));
+            }
+        }
+
+        // when
+        List<String> uploadedKeys = s3Service.uploadAll(files, path);
+
+        // then
+        assertThat(uploadedKeys).hasSize(60).doesNotHaveDuplicates();
+        verify(s3Template, times(60)).upload(eq("test-bucket"), any(), any(), any());
+
+        ArgumentCaptor<S3RollbackEvent> eventCaptor = ArgumentCaptor.forClass(S3RollbackEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().filePaths()).hasSize(60);
+    }
+
+    @ParameterizedTest(name = "100장 중 {0}번 인덱스에서 첫 실패")
+    @ValueSource(ints = {1, 10, 50, 99})
+    @DisplayName("사진 100장의 실패 위치가 달라도 실패 전 성공한 Key만 롤백 이벤트에 등록한다")
+    void stopAtFirstFailureAndRegisterPreviousSuccessfulKeys(int failureIndex) {
+        // given
+        List<MultipartFile> files = IntStream.range(0, 100)
+                .mapToObj(index -> index == failureIndex
+                        ? (MultipartFile) file("fail-" + index + ".png", "failure")
+                        : (MultipartFile) file("success-" + index + ".png", "success"))
+                .toList();
+        doAnswer(invocation -> {
+            String key = invocation.getArgument(1, String.class);
+            if (key.contains("_fail-")) {
+                throw new RuntimeException("S3 upload failed");
+            }
+            return null;
+        }).when(s3Template).upload(any(), any(), any(), any());
+
+        // when
+        Throwable thrown = catchThrowable(() -> s3Service.uploadAll(files, path));
+
+        // then
+        assertThat(thrown)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("S3 upload failed");
+        verify(s3Template, times(failureIndex + 1))
+                .upload(eq("test-bucket"), any(), any(), any());
+
+        verify(s3Template, never()).deleteObject(eq("test-bucket"), any());
+        ArgumentCaptor<S3RollbackEvent> eventCaptor = ArgumentCaptor.forClass(S3RollbackEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().filePaths())
+                .hasSize(failureIndex)
+                .allMatch(key -> key.contains("_success-"));
+    }
+
+    @Test
+    @DisplayName("사진 100장의 첫 번째 업로드가 실패하면 나머지 99장을 시도하지 않고 이벤트도 발행하지 않는다")
+    void stopWithoutEventWhenFirstOfOneHundredFilesFails() {
+        // given
+        List<MultipartFile> files = IntStream.range(0, 100)
+                .mapToObj(index -> (MultipartFile) file("fail-" + index + ".png", "failure"))
+                .toList();
+        doAnswer(invocation -> {
+            throw new RuntimeException("S3 upload failed");
+        }).when(s3Template).upload(any(), any(), any(), any());
+
+        // when
+        Throwable thrown = catchThrowable(() -> s3Service.uploadAll(files, path));
+
+        // then
+        assertThat(thrown)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("S3 upload failed");
+        verify(s3Template).upload(eq("test-bucket"), any(), any(), any());
+        verify(s3Template, never()).deleteObject(eq("test-bucket"), any());
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
     private MockMultipartFile file(String name, String content) {

--- a/src/test/java/org/zerock/puppyrun/s3/S3TransactionRollbackIntegrationTest.java
+++ b/src/test/java/org/zerock/puppyrun/s3/S3TransactionRollbackIntegrationTest.java
@@ -1,0 +1,204 @@
+package org.zerock.puppyrun.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import io.awspring.cloud.s3.S3Template;
+import jakarta.persistence.EntityManager;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.multipart.MultipartFile;
+import org.zerock.puppyrun.a_config.TestContainerConfig;
+import org.zerock.puppyrun.common.s3.PathContext;
+import org.zerock.puppyrun.common.s3.S3Service;
+import org.zerock.puppyrun.member.entity.Member;
+
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@DisplayName("S3와 DB 트랜잭션 보상 처리 통합 테스트")
+class S3TransactionRollbackIntegrationTest extends TestContainerConfig {
+
+    private static final String BUCKET = "AWS_S3_BUCKET_NAME";
+    private static final PathContext PATH = new PathContext.UserProfileContext(
+            UUID.fromString("00000000-0000-0000-0000-000000000001")
+    );
+
+    @Autowired
+    private S3Service s3Service;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @MockBean
+    private S3Template s3Template;
+
+    @Test
+    @DisplayName("S3 업로드 이후 후속 작업이 실패하면 트랜잭션 롤백 후 업로드 객체를 삭제한다")
+    void deleteUploadedObjectAfterTransactionRollback() {
+        // given
+        MockMultipartFile file = file("profile.png", "profile");
+        AtomicReference<String> uploadedKey = new AtomicReference<>();
+
+        // when
+        Throwable thrown = catchThrowable(() -> transactionTemplate.executeWithoutResult(status -> {
+            uploadedKey.set(s3Service.upload(file, PATH));
+            throw new IllegalStateException("downstream database work failed");
+        }));
+
+        // then
+        assertThat(thrown)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("downstream database work failed");
+        assertThat(uploadedKey.get()).endsWith("_profile.png");
+        verify(s3Template).upload(eq(BUCKET), eq(uploadedKey.get()), any(), any());
+        verify(s3Template, timeout(3_000)).deleteObject(BUCKET, uploadedKey.get());
+    }
+
+    @Test
+    @DisplayName("메서드 반환 후 JPA flush가 실패해도 트랜잭션 롤백 후 업로드 객체를 삭제한다")
+    void deleteUploadedObjectAfterCommitTimeFlushFailure() {
+        // given
+        MockMultipartFile file = file("flush-failure.png", "profile");
+        AtomicReference<String> uploadedKey = new AtomicReference<>();
+
+        // when
+        Throwable thrown = catchThrowable(() -> transactionTemplate.executeWithoutResult(status -> {
+            uploadedKey.set(s3Service.upload(file, PATH));
+
+            // Service로는 만들 수 없는 중복 이메일 상태를 의도적으로 구성해 커밋 시 flush 실패를 재현한다.
+            entityManager.persist(member("first", "duplicate@test.com"));
+            entityManager.persist(member("second", "duplicate@test.com"));
+        }));
+
+        // then
+        assertThat(thrown)
+                .isNotNull()
+                .hasRootCauseInstanceOf(SQLIntegrityConstraintViolationException.class);
+        assertThat(uploadedKey.get()).endsWith("_flush-failure.png");
+        verify(s3Template).upload(eq(BUCKET), eq(uploadedKey.get()), any(), any());
+        verify(s3Template, timeout(3_000)).deleteObject(BUCKET, uploadedKey.get());
+    }
+
+    @Test
+    @DisplayName("S3 업로드 이후 DB 트랜잭션이 커밋되면 업로드 객체를 삭제하지 않는다")
+    void keepUploadedObjectAfterTransactionCommit() {
+        // given
+        MockMultipartFile file = file("profile.png", "profile");
+
+        // when
+        String uploadedKey = transactionTemplate.execute(status -> s3Service.upload(file, PATH));
+
+        // then
+        assertThat(uploadedKey).endsWith("_profile.png");
+        verify(s3Template).upload(eq(BUCKET), eq(uploadedKey), any(), any());
+        verify(s3Template, after(500).never()).deleteObject(eq(BUCKET), any());
+    }
+
+    @Test
+    @DisplayName("순차 업로드가 부분 실패하면 트랜잭션 롤백 전에는 삭제하지 않고 롤백 후 이전 성공 객체를 삭제한다")
+    void deletePreviousSuccessfulObjectsOnlyAfterTransactionRollback() {
+        // given
+        MockMultipartFile success = file("success.png", "success");
+        MockMultipartFile failure = file("failure.png", "failure");
+        AtomicReference<Throwable> uploadFailure = new AtomicReference<>();
+        doAnswer(invocation -> {
+            String key = invocation.getArgument(1, String.class);
+            if (key.endsWith("_failure.png")) {
+                throw new RuntimeException("S3 upload failed");
+            }
+            return null;
+        }).when(s3Template).upload(any(), any(), any(), any());
+
+        // when
+        transactionTemplate.executeWithoutResult(status -> {
+            uploadFailure.set(catchThrowable(
+                    () -> s3Service.uploadAll(List.of(success, failure), PATH)
+            ));
+            verify(s3Template, never()).deleteObject(eq(BUCKET), any());
+            status.setRollbackOnly();
+        });
+
+        // then
+        assertThat(uploadFailure.get())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("S3 upload failed");
+
+        ArgumentCaptor<String> deletedKeyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(s3Template, timeout(3_000)).deleteObject(eq(BUCKET), deletedKeyCaptor.capture());
+        assertThat(deletedKeyCaptor.getValue()).endsWith("_success.png");
+        verify(s3Template, after(500).never())
+                .deleteObject(eq(BUCKET), org.mockito.ArgumentMatchers.endsWith("_failure.png"));
+    }
+
+    @Test
+    @DisplayName("사진 100장의 81번째 업로드가 실패하면 이후 요청을 중단하고 롤백 후 이전 성공 80장을 삭제한다")
+    void stopAtEightyFirstFailureAndDeletePreviousEightyObjectsAfterRollback() {
+        // given
+        List<MultipartFile> files = IntStream.range(0, 100)
+                .mapToObj(index -> index == 80
+                        ? (MultipartFile) file("fail-80.png", "failure")
+                        : (MultipartFile) file("success-" + index + ".png", "success"))
+                .toList();
+        doAnswer(invocation -> {
+            String key = invocation.getArgument(1, String.class);
+            if (key.contains("_fail-")) {
+                throw new RuntimeException("S3 upload failed");
+            }
+            return null;
+        }).when(s3Template).upload(any(), any(), any(), any());
+
+        // when
+        Throwable thrown = catchThrowable(() -> transactionTemplate.executeWithoutResult(
+                status -> s3Service.uploadAll(files, PATH)
+        ));
+
+        // then
+        assertThat(thrown)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("S3 upload failed");
+        verify(s3Template, times(81)).upload(eq(BUCKET), any(), any(), any());
+
+        ArgumentCaptor<String> deletedKeysCaptor = ArgumentCaptor.forClass(String.class);
+        verify(s3Template, timeout(5_000).times(80))
+                .deleteObject(eq(BUCKET), deletedKeysCaptor.capture());
+        assertThat(deletedKeysCaptor.getAllValues())
+                .hasSize(80)
+                .doesNotHaveDuplicates()
+                .allMatch(key -> key.contains("_success-"));
+    }
+
+    private MockMultipartFile file(String name, String content) {
+        return new MockMultipartFile("file", name, "image/png", content.getBytes());
+    }
+
+    private Member member(String nickname, String email) {
+        return Member.builder()
+                .id(UUID.randomUUID())
+                .nickName(nickname)
+                .email(email)
+                .password("encoded-password")
+                .build();
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/support/BenchmarkStatistics.java
+++ b/src/test/java/org/zerock/puppyrun/support/BenchmarkStatistics.java
@@ -1,0 +1,56 @@
+package org.zerock.puppyrun.support;
+
+import java.util.List;
+
+/**
+ * 수동 성능 테스트의 반복 측정값을 동일한 기준으로 요약합니다.
+ */
+public record BenchmarkStatistics(
+        int samples,
+        double meanMs,
+        double medianMs,
+        double p95Ms
+) {
+
+    public static BenchmarkStatistics fromNanos(List<Long> elapsedNanos) {
+        if (elapsedNanos == null || elapsedNanos.isEmpty()) {
+            throw new IllegalArgumentException("측정값은 한 건 이상 필요합니다.");
+        }
+
+        List<Double> sortedMs = elapsedNanos.stream()
+                .map(nanos -> nanos / 1_000_000.0)
+                .sorted()
+                .toList();
+
+        double mean = sortedMs.stream()
+                .mapToDouble(Double::doubleValue)
+                .average()
+                .orElseThrow();
+        double median = percentile(sortedMs, 0.50);
+        double p95 = percentile(sortedMs, 0.95);
+
+        return new BenchmarkStatistics(sortedMs.size(), mean, median, p95);
+    }
+
+    public double operationsPerSecond(int operationsPerSample) {
+        return operationsPerSample / (meanMs / 1_000.0);
+    }
+
+    public String format(String benchmark, int operationsPerSample, String operationUnit) {
+        return String.format(
+                "benchmark=%s, samples=%d, mean_ms=%.3f, median_ms=%.3f, p95_ms=%.3f, throughput=%.2f %s/s",
+                benchmark,
+                samples,
+                meanMs,
+                medianMs,
+                p95Ms,
+                operationsPerSecond(operationsPerSample),
+                operationUnit
+        );
+    }
+
+    private static double percentile(List<Double> sorted, double percentile) {
+        int index = Math.max(0, (int) Math.ceil(sorted.size() * percentile) - 1);
+        return sorted.get(index);
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request: S3 순차 업로드 보상 및 비동기 traceId 전파

# 📝 작업 요약 (Summary)

- S3 다중 업로드가 공용 스레드 풀에서 실행되어 요청 traceId가 끊기던 문제를 해소하고, 실패 시 이미 업로드된 객체만 확실히 보상 삭제하도록 개선했습니다.
- 비동기 삭제와 알림 처리에도 요청 traceId를 전파해 하나의 요청 흐름을 로그에서 추적할 수 있게 했습니다.
- DB 엔티티나 스키마 변경은 없습니다.

# 🛠️ 변경 사항 (Changes)

## 1. S3 업로드 및 트랜잭션 보상

- **S3Service**
  - 기본 공용 스레드 풀을 사용하는 병렬 업로드를 순차 업로드로 전환했습니다.
  - 업로드 도중 실패하면 그 이전에 성공한 객체 Key만 `S3RollbackEvent`에 등록합니다.
  - 첫 파일에서 실패한 경우에는 롤백 이벤트를 발행하지 않고 이후 파일을 시도하지 않습니다.
  - 비동기 S3 삭제는 `applicationTaskExecutor`를 명시적으로 사용합니다.
- **테스트**
  - 100개 파일의 업로드, null·빈 파일 혼합 입력, 실패 위치별 보상 대상을 검증합니다.
  - 트랜잭션 롤백 이후에만 이전 성공 객체가 삭제되는 통합 테스트를 추가했습니다.
  - 환경 변수로만 실행되는 수동 성능 측정과 공통 통계 계산을 추가했습니다.

## 2. 비동기 로그 추적

- **AsyncConfig**
  - `TaskDecorator`로 부모 작업의 MDC를 비동기 작업에 복사하고, 완료 후 작업 스레드의 MDC를 복원합니다.
  - 일반 비동기 작업용 `applicationTaskExecutor`와 FCM 알림 실행기에 동일한 MDC 전파를 적용했습니다.
- **TraceIdFilter**
  - HTTP 4xx 응답은 WARN, 5xx 응답은 ERROR, 정상 응답은 INFO로 접근 로그를 구분합니다.