### PR TITLE
feat: 회원 탈퇴 및 연관 데이터 정리 (#7)

### DIFF
--- a/src/main/java/org/zerock/puppyrun/member/controller/AccountController.java
+++ b/src/main/java/org/zerock/puppyrun/member/controller/AccountController.java
@@ -14,6 +14,7 @@ import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.member.DTO.MemberDTO;
 import org.zerock.puppyrun.member.controller.request.ChangeNicknameRequest;
 import org.zerock.puppyrun.member.controller.request.ChangePasswordRequest;
+import org.zerock.puppyrun.member.controller.request.DeleteAccountRequest;
 import org.zerock.puppyrun.member.controller.response.AccountResponse;
 import org.zerock.puppyrun.member.service.MemberService;
 
@@ -76,9 +77,12 @@ public class AccountController {
     }
 
     // 계정 삭제
-    // @DeleteMapping("/")
-    public ResponseEntity<?> deleteAccount(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        // TODO 추후 기능 개발 예정
-        return ResponseEntity.ok("계정 삭제 완료");
+    @DeleteMapping
+    public ResponseEntity<Void> deleteAccount(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody DeleteAccountRequest request
+    ) {
+        memberService.accountDelete(userPrincipal.id(), request.password());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/zerock/puppyrun/member/controller/request/DeleteAccountRequest.java
+++ b/src/main/java/org/zerock/puppyrun/member/controller/request/DeleteAccountRequest.java
@@ -1,0 +1,9 @@
+package org.zerock.puppyrun.member.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DeleteAccountRequest(
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/src/main/java/org/zerock/puppyrun/member/service/AccountDeletionNotificationCleanupEvent.java
+++ b/src/main/java/org/zerock/puppyrun/member/service/AccountDeletionNotificationCleanupEvent.java
@@ -1,0 +1,5 @@
+package org.zerock.puppyrun.member.service;
+
+/** 회원 탈퇴 DB 커밋 후 해제할 FCM 토큰입니다. */
+public record AccountDeletionNotificationCleanupEvent(String fcmToken) {
+}

--- a/src/main/java/org/zerock/puppyrun/member/service/AccountDeletionNotificationCleanupHandler.java
+++ b/src/main/java/org/zerock/puppyrun/member/service/AccountDeletionNotificationCleanupHandler.java
@@ -1,0 +1,25 @@
+package org.zerock.puppyrun.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.zerock.puppyrun.notification.client.NotificationEventClient;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AccountDeletionNotificationCleanupHandler {
+    private final NotificationEventClient notificationEventClient;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(AccountDeletionNotificationCleanupEvent event) {
+        for (NotificationType type : NotificationType.values()) {
+            notificationEventClient.manageTopicSubscription(event.fcmToken(), type.getCode(), false);
+        }
+        log.info("회원 탈퇴 후 FCM 토픽 구독 해제: token={}, topicCount={}",
+                event.fcmToken(), NotificationType.values().length);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/member/service/AccountDeletionS3CleanupEvent.java
+++ b/src/main/java/org/zerock/puppyrun/member/service/AccountDeletionS3CleanupEvent.java
@@ -1,0 +1,11 @@
+package org.zerock.puppyrun.member.service;
+
+import java.util.List;
+
+/** 회원 탈퇴 DB 커밋 후 삭제할 S3 객체 목록입니다. */
+public record AccountDeletionS3CleanupEvent(List<String> filePaths) {
+
+    public AccountDeletionS3CleanupEvent {
+        filePaths = List.copyOf(filePaths);
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/member/service/AccountDeletionS3CleanupHandler.java
+++ b/src/main/java/org/zerock/puppyrun/member/service/AccountDeletionS3CleanupHandler.java
@@ -1,0 +1,21 @@
+package org.zerock.puppyrun.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.zerock.puppyrun.common.s3.S3Service;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AccountDeletionS3CleanupHandler {
+    private final S3Service s3Service;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(AccountDeletionS3CleanupEvent event) {
+        log.info("회원 탈퇴 후 S3 이미지 삭제: {}건", event.filePaths().size());
+        s3Service.deleteAll(event.filePaths());
+    }
+}

--- a/src/main/java/org/zerock/puppyrun/member/service/MemberService.java
+++ b/src/main/java/org/zerock/puppyrun/member/service/MemberService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.zerock.puppyrun.common.exception.InvalidValueException;
 import org.zerock.puppyrun.member.DTO.MemberDTO;
 import org.zerock.puppyrun.member.entity.Member;
-import org.zerock.puppyrun.member.exception.UserNotFoundException;
 import org.zerock.puppyrun.member.exception.UserUnauthorizedException;
 import org.zerock.puppyrun.member.repository.MemberRepository;
 import org.zerock.puppyrun.notification.service.NotificationCommandService;
@@ -125,8 +124,8 @@ public class MemberService {
         String encodedPassword = member.getPassword();
         matchPassword(password, encodedPassword);
 
-        trackingCommandService.deleteImagesForDeletedMember(id);
-        petCommandService.deleteProfileImagesForDeletedMember(id);
+        trackingCommandService.deleteForDeletedMember(id);
+        petCommandService.deleteForDeletedMember(id);
         notificationCommandService.unsubscribeDeletedMember(id);
         memberRepository.delete(member);
     }

--- a/src/main/java/org/zerock/puppyrun/member/service/MemberService.java
+++ b/src/main/java/org/zerock/puppyrun/member/service/MemberService.java
@@ -12,6 +12,9 @@ import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.member.exception.UserNotFoundException;
 import org.zerock.puppyrun.member.exception.UserUnauthorizedException;
 import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.notification.service.NotificationCommandService;
+import org.zerock.puppyrun.pet.service.PetCommandService;
+import org.zerock.puppyrun.tracking.service.TrackingCommandService;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +23,9 @@ import org.zerock.puppyrun.member.repository.MemberRepository;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final TrackingCommandService trackingCommandService;
+    private final PetCommandService petCommandService;
+    private final NotificationCommandService notificationCommandService;
 
     /**
      * 비밀번호 일치 여부 확인
@@ -115,11 +121,14 @@ public class MemberService {
      */
     @Transactional
     public void accountDelete(UUID id, String password) {
-        // TODO 나중에 기능 개발 할 예정
         Member member = memberRepository.findByIdOrThrow(id);
         String encodedPassword = member.getPassword();
         matchPassword(password, encodedPassword);
-        member.setDeactivate();
+
+        trackingCommandService.deleteImagesForDeletedMember(id);
+        petCommandService.deleteProfileImagesForDeletedMember(id);
+        notificationCommandService.unsubscribeDeletedMember(id);
+        memberRepository.delete(member);
     }
 
 }

--- a/src/main/java/org/zerock/puppyrun/notification/entity/NotificationSettings.java
+++ b/src/main/java/org/zerock/puppyrun/notification/entity/NotificationSettings.java
@@ -21,6 +21,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.zerock.puppyrun.common.entity.BaseEntity;
 import org.zerock.puppyrun.member.entity.Member;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 
 @Entity
@@ -32,6 +34,7 @@ public class NotificationSettings extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     // 푸시 알림을 보낼 기기의 고유 주소

--- a/src/main/java/org/zerock/puppyrun/notification/entity/UserSelectedWalkingTime.java
+++ b/src/main/java/org/zerock/puppyrun/notification/entity/UserSelectedWalkingTime.java
@@ -15,6 +15,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.zerock.puppyrun.common.entity.BaseEntity;
 import org.zerock.puppyrun.member.entity.Member;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 /** 회원이 직접 선택한 날씨 추천 산책 시간과 위치입니다. */
 @Entity
@@ -28,6 +30,7 @@ public class UserSelectedWalkingTime extends BaseEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(nullable = false)

--- a/src/main/java/org/zerock/puppyrun/notification/entity/WalkingPreference.java
+++ b/src/main/java/org/zerock/puppyrun/notification/entity/WalkingPreference.java
@@ -17,6 +17,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.zerock.puppyrun.common.entity.BaseEntity;
 import org.zerock.puppyrun.member.entity.Member;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 /**
  * 특정 분석일의 회원 산책 선호 시간 결과를 저장합니다.
@@ -38,6 +40,7 @@ public class WalkingPreference extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(name = "analysis_date", nullable = false)

--- a/src/main/java/org/zerock/puppyrun/notification/service/NotificationCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/notification/service/NotificationCommandService.java
@@ -2,9 +2,11 @@ package org.zerock.puppyrun.notification.service;
 
 import java.util.Arrays;
 import java.util.Set;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.common.exception.BusinessException;
@@ -12,6 +14,7 @@ import org.zerock.puppyrun.common.exception.ExistsResourceException;
 import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.member.exception.UserNotFoundException;
 import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.member.service.AccountDeletionNotificationCleanupEvent;
 import org.zerock.puppyrun.notification.client.NotificationEventClient;
 import org.zerock.puppyrun.notification.controller.request.FcmTokenUpdateRequest;
 import org.zerock.puppyrun.notification.controller.request.NotificationAgreeRequest;
@@ -37,6 +40,7 @@ public class NotificationCommandService {
     private final NotificationRepository notificationRepository;
     private final MemberRepository memberRepository;
     private final NotificationEventClient notificationEventClient;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 특정 알림 타입의 수신 여부를 개별적으로 켜거나 끕니다. 알림 상태 변경 시, 해당 알림에 매핑된 FCM 토픽 구독 상태도 함께 동기화됩니다.
@@ -210,6 +214,16 @@ public class NotificationCommandService {
                 userPrincipal.id(),
                 allowedTypes.size()
         );
+    }
+
+    /** 회원 탈퇴가 커밋된 후 FCM 토픽 구독을 해제하도록 이벤트를 발행합니다. */
+    public void unsubscribeDeletedMember(UUID memberId) {
+        notificationRepository.findByMemberId(memberId)
+                .map(NotificationSettings::getFcmToken)
+                .filter(token -> !token.isBlank())
+                .ifPresent(token -> eventPublisher.publishEvent(
+                        new AccountDeletionNotificationCleanupEvent(token)
+                ));
     }
 
     /**

--- a/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
+++ b/src/main/java/org/zerock/puppyrun/pet/entity/Pet.java
@@ -17,6 +17,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.zerock.puppyrun.common.entity.BaseEntity;
 import org.zerock.puppyrun.common.exception.DataIntegrityException;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.pet.DTO.UpdatePetDTO;
 
@@ -31,6 +33,7 @@ public class Pet extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(nullable = false, length = 50)

--- a/src/main/java/org/zerock/puppyrun/pet/repository/PetRepository.java
+++ b/src/main/java/org/zerock/puppyrun/pet/repository/PetRepository.java
@@ -34,6 +34,9 @@ public interface PetRepository extends JpaRepository<Pet, UUID> {
 
     List<Pet> findAllByMemberIdAndIdIn(UUID memberId, List<UUID> petIds);
 
+    @Query("SELECT p.profileImageUrl FROM Pet p WHERE p.member.id = :memberId AND p.profileImageUrl IS NOT NULL")
+    List<String> findProfileImageUrlsByMemberId(@Param("memberId") UUID memberId);
+
     @Query("SELECT p.id FROM Pet p WHERE p.member.id = :memberId")
     List<UUID> findPetIdsByMemberId(@Param("memberId") UUID memberId);
 }

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetCommandService.java
@@ -1,9 +1,11 @@
 package org.zerock.puppyrun.pet.service;
 
 import java.util.UUID;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.s3.PathContext.PetProfileContext;
@@ -11,6 +13,7 @@ import org.zerock.puppyrun.common.s3.S3Service;
 import org.zerock.puppyrun.common.auth.security.UserPrincipal;
 import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.member.service.AccountDeletionS3CleanupEvent;
 import org.zerock.puppyrun.pet.DTO.UpdatePetDTO;
 import org.zerock.puppyrun.pet.controller.request.RegisterPetRequest;
 import org.zerock.puppyrun.pet.controller.request.RegisterPetWeightLogRequest;
@@ -35,6 +38,7 @@ public class PetCommandService {
     private final PetStatistics petStatistics;
 
     private final S3Service s3Service;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 새로운 펫을 등록합니다.
@@ -135,6 +139,17 @@ public class PetCommandService {
     public void deletePet(UserPrincipal userPrincipal, UUID petId) {
         Pet pet = petRepository.findByIdAndVerifyOwnership(petId, userPrincipal.id());
         petRepository.deleteById(petId);
+    }
+
+    /**
+     * 회원 탈퇴 시 삭제되는 펫들의 프로필 이미지를 정리합니다.
+     */
+    public void deleteProfileImagesForDeletedMember(UUID memberId) {
+        List<String> imagePaths = petRepository.findProfileImageUrlsByMemberId(memberId);
+
+        if (!imagePaths.isEmpty()) {
+            eventPublisher.publishEvent(new AccountDeletionS3CleanupEvent(imagePaths));
+        }
     }
 
     /**

--- a/src/main/java/org/zerock/puppyrun/pet/service/PetCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/pet/service/PetCommandService.java
@@ -144,7 +144,7 @@ public class PetCommandService {
     /**
      * 회원 탈퇴 시 삭제되는 펫들의 프로필 이미지를 정리합니다.
      */
-    public void deleteProfileImagesForDeletedMember(UUID memberId) {
+    public void deleteForDeletedMember(UUID memberId) {
         List<String> imagePaths = petRepository.findProfileImageUrlsByMemberId(memberId);
 
         if (!imagePaths.isEmpty()) {

--- a/src/main/java/org/zerock/puppyrun/tracking/entity/Tracking.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/entity/Tracking.java
@@ -36,8 +36,8 @@ public class Tracking extends BaseEntity {
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY) // 다대일 관계, 지연 로딩
-    @JoinColumn(name = "member_id", nullable = false) // 외래 키 컬럼명 지정
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "member_id") // 회원 탈퇴 후에도 산책 기록은 보존한다.
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Member member;
 
     @Column(nullable = false)

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingImageRepository.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingImageRepository.java
@@ -1,0 +1,31 @@
+package org.zerock.puppyrun.tracking.repository;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.zerock.puppyrun.tracking.entity.TrackingImage;
+
+@Repository
+public interface TrackingImageRepository extends JpaRepository<TrackingImage, UUID> {
+
+    @Query("""
+            select image.imageUrl
+            from TrackingImage image
+            join image.tracking tracking
+            where tracking.member.id = :memberId
+            """)
+    List<String> findImageUrlsByMemberId(@Param("memberId") UUID memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from TrackingImage image
+            where image.tracking.id in (
+                select tracking.id from Tracking tracking where tracking.member.id = :memberId
+            )
+            """)
+    void deleteByTrackingMemberId(@Param("memberId") UUID memberId);
+}

--- a/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepository.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/repository/TrackingRepository.java
@@ -3,10 +3,14 @@ package org.zerock.puppyrun.tracking.repository;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
 import org.zerock.puppyrun.common.exception.UserForbiddenException;
 import org.zerock.puppyrun.tracking.entity.Tracking;
+import org.zerock.puppyrun.tracking.entity.Visibility;
 
 @Repository
 public interface TrackingRepository extends JpaRepository<Tracking, UUID>, TrackingRepoCustom {
@@ -30,5 +34,16 @@ public interface TrackingRepository extends JpaRepository<Tracking, UUID>, Track
     }
 
     List<Tracking> findAllByMemberId(UUID memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Tracking tracking
+               set tracking.visibility = :visibility
+             where tracking.member.id = :memberId
+            """)
+    void updateVisibilityByMemberId(
+            @Param("memberId") UUID memberId,
+            @Param("visibility") Visibility visibility
+    );
 
 }

--- a/src/main/java/org/zerock/puppyrun/tracking/service/TrackingCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/service/TrackingCommandService.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.zerock.puppyrun.common.exception.ResourceNotFoundException;
@@ -26,7 +27,9 @@ import org.zerock.puppyrun.diary.entity.Diary;
 import org.zerock.puppyrun.diary.repository.DiaryRepository;
 import org.zerock.puppyrun.member.entity.Member;
 import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.member.service.AccountDeletionS3CleanupEvent;
 import org.zerock.puppyrun.pet.repository.PetRepository;
+import org.zerock.puppyrun.tracking.repository.TrackingImageRepository;
 import org.zerock.puppyrun.tracking.controller.request.ChangeVisibilityRequest;
 import org.zerock.puppyrun.tracking.controller.request.RegisterTrackingRequest;
 import org.zerock.puppyrun.tracking.controller.request.RegisterTrackingRequest.restPeriods;
@@ -45,6 +48,8 @@ public class TrackingCommandService {
     private final MemberRepository memberRepository;
     private final PetTrackingRepository petTrackingRepository;
     private final PetRepository petRepository;
+    private final TrackingImageRepository trackingImageRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 이미지 업로드를 의존성 주입
     private final S3Service s3Service;
@@ -147,6 +152,17 @@ public class TrackingCommandService {
 
         if (!images.isEmpty()) {
             s3Service.deleteAll(images);
+        }
+    }
+
+    /** 회원 탈퇴 시 보존되는 산책의 이미지 참조를 정리합니다. */
+    public void deleteImagesForDeletedMember(UUID memberId) {
+        List<String> imagePaths = trackingImageRepository.findImageUrlsByMemberId(memberId);
+
+        trackingImageRepository.deleteByTrackingMemberId(memberId);
+
+        if (!imagePaths.isEmpty()) {
+            eventPublisher.publishEvent(new AccountDeletionS3CleanupEvent(imagePaths));
         }
     }
 

--- a/src/main/java/org/zerock/puppyrun/tracking/service/TrackingCommandService.java
+++ b/src/main/java/org/zerock/puppyrun/tracking/service/TrackingCommandService.java
@@ -34,7 +34,6 @@ import org.zerock.puppyrun.tracking.controller.request.ChangeVisibilityRequest;
 import org.zerock.puppyrun.tracking.controller.request.RegisterTrackingRequest;
 import org.zerock.puppyrun.tracking.controller.request.RegisterTrackingRequest.restPeriods;
 import org.zerock.puppyrun.tracking.controller.request.UpdateTrackingRequest;
-import org.zerock.puppyrun.tracking.DTO.UpdateTrackingDTO;
 import org.zerock.puppyrun.tracking.controller.response.TrackingDetailResponse;
 
 @Service
@@ -155,10 +154,13 @@ public class TrackingCommandService {
         }
     }
 
-    /** 회원 탈퇴 시 보존되는 산책의 이미지 참조를 정리합니다. */
-    public void deleteImagesForDeletedMember(UUID memberId) {
+    /**
+     * 회원 탈퇴 시 보존되는 산책을 비공개로 전환하고 이미지 참조를 정리합니다.
+     */
+    public void deleteForDeletedMember(UUID memberId) {
         List<String> imagePaths = trackingImageRepository.findImageUrlsByMemberId(memberId);
 
+        trackingRepository.updateVisibilityByMemberId(memberId, Visibility.PRIVATE);
         trackingImageRepository.deleteByTrackingMemberId(memberId);
 
         if (!imagePaths.isEmpty()) {

--- a/src/test/java/org/zerock/puppyrun/member/service/AccountDeletionNotificationCleanupHandlerTest.java
+++ b/src/test/java/org/zerock/puppyrun/member/service/AccountDeletionNotificationCleanupHandlerTest.java
@@ -1,0 +1,42 @@
+package org.zerock.puppyrun.member.service;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.zerock.puppyrun.notification.client.NotificationEventClient;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+
+@ExtendWith(MockitoExtension.class)
+class AccountDeletionNotificationCleanupHandlerTest {
+
+    @Mock
+    private NotificationEventClient notificationEventClient;
+
+    @InjectMocks
+    private AccountDeletionNotificationCleanupHandler handler;
+
+    @Test
+    @DisplayName("회원 탈퇴 후 모든 FCM 알림 토픽을 구독 해제한다")
+    void unsubscribeAllTopics() {
+        // given
+        String fcmToken = "withdrawal-fcm-token";
+
+        // when
+        handler.handle(new AccountDeletionNotificationCleanupEvent(fcmToken));
+
+        // then
+        for (NotificationType type : NotificationType.values()) {
+            verify(notificationEventClient).manageTopicSubscription(fcmToken, type.getCode(), false);
+        }
+        verify(notificationEventClient, times(NotificationType.values().length))
+                .manageTopicSubscription(eq(fcmToken), anyString(), eq(false));
+    }
+}

--- a/src/test/java/org/zerock/puppyrun/member/service/MemberServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/member/service/MemberServiceTest.java
@@ -111,7 +111,9 @@ class MemberServiceTest extends TestContainerConfig {
         ).content()).isEmpty();
         assertThat(trackingRepository.findById(tracking.getId())).isPresent()
                 .get()
-                .extracting(savedTracking -> savedTracking.getMember())
-                .isNull();
+                .satisfies(savedTracking -> {
+                    assertThat(savedTracking.getMember()).isNull();
+                    assertThat(savedTracking.getVisibility()).isEqualTo(Visibility.PRIVATE);
+                });
     }
 }

--- a/src/test/java/org/zerock/puppyrun/member/service/MemberServiceTest.java
+++ b/src/test/java/org/zerock/puppyrun/member/service/MemberServiceTest.java
@@ -1,0 +1,117 @@
+package org.zerock.puppyrun.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.data.domain.PageRequest;
+import org.zerock.puppyrun.a_config.TestContainerConfig;
+import org.zerock.puppyrun.member.entity.Member;
+import org.zerock.puppyrun.member.repository.MemberRepository;
+import org.zerock.puppyrun.pet.entity.Breed;
+import org.zerock.puppyrun.pet.entity.Pet;
+import org.zerock.puppyrun.pet.repository.PetRepository;
+import org.zerock.puppyrun.notification.entity.NotificationSettings;
+import org.zerock.puppyrun.notification.entity.NotificationType;
+import org.zerock.puppyrun.notification.repository.NotificationRepository;
+import org.zerock.puppyrun.tracking.entity.Tracking;
+import org.zerock.puppyrun.tracking.entity.TrackingImage;
+import org.zerock.puppyrun.tracking.entity.Visibility;
+import org.zerock.puppyrun.tracking.repository.TrackingImageRepository;
+import org.zerock.puppyrun.tracking.repository.TrackingRepository;
+
+class MemberServiceTest extends TestContainerConfig {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @Autowired
+    private TrackingRepository trackingRepository;
+
+    @Autowired
+    private TrackingImageRepository trackingImageRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("회원 탈퇴 시 펫과 산책 이미지는 삭제하고 산책은 작성자 없이 보존한다")
+    void deleteAccount() {
+        // given
+        String rawPassword = "PuppyRun123!";
+        Member member = memberRepository.save(Member.builder()
+                .id(UUID.randomUUID())
+                .nickName("탈퇴대상")
+                .email("withdraw@example.com")
+                .password(passwordEncoder.encode(rawPassword))
+                .build());
+        Pet pet = petRepository.save(Pet.builder()
+                .member(member)
+                .name("멍멍이")
+                .breed(Breed.MALTESE)
+                .isNeutered(true)
+                .gender("M")
+                .build());
+        pet.updateProfile("test/pet-profile.png");
+        Tracking tracking = trackingRepository.save(Tracking.builder()
+                .member(member)
+                .startedAt(LocalDateTime.of(2026, 1, 1, 10, 0))
+                .endedAt(LocalDateTime.of(2026, 1, 1, 10, 30))
+                .distance(1500)
+                .visibility(Visibility.PUBLIC)
+                .averagePace(5.0)
+                .restDuration(0)
+                .images(null)
+                .build());
+        trackingImageRepository.save(TrackingImage.builder()
+                .tracking(tracking)
+                .imageUrl("test/tracking-image.png")
+                .imageOrder(0)
+                .build());
+        notificationRepository.save(NotificationSettings.builder()
+                .member(member)
+                .fcmToken("withdrawal-fcm-token")
+                .isPushAgreed(true)
+                .build());
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        memberService.accountDelete(member.getId(), rawPassword);
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        assertThat(memberRepository.findById(member.getId())).isEmpty();
+        assertThat(petRepository.findById(pet.getId())).isEmpty();
+        assertThat(trackingImageRepository.count()).isZero();
+        assertThat(notificationRepository.findByMemberId(member.getId())).isEmpty();
+        assertThat(notificationRepository.findNextMembers(
+                null,
+                null,
+                PageRequest.of(0, 100),
+                NotificationType.DAILY_WALKING_REMINDER
+        ).content()).isEmpty();
+        assertThat(trackingRepository.findById(tracking.getId())).isPresent()
+                .get()
+                .extracting(savedTracking -> savedTracking.getMember())
+                .isNull();
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request: 회원 탈퇴 및 연관 데이터 정리 (#7)

# 📝 작업 요약 (Summary)

- 회원 탈퇴 시 개인정보성 연관 데이터와 업로드 이미지를 정리하고, 산책 기록은 작성자 제거·비공개 전환 후 보존하도록 구현했습니다.
- 탈퇴한 회원이 개인화 알림 또는 FCM 토픽 알림을 수신하지 않도록 알림 설정 삭제와 토픽 구독 해제를 함께 처리했습니다.
- **DB 영향도**: 회원 FK는 기본적으로 `ON DELETE CASCADE`를 적용하고, `tracking.member_id`만 `ON DELETE SET NULL`로 변경했습니다. 

> 운영 DB는 `ddl-auto: validate`이므로 배포 전 기존 FK를 동일 정책으로 변경하는 마이그레이션이 필요합니다.

# 🛠️ 변경 사항 (Changes)

## 1. 회원 탈퇴 API 및 데이터 정리

- **AccountController / MemberService**
    - `DELETE /api/account`를 추가했습니다.
    - 인증된 회원의 ID와 요청 비밀번호를 검증한 뒤 회원을 물리 삭제합니다.
- **FK 정책**
  - 펫, 알림 설정, 산책 선호도, 선택 산책 시간은 회원 삭제 시 DB cascade로 삭제합니다.
  - 산책은 보존하며, 회원 삭제 시 `tracking.member_id`는 `NULL`로 변경합니다.
- **TrackingRepository / TrackingCommandService**
  - 탈퇴 회원의 산책은 단일 bulk update로 모두 `PRIVATE`로 전환해 공개 조회 대상에서 제외합니다.
  - 산책 이미지 참조를 삭제하고 S3 정리 이벤트를 발행합니다.

## 2. 도메인별 이미지 및 알림 정리

- **PetCommandService**
    - 탈퇴 회원의 펫 프로필 이미지 경로를 수집하고 S3 삭제 이벤트를 발행합니다.
- **NotificationCommandService**
    - 탈퇴 회원의 FCM 토큰을 확인하고, DB 커밋 후 모든 알림 토픽 구독을 해제하는 이벤트를 발행합니다.
- **Cleanup Handler**
    - DB 커밋 이후 S3 객체 삭제 및 FCM 토픽 구독 해제를 수행해 롤백된 탈퇴 요청이 외부 리소스를 먼저 정리하지 않도록 했습니다.

## 3. 테스트

- 회원 탈퇴 통합 테스트로 회원·펫·알림 설정·산책 이미지 삭제와 산책의 작성자 `NULL`·`PRIVATE` 보존을 검증했습니다.
- 개인화 알림 수신 대상 조회에서 탈퇴 회원이 제외되는 것을 검증했습니다.
- FCM 모든 알림 토픽 구독 해제 이벤트를 단위 테스트로 검증했습니다.

# 📸 테스트 시나리오 (Test Scenarios)

## 1. 회원 탈퇴

* **Method**: `DELETE`
* **URL**: `/api/account`
* **Content-Type**: `application/json`
* **Header**: `Authorization: Bearer {accessToken}`

### ✅ 1-1 : 비밀번호 확인 후 회원 탈퇴

**Request Body**

```json
{
  "password": "PuppyRunPassword123!"
}
```

**Response (204 No Content)**

```text
응답 본문 없음
```

- 회원, 펫, 알림 설정과 산책 이미지는 삭제됩니다.
- 산책 본문과 경로는 남으며 `member_id`는 `NULL`, 공개 범위는 `PRIVATE`입니다.
- 펫 프로필·산책 이미지 S3 객체와 FCM 모든 토픽 구독은 DB 커밋 후 정리됩니다.

### ❌ 1-2 : 비밀번호 미입력

**Request Body**

```json
{
  "password": ""
}
```

**Response (400 Bad Request)**

```json
{
  "code": "CLIENT_001",
  "description": "잘못된 요청입니다.",
  "message": "비밀번호는 필수입니다.",
  "path": "/api/account",
  "timestamp": "2026-08-28T14:00:00"
}
```

### ❌ 1-3 : 비밀번호 불일치

**Request Body**

```json
{
  "password": "wrong-password"
}
```

**Response (401 Unauthorized)**

```json
{
  "code": "AUTH_001",
  "description": "로그인 정보가 유효하지 않습니다.",
  "message": "비밀번호가 틀립니다.",
  "path": "/api/account",
  "timestamp": "2026-08-28T14:00:00"
}
```
